### PR TITLE
Fixed GNPE training bug (from inference branch)

### DIFF
--- a/dingo/gw/training/train_builders.py
+++ b/dingo/gw/training/train_builders.py
@@ -114,6 +114,7 @@ def set_train_transforms(wfd, data_settings, asd_dataset_path, omit_transforms=N
                 ifo_list,
                 d["kernel"],
                 d["exact_equiv"],
+                inference=False,
             )
         )
         extra_context_parameters += transforms[-1].get_context_parameters()

--- a/dingo/gw/transforms/gnpe_transforms.py
+++ b/dingo/gw/transforms/gnpe_transforms.py
@@ -28,7 +28,7 @@ class GNPEShiftDetectorTimes(object):
     """
 
     def __init__(
-        self, ifo_list, kernel, exact_global_equivariance=True, inference=True
+        self, ifo_list, kernel, exact_global_equivariance=True, inference=False
     ):
         """
         ifo_list : bilby.gw.detector.InterferometerList
@@ -39,7 +39,7 @@ class GNPEShiftDetectorTimes(object):
         exact_global_equivariance : bool = True
             Whether to impose the exact global time translation symmetry.
             (Default True)
-        inference: bool = True
+        inference: bool = False
             Whether to use inference mode or not
         """
         self.ifo_names = [ifo.name for ifo in ifo_list]


### PR DESCRIPTION
After merging the inference branch, GNPE was accidentally called in inference mode.
This was due to an incorrect default argument, and lead to conditioning of the inference network on `t - t_hat` instead of the proxy `-t_hat` itself:

```
            if not self.inference:
                # at train time, two time shifts need to be applied:
                #   1) the time shift by t for the detector projection
                #   2) the time shift by - t_hat for gnpe
                # we combine these to one shift by t - t_hat for efficiency
                extrinsic_parameters[f"{ifo_name}_time"] = t - t_hat
            else:
                # at inference time, the data is already projected onto the detector,
                # so only the gnpe time shift by - t_hat needs to be applied
                extrinsic_parameters[f"{ifo_name}_time"] = -t_hat
```

I fixed the bug by (i) changing the default argument and (ii) additionally explicitly setting `inference=False` in the train builder. The latter is only for clarity, and not required after changing the default argument.