### PR TITLE
Add calibration uncertainty marginalization to dingo-pipe

### DIFF
--- a/dingo/gw/injection.py
+++ b/dingo/gw/injection.py
@@ -116,6 +116,7 @@ class GWSignal(object):
                     self.data_domain,
                     self.calibration_envelope,
                     self.num_calibration_curves,
+                    self.num_calibration_nodes,
                 )
             )
         if self.whiten:

--- a/dingo/gw/injection.py
+++ b/dingo/gw/injection.py
@@ -65,6 +65,7 @@ class GWSignal(object):
 
         # When we set self.whiten, the projection transforms are automatically prepared.
         self._calibration_envelope = None
+        self._calibration_marginalization_kwargs = None
         self.whiten = False
 
         self.asd = None
@@ -91,17 +92,25 @@ class GWSignal(object):
         self._initialize_transform()
 
     @property
-    def calibration_envelope(self):
+    def calibration_marginalization_kwargs(self):
         """
-        Either None, str 'generate' or a dict with
-        {"H1": filepath, "L1":filepath, ...} with locations of
-        lookup tables for the calibration uncertainty curves
-        """
-        return self._calibration_envelope
+        Dictionary with the following keys:
 
-    @calibration_envelope.setter
-    def calibration_envelope(self, value):
-        self._calibration_envelope = value
+        calibration_envelope
+            Dictionary of the form {"H1": filepath, "L1": filepath, ...} with locations of
+            lookup tables for the calibration uncertainty curves.
+
+        num_calibration_nodes
+            Number of nodes for the calibration model.
+
+        num_calibration_curves
+            Number of calibration curves to use in marginalization.
+        """
+        return self._calibration_marginalization_kwargs
+
+    @calibration_marginalization_kwargs.setter
+    def calibration_marginalization_kwargs(self, value):
+        self._calibration_marginalization_kwargs = value
         self._initialize_transform()
 
     def _initialize_transform(self):
@@ -109,14 +118,12 @@ class GWSignal(object):
             GetDetectorTimes(self.ifo_list, self.t_ref),
             ProjectOntoDetectors(self.ifo_list, self.data_domain, self.t_ref),
         ]
-        if self.calibration_envelope is not None:
+        if self.calibration_marginalization_kwargs:
             transforms.append(
                 ApplyCalibrationUncertainty(
                     self.ifo_list,
                     self.data_domain,
-                    self.calibration_envelope,
-                    self.num_calibration_curves,
-                    self.num_calibration_nodes,
+                    **self.calibration_marginalization_kwargs
                 )
             )
         if self.whiten:

--- a/dingo/gw/likelihood.py
+++ b/dingo/gw/likelihood.py
@@ -1,3 +1,4 @@
+import sys
 from multiprocessing import Pool
 
 import numpy as np
@@ -120,34 +121,8 @@ class StationaryGaussianGWLikelihood(GWSignal, Likelihood):
             else:
                 print("Using phase marginalization with (2,2) mode approximation.")
 
-        # optionally initialize calibration marginalization
-        self.calibration_marginalization = False
-        if calibration_marginalization_kwargs is not None:
-            self.calibration_marginalization = True
-            self.initialize_calibration_marginalization(
-                **calibration_marginalization_kwargs
-            )
-
-    def initialize_calibration_marginalization(
-        self, calibration_envelope, num_calibration_curves=1, num_calibration_nodes=10,
-    ):
-        """
-        Initialize calibration marginalization table which will use the files provided to
-        multiply the signal by a calibration envelope.
-
-        Parameters
-        ----------
-        num_calibration_curves : int
-            The number of calibration curves to average over. Will default to 1. Increasing this will
-            decrease the sample efficiency due to the calibration errors.
-
-        calibration_lookup_table : dict
-            Dict with locations of .h5 files of calibration envelopes {"H1":, filepath,...}
-            optionally can be set to 'generate'
-        """
-        self.num_calibration_curves = num_calibration_curves
-        self.num_calibration_nodes = num_calibration_nodes
-        self.calibration_envelope = calibration_envelope
+        # Initialize calibration marginalization using the setter from GWSignal.
+        self.calibration_marginalization_kwargs = calibration_marginalization_kwargs
 
     def initialize_time_marginalization(self, t_lower, t_upper, n_fft=1):
         """
@@ -206,7 +181,7 @@ class StationaryGaussianGWLikelihood(GWSignal, Likelihood):
                 [
                     self.time_marginalization,
                     self.phase_marginalization,
-                    self.calibration_marginalization,
+                    bool(self.calibration_marginalization_kwargs),
                 ]
             )
             > 1
@@ -220,7 +195,7 @@ class StationaryGaussianGWLikelihood(GWSignal, Likelihood):
             return self._log_likelihood_time_marginalized(theta)
         elif self.phase_marginalization:
             return self._log_likelihood_phase_marginalized(theta)
-        elif self.calibration_marginalization:
+        elif self.calibration_marginalization_kwargs:
             return self._log_likelihood_calibration_marginalized(theta)
         else:
             return self._log_likelihood(theta)
@@ -550,7 +525,11 @@ class StationaryGaussianGWLikelihood(GWSignal, Likelihood):
         # Step 1: Compute whitened GW strain mu(theta) for parameters theta.
         mu = self.signal(theta)["waveform"]
         d = self.whitened_strains
-        d = {ifo: np.tile(v, (self.num_calibration_curves, 1)) for ifo, v in d.items()}
+
+        # In the calibration-marginalization case, the values of mu for each detector
+        # have an additional leading dimension, which corresponds to the calibration
+        # draws. These are averaged over in computing the likelihood.
+        # TODO: Combine with _log_likelihood() into a single method.
 
         # Step 2: Compute likelihood. log_Zn is precomputed, so we only need to
         # compute the remaining terms rho2opt and kappa2
@@ -560,7 +539,7 @@ class StationaryGaussianGWLikelihood(GWSignal, Likelihood):
         )
         kappa2 = np.sum(
             [
-                inner_product(d_ifo.T, mu_ifo.T)
+                inner_product(d_ifo[:, None], mu_ifo.T)
                 for d_ifo, mu_ifo in zip(d.values(), mu.values())
             ],
             axis=0,

--- a/dingo/gw/likelihood.py
+++ b/dingo/gw/likelihood.py
@@ -129,7 +129,7 @@ class StationaryGaussianGWLikelihood(GWSignal, Likelihood):
             )
 
     def initialize_calibration_marginalization(
-        self, calibration_envelope, num_calibration_curves=1
+        self, calibration_envelope, num_calibration_curves=1, num_calibration_nodes=10,
     ):
         """
         Initialize calibration marginalization table which will use the files provided to
@@ -146,6 +146,7 @@ class StationaryGaussianGWLikelihood(GWSignal, Likelihood):
             optionally can be set to 'generate'
         """
         self.num_calibration_curves = num_calibration_curves
+        self.num_calibration_nodes = num_calibration_nodes
         self.calibration_envelope = calibration_envelope
 
     def initialize_time_marginalization(self, t_lower, t_upper, n_fft=1):

--- a/dingo/gw/pipe/importance_sampling.py
+++ b/dingo/gw/pipe/importance_sampling.py
@@ -117,6 +117,12 @@ class ImportanceSamplingInput(Input):
                 "num_calibration_nodes": self.spline_calibration_nodes,
                 "num_calibration_curves": self.spline_calibration_curves,
             }
+        elif self.calibration_model == None:
+            return None
+        else:
+            raise ValueError(
+                "The only calibration model which is supported is 'CubicSpline'"
+            )
 
     @property
     def importance_sampling_settings(self):
@@ -124,7 +130,6 @@ class ImportanceSamplingInput(Input):
 
     @importance_sampling_settings.setter
     def importance_sampling_settings(self, settings):
-
         # Set up defaults.
         if "phase" not in self.result.samples.columns:
             self._importance_sampling_settings = IMPORTANCE_SAMPLING_SETTINGS[

--- a/dingo/gw/pipe/importance_sampling.py
+++ b/dingo/gw/pipe/importance_sampling.py
@@ -80,10 +80,11 @@ class ImportanceSamplingInput(Input):
         # self.roq_folder = args.roq_folder
         # self.roq_scale_factor = args.roq_scale_factor
         #
-        # # Calibration
-        # self.calibration_model = args.calibration_model
-        # self.spline_calibration_nodes = args.spline_calibration_nodes
-        # self.spline_calibration_envelope_dict = args.spline_calibration_envelope_dict
+        # Calibration
+        self.calibration_model = args.calibration_model
+        self.spline_calibration_nodes = args.spline_calibration_nodes
+        self.spline_calibration_envelope_dict = args.spline_calibration_envelope_dict
+        self.spline_calibration_curves = args.spline_calibration_curves
 
         # # Marginalization
         # self.distance_marginalization = args.distance_marginalization
@@ -107,6 +108,15 @@ class ImportanceSamplingInput(Input):
     def _load_event(self):
         event_dataset = EventDataset(file_name=self.event_data_file)
         self.result.reset_event(event_dataset)
+
+    @property
+    def calibration_marginalization_kwargs(self):
+        if self.calibration_model == "CubicSpline":
+            return {
+                "calibration_envelope": self.spline_calibration_envelope_dict,
+                "num_calibration_nodes": self.spline_calibration_nodes,
+                "num_calibration_curves": self.spline_calibration_curves,
+            }
 
     @property
     def importance_sampling_settings(self):
@@ -154,6 +164,7 @@ class ImportanceSamplingInput(Input):
             phase_marginalization_kwargs=self.importance_sampling_settings.get(
                 "phase_marginalization"
             ),
+            calibration_marginalization_kwargs=self.calibration_marginalization_kwargs,
         )
 
         if self.prior_dict:
@@ -168,9 +179,7 @@ class ImportanceSamplingInput(Input):
             self.result.update_prior(self.prior_dict)
 
         self.result.print_summary()
-        self.result.to_file(
-            os.path.join(self.result_directory, self.label + ".hdf5")
-        )
+        self.result.to_file(os.path.join(self.result_directory, self.label + ".hdf5"))
 
     @property
     def priors(self):

--- a/dingo/gw/pipe/parser.py
+++ b/dingo/gw/pipe/parser.py
@@ -62,31 +62,40 @@ def create_parser(top_level=True):
     #     version=f"%(prog)s={get_version_information()}\nbilby={bilby.__version__}",
     # )
 
-    # calibration_parser = parser.add_argument_group(
-    #     "Calibration arguments",
-    #     description="Which calibration model and settings to use.",
-    # )
-    # calibration_parser.add(
-    #     "--calibration-model",
-    #     type=nonestr,
-    #     default=None,
-    #     choices=["CubicSpline", None],
-    #     help="Choice of calibration model, if None, no calibration is used",
-    # )
-    #
-    # calibration_parser.add(
-    #     "--spline-calibration-envelope-dict",
-    #     type=nonestr,
-    #     default=None,
-    #     help=("Dictionary pointing to the spline calibration envelope files"),
-    # )
-    #
-    # calibration_parser.add(
-    #     "--spline-calibration-nodes",
-    #     type=int,
-    #     default=10,
-    #     help=("Number of calibration nodes"),
-    # )
+    calibration_parser = parser.add_argument_group(
+        "Calibration arguments",
+        description="Which calibration model and settings to use. Calibration "
+                    "uncertainty is marginalizaed over during importance sampling.",
+    )
+    calibration_parser.add(
+        "--calibration-model",
+        type=nonestr,
+        default=None,
+        choices=["CubicSpline", None],
+        help="Choice of calibration model, if None, no calibration is used",
+    )
+
+    calibration_parser.add(
+        "--spline-calibration-envelope-dict",
+        type=nonestr,
+        default=None,
+        help=("Dictionary pointing to the spline calibration envelope files"),
+    )
+
+    calibration_parser.add(
+        "--spline-calibration-nodes",
+        type=int,
+        default=10,
+        help=("Number of calibration nodes"),
+    )
+
+    calibration_parser.add(
+        "--spline-calibration-curves",
+        type=int,
+        default=1000,
+        help=("Number of calibration curves to use in marginalizing over calibration "
+              "uncertainty"),
+    )
     #
     # calibration_parser.add(
     #     "--spline-calibration-amplitude-uncertainty-dict",

--- a/dingo/gw/transforms/detector_transforms.py
+++ b/dingo/gw/transforms/detector_transforms.py
@@ -10,7 +10,6 @@ from bilby.gw.prior import CalibrationPriorDict
 
 
 CC = 299792458.0
-NUM_CALIBRATION_NODES = 10
 
 
 def time_delay_from_geocenter(
@@ -241,18 +240,18 @@ class TimeShiftStrain(object):
 
 class ApplyCalibrationUncertainty(object):
     """
-    Based off: 
+    Based off:
 
     https://dcc.ligo.org/LIGO-T1400682/public
 
-    Usually gravitational wave data is in the form 
-    
+    Usually gravitational wave data is in the form
+
     d(f) = h_obs(f) + n(f)                                          (1)
 
     Where d is the data, h is the waveform and n is the noise. However, since
     the detector is not perfectly calibrated, there are corrections to the
     waveform in the form
-    
+
     h_obs(f) = h(f) * (1 + \delta A(f)) * exp(i \delta \phi(f))      (2)
 
     We can parameterize A(f) and \phi(f) with a cubic spline i.e.
@@ -262,11 +261,11 @@ class ApplyCalibrationUncertainty(object):
 
     The \A_i and \phi_i are drawn from gaussians centered at 0 with standard
     deviations determined by the calibration envelope which varies event to
-    event. This method draws multiple splines and multiplies the waveform 
+    event. This method draws multiple splines and multiplies the waveform
     by the splines. Later when computing the likelihoods, we can marginalize
-    over these waveforms thereby mitigating the effects of calibration 
-    uncertainties in the detectors.  
-    
+    over these waveforms thereby mitigating the effects of calibration
+    uncertainties in the detectors.
+
 
     calibration_marginalization_kwargs: dict
         Calibration marginalization kwargs. If None no calibration marginalization is
@@ -276,7 +275,12 @@ class ApplyCalibrationUncertainty(object):
     """
 
     def __init__(
-        self, ifo_list, data_domain, calibration_envelope, num_calibration_curves
+        self,
+        ifo_list,
+        data_domain,
+        calibration_envelope,
+        num_calibration_curves,
+        num_calibration_nodes,
     ):
         """
         Initialize calibration marginalization. This requires the user to give
@@ -304,13 +308,13 @@ class ApplyCalibrationUncertainty(object):
         if all([s.endswith(".txt") for s in calibration_envelope.values()]):
             # Generating .h5 lookup table from priors in .txt file
             self.calibration_envelope = calibration_envelope
-            for i, ifo in enumerate(self.ifo_list):
+            for ifo in self.ifo_list:
                 # Setting calibration model to cubic spline
                 ifo.calibration_model = calibration.CubicSpline(
                     f"recalib_{ifo.name}_",
                     minimum_frequency=data_domain.f_min,
                     maximum_frequency=data_domain.f_max,
-                    n_points=NUM_CALIBRATION_NODES,
+                    n_points=num_calibration_nodes,
                 )
 
                 # Setting priors
@@ -326,7 +330,7 @@ class ApplyCalibrationUncertainty(object):
                     self.calibration_envelope[ifo.name],
                     self.data_domain.f_min,
                     self.data_domain.f_max,
-                    NUM_CALIBRATION_NODES,
+                    num_calibration_nodes,
                     ifo.name,
                 )
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -38,6 +38,7 @@ extensions = [
     'myst_nb',
     'sphinxcontrib.mermaid',
     'sphinxcontrib.bibtex',
+    'sphinx_math_dollar',
 ]
 
 myst_enable_extensions = [
@@ -55,6 +56,20 @@ myst_enable_extensions = [
     "substitution",
     "tasklist",
 ]
+
+mathjax_config = {
+    'tex2jax': {
+        'inlineMath': [ ["\\(","\\)"] ],
+        'displayMath': [["\\[","\\]"] ],
+    },
+}
+
+mathjax3_config = {
+  "tex": {
+    "inlineMath": [['\\(', '\\)']],
+    "displayMath": [["\\[", "\\]"]],
+  }
+}
 
 myst_heading_anchors = 2
 

--- a/docs/source/dingo_pipe.md
+++ b/docs/source/dingo_pipe.md
@@ -50,6 +50,15 @@ sampling-frequency = 2048.0
 importance-sampling-updates = {'duration': 4.0}
 
 ################################################################################
+## Calibration marginalization arguments
+################################################################################
+
+calibration-model = CubicSpline
+spline-calibration-envelope-dict = {H1: GWTC1_GW150914_H_CalEnv.txt, L1: GWTC1_GW150914_L_CalEnv.txt}
+spline-calibration-nodes = 10
+spline-calibration-curves = 1000
+
+################################################################################
 ## Plotting arguments
 ################################################################################
 
@@ -96,6 +105,22 @@ If extending the prior support during importance sampling, be sure that the post
 By default, dingo_pipe assumes that it is necessary to sample the phase synthetically, so it will do so before importance sampling. This can be turned off by passing an empty dictionary to `importance-sampling-settings`.
 
 Importance sampling (including synthetic phase sampling) is an expensive step, so dingo_pipe allows for parallelization: this step is split over `n-parallel` jobs, each of which uses `request-cpus-importance-sampling` processes. In the backend, this makes use of the Result [split()](dingo.core.result.Result.split) and [merge()](dingo.core.result.Result.merge) methods.
+
+### Calibration marginalization
+
+Settings related to calibration are used to **marginalize** over calibration uncertainty during importance sampling.
+
+calibration-model
+: None or "CubicSpline". If "CubicSpline", perform calibration marginalization using a cubic spline calibration model. If None do not perform calibration marginalization. (Default: None)
+
+spline-calibration-envelope-dict
+: Dictionary pointing to the spline calibration envelope files. This is required if calibration-model is "CubicSpline".
+
+spline-calibration-nodes
+: Number of calibration nodes. (Default: 10)
+
+spline-calibration-curves
+: Number of calibration curves to use for marginalization. (Default: 1000)
 
 ## Plotting
 

--- a/examples/is_settings.yaml
+++ b/examples/is_settings.yaml
@@ -43,6 +43,7 @@ nde:
 
 calibration_marginalization:
   num_calibration_curves: 100
+  num_calibration_nodes: 10
   calibration_envelope:
     H1: <path/to/H1-calibration-envelope>
     L1: <path/to/L1-calibration-envelope> 

--- a/examples/pipe/GW150914.ini
+++ b/examples/pipe/GW150914.ini
@@ -39,6 +39,15 @@ psd-length = 128
 # importance-sampling-updates = {'duration': 4.0}
 
 ################################################################################
+## Calibration marginalization arguments
+################################################################################
+
+calibration-model = CubicSpline
+spline-calibration-envelope-dict = {H1: GWTC1_GW150914_H_CalEnv.txt, L1: GWTC1_GW150914_L_CalEnv.txt}
+spline-calibration-nodes = 10
+spline-calibration-curves = 1000
+
+################################################################################
 ## Plotting arguments
 ################################################################################
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,6 +72,7 @@ dev = [
     "pylint",
     "pytest",
     "sphinx",
+    "sphinx-math-dollar",
     "sphinx-rtd-theme",
     "sphinxcontrib-mermaid",
     "sphinxcontrib-bibtex",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,6 +75,7 @@ dev = [
     "myst-nb",
     "sphinxcontrib-mermaid",
     "sphinxcontrib-bibtex",
+    "sphinx-math-dollar",
     "myst-parser",
     "linkify-it-py"
 ]


### PR DESCRIPTION
This pull request adds the ability to marginalize over detector calibration uncertainty to dingo-pipe. This takes place during the importance sampling stage.

It adds the following keys to the INI files:

* calibration-model
* spline-calibration-envelope-dict
* spline-calibration-nodes
* spline-calibration-curves (not present in bilby-pipe)

Usage is explained in the documentation. It should be noted that these have slightly different interpretation than in bilby-pipe, where one typically performs inference over the calibration parameters rather than marginalizing over them.

In addition, there was a small refactoring of the calibration marginalization code to simplify it.

@jonaswildberger You probably need to update #131 to accommodate these additional INI keys.