### PR TITLE
ASDDataset added to dingo_ls

### DIFF
--- a/dingo/gw/ls_cli.py
+++ b/dingo/gw/ls_cli.py
@@ -111,7 +111,7 @@ def ls():
             print("\nASD dataset\n" + "================\n")
 
             print(f"Dataset size: {asd_dataset.length_info}\n")
-            print(f"GPS times: {asd_dataset.gps_info}")
+            print(f"GPS times (min/max): {asd_dataset.gps_info}")
 
             print(
                 "\nSettings\n"

--- a/dingo/gw/noise/asd_dataset.py
+++ b/dingo/gw/noise/asd_dataset.py
@@ -1,4 +1,6 @@
 import copy
+from typing import Iterable
+
 from dingo.gw.domains import build_domain
 from dingo.gw.gwutils import *
 from dingo.gw.dataset import DingoDataset
@@ -79,8 +81,8 @@ class ASDDataset(DingoDataset):
         """Min/Max GPS time for each detector."""
         gps_info_dict = {}
         for key, val in self.gps_times.items():
-            if isinstance(val, int):
-                 gps_info_dict[key] = val
+            if not isinstance(val, Iterable):
+                gps_info_dict[key] = val
             else:
                 gps_info_dict[key] = (min(val), max(val))
         return gps_info_dict


### PR DESCRIPTION
Extended `dingo_ls` for the ASDDataset. Printing the number of ASDs for each detectors together with information about the min/max GPS time across all estimated ASDs in each detector.