### PR TITLE
Fix inclination bug in waveform generation

### DIFF
--- a/dingo/gw/waveform_generator.py
+++ b/dingo/gw/waveform_generator.py
@@ -176,7 +176,7 @@ class WaveformGenerator:
         # Construct argument list for FD and TD lal waveform generator wrappers
         spins_cartesian = s1x, s1y, s1z, s2x, s2y, s2z
         masses = (p['mass_1'], p['mass_2'])
-        extra_params = (p['luminosity_distance'], p['theta_jn'], p['phase'])
+        extra_params = (p['luminosity_distance'], iota, p['phase'])
         ecc_params = (0.0, 0.0, 0.0)  # longAscNodes, eccentricity, meanPerAno
 
         D = self.domain


### PR DESCRIPTION
This provides the correct inclination argument to `SimInspiralFD()`. It takes `iota`, not `theta_jn`, which we had been passing previously. This should hopefully fix the slightly-off posteriors.