### PR TITLE
Improve the identification of SVD basis file in dingo_ls.

### DIFF
--- a/dingo/gw/SVD.py
+++ b/dingo/gw/SVD.py
@@ -174,6 +174,8 @@ class SVDBasis(DingoDataset):
         filename : str
         """
         super().from_file(filename)
+        if self.V is None:
+            raise KeyError("File does not contain SVD V matrix. No SVD basis to load.")
         self.Vh = self.V.T.conj()
         self.n = self.V.shape[1]
 
@@ -187,6 +189,8 @@ class SVDBasis(DingoDataset):
             The dictionary should contain at least a 'V' key, and optionally an 's' key.
         """
         super().from_dictionary(dictionary)
+        if self.V is None:
+            raise KeyError("dict does not contain SVD V matrix. No SVD basis to load.")
         self.Vh = self.V.T.conj()
         self.n = self.V.shape[1]
 

--- a/dingo/gw/ls_cli.py
+++ b/dingo/gw/ls_cli.py
@@ -28,13 +28,13 @@ def ls():
         )
 
     elif path.suffix == ".hdf5":
-        if path.stem.startswith("svd"):
+        try:
             svd = SVDBasis(file_name=args.file_name)
             print(f"SVD dataset of size n={svd.n}.")
             print("Validation summary:")
             svd.print_validation_summary()
 
-        else:
+        except KeyError:
             dataset = DingoDataset(file_name=args.file_name, data_keys=["svd"])
             if dataset.settings is not None:
                 print(


### PR DESCRIPTION
This is a minor change to try to identify the contents of an `HDF5` file for the `dingo_ls` command.

We require special handling for files that contain only an SVD basis, and previously I was identifying this based on the file name. However, this was confusing some intermediate files produced during condor dataset generation. Now, we use a try-except statement.

If anybody has a better idea to make this cleaner, I'm open to suggestions.