### PR TITLE
Replace chainconsumer with corner

### DIFF
--- a/dingo/core/density/unconditional_density_estimation.py
+++ b/dingo/core/density/unconditional_density_estimation.py
@@ -124,36 +124,3 @@ def parse_args():
         help="Path to settings file.",
     )
     return parser.parse_args()
-
-
-def main():
-    # load settings
-    args = parse_args()
-    with open(args.settings, "r") as fp:
-        settings = yaml.safe_load(fp)
-
-    # load samples from dingo output
-    samples = pd.read_pickle(settings["data"]["sample_file"])
-
-    model = train_unconditional_density_estimator(
-        samples, settings, dirname(args.settings)
-    )
-
-    model.model.eval()
-    with torch.no_grad():
-        new_samples = model.model.sample(num_samples=10000)
-    new_samples = new_samples.cpu().numpy() * std + mean
-    new_samples = pd.DataFrame(new_samples, columns=parameters)
-    test_samples = pd.DataFrame(samples[num_train_samples:], columns=parameters)
-
-    from dingo.gw.inference.visualization import generate_cornerplot
-
-    generate_cornerplot(
-        {"samples": test_samples, "color": "blue", "name": "test samples"},
-        {"samples": new_samples, "color": "orange", "name": "new samples"},
-        filename=join(dirname(f), "out.pdf"),
-    )
-
-
-if __name__ == "__main__":
-    main()

--- a/dingo/core/density/unconditional_density_estimation.py
+++ b/dingo/core/density/unconditional_density_estimation.py
@@ -1,9 +1,6 @@
 import copy
-from typing import Optional
 
 import torch
-import yaml
-from os.path import dirname, join
 
 from dingo.core.utils import build_train_and_test_loaders
 from dingo.core.utils.trainutils import RuntimeLimits

--- a/dingo/core/result.py
+++ b/dingo/core/result.py
@@ -7,8 +7,6 @@ import numpy as np
 from typing import Optional
 
 import pandas as pd
-import corner
-import matplotlib as mpl
 from matplotlib import pyplot as plt
 from scipy.constants import golden
 from scipy.special import logsumexp

--- a/dingo/core/result.py
+++ b/dingo/core/result.py
@@ -7,10 +7,11 @@ import numpy as np
 from typing import Optional
 
 import pandas as pd
-import matplotlib.pyplot as plt
-from chainconsumer import ChainConsumer
+import corner
+import matplotlib as mpl
+from matplotlib import pyplot as plt
 from scipy.constants import golden
-from scipy.special import logsumexp, erfinv
+from scipy.special import logsumexp
 from bilby.core.prior import Constraint, DeltaFunction
 
 from dingo.core.dataset import DingoDataset
@@ -604,32 +605,95 @@ class Result(DingoDataset):
         if parameters:
             theta = theta[parameters]
 
-        c = ChainConsumer()
+        # Define plot properties
+        cmap = "Dark2"
+        color_1 = mpl.colors.rgb2hex(plt.get_cmap(cmap)(0))
+        color_2 = mpl.colors.rgb2hex(plt.get_cmap(cmap)(1))
+        label_1 = "Dingo"
+        label_2 = "Dingo-IS"
+        corner_params = {
+            "smooth": 1.0,
+            "smooth1d": 1.0,
+            "plot_datapoints": False,
+            "plot_density": False,
+            "plot_contours": True,
+            "levels": [0.5, 0.9],
+            "bins": 30,
+        }
+
+        serif_old = mpl.rcParams["font.family"]
+        mpl.rcParams["font.family"] = "serif"
+        linewidth_old = mpl.rcParams["lines.linewidth"]
+        mpl.rcParams["lines.linewidth"] = 2.5
 
         # Plot pre-importance sampling samples. I.e., drop weights, if present.
-        c.add_chain(theta, weights=None, color="orange", name="Dingo")
+        fig = corner.corner(
+            theta.to_numpy(),
+            color=color_1,
+            no_fill_contours=True,
+            labels=theta.columns,
+            **corner_params,
+        )
         n = 1
 
         if "weights" in theta:
-            c.add_chain(
-                theta, weights=theta["weights"].to_numpy(), color="red", name="Dingo-IS"
+            corner.corner(
+                theta.to_numpy(),
+                color=color_2,
+                no_fill_contours=True,
+                labels=theta.columns,
+                weights=theta["weights"].to_numpy(),
+                fig=fig,
+                **corner_params,
             )
             n = 2
 
-        c.configure(
-            linestyles=["-"] * n,
-            linewidths=[1.5] * n,
-            sigmas=[np.sqrt(2) * erfinv(x) for x in [0.5, 0.9]],
-            shade=[False] + [True] * (n - 1),
-            shade_alpha=0.3,
-            bar_shade=False,
-            label_font_size=10,
-            tick_font_size=10,
-            usetex=False,
-            legend_kwargs={"fontsize": 30},
-            kde=0.7,
+        # Eliminate spacing between the 2D plots
+        fig.subplots_adjust(wspace=0, hspace=0)
+
+        # Add legend
+        handles = [
+            plt.Line2D([], [], color=color_1, label=label_1, linewidth=5, markersize=20)
+        ]
+        if n == 2:
+            handles.append(
+                plt.Line2D(
+                    [], [], color=color_2, label=label_2, linewidth=5, markersize=20
+                )
+            )
+        fig.legend(
+            handles=handles,
+            loc="upper right",
+            fontsize=50,
+            labelcolor="linecolor",
         )
-        c.plotter.plot(filename=filename)
+
+        # Customize tick and label properties for each axis
+        for i, ax in enumerate(fig.get_axes()):
+            if ax.get_xlabel():
+                ax.tick_params(
+                    axis="x", labelsize=14, length=6, width=1.5
+                )  # Adjust labelsize, length, and width
+                ax.xaxis.label.set_size(16)  # Adjust x-axis label font size
+            else:
+                ax.tick_params(axis="x", which="both", bottom=False)
+            if ax.get_ylabel():
+                ax.tick_params(
+                    axis="y", labelsize=14, length=6, width=1.5
+                )  # Adjust labelsize, length, and width
+                ax.yaxis.label.set_size(16)  # Adjust x-axis label font size
+            else:
+                ax.tick_params(axis="y", which="both", left=False)
+
+            # Turn off grid
+            ax.grid()
+
+        # Save the figure
+        plt.savefig(filename)
+
+        # Reset rcParams to original values
+        mpl.rcParams["font.family"] = serif_old
+        mpl.rcParams["lines.linewidth"] = linewidth_old
 
     def plot_log_probs(self, filename="log_probs.png"):
         """

--- a/dingo/core/utils/plotting.py
+++ b/dingo/core/utils/plotting.py
@@ -53,13 +53,21 @@ def plot_corner_multi(
     if not isinstance(labels, list):
         labels = [labels]
 
+    # Only plot common parameters for all sample sets, keeping the same order as the
+    # first sample set.
+    common_parameters = [
+        p
+        for p in samples[0].columns
+        if p in set.intersection(*(set(s.columns) for s in samples))
+    ]
+
     fig = None
     handles = []
     for i, (s, w, l) in enumerate(zip_longest(samples, weights, labels)):
         color = mpl.colors.rgb2hex(plt.get_cmap(cmap)(i))
         fig = corner.corner(
-            s.to_numpy(),
-            labels=s.columns,
+            s[common_parameters].to_numpy(),
+            labels=common_parameters,
             weights=w,
             color=color,
             no_fill_contours=True,

--- a/dingo/core/utils/plotting.py
+++ b/dingo/core/utils/plotting.py
@@ -70,16 +70,20 @@ def plot_corner_multi(
             labels=common_parameters,
             weights=w,
             color=color,
-            no_fill_contours=True,
+            no_fill_contours=False,
             fig=fig,
-            **corner_params
+            **corner_params,
         )
         handles.append(
             plt.Line2D([], [], color=color, label=l, linewidth=5, markersize=20)
         )
 
     # Eliminate spacing between the 2D plots
-    fig.subplots_adjust(wspace=0, hspace=0)
+    if len(common_parameters) > 8:
+        fig.subplots_adjust(wspace=0, hspace=0)
+    else:
+        space = 1 / (4 * len(common_parameters))
+        fig.subplots_adjust(wspace=space, hspace=space)
 
     fig.legend(
         handles=handles,
@@ -114,3 +118,5 @@ def plot_corner_multi(
     # Reset rcParams to original values
     mpl.rcParams["font.family"] = serif_old
     mpl.rcParams["lines.linewidth"] = linewidth_old
+
+    return fig

--- a/dingo/core/utils/plotting.py
+++ b/dingo/core/utils/plotting.py
@@ -1,0 +1,108 @@
+from itertools import zip_longest
+
+import matplotlib as mpl
+import matplotlib.pyplot as plt
+import corner
+import numpy as np
+import pandas as pd
+
+
+def plot_corner_multi(
+    samples, weights=None, labels=None, filename="corner.pdf", **kwargs
+):
+    """
+    Generate a corner plot for multiple posteriors.
+
+    Parameters
+    ----------
+    samples : list[pd.DataFrame]
+        List of sample sets. The DataFrame column names are used as parameter labels.
+    weights : list[np.ndarray or None] or None
+        List of weights sets. The length of each array should be the same as the length of
+        the corresponding samples.
+    labels : list[str or None] or None
+        Labels for the posteriors.
+    filename : str
+        Where to save samples.
+    **kwargs :
+        Forwarded to corner.corner.
+    """
+    # Define plot properties
+    cmap = "Dark2"
+    corner_params = {
+        "smooth": 1.0,
+        "smooth1d": 1.0,
+        "plot_datapoints": False,
+        "plot_density": False,
+        "plot_contours": True,
+        "levels": [0.5, 0.9],
+        "bins": 30,
+    }
+    corner_params.update(kwargs)
+
+    serif_old = mpl.rcParams["font.family"]
+    mpl.rcParams["font.family"] = "serif"
+    linewidth_old = mpl.rcParams["lines.linewidth"]
+    mpl.rcParams["lines.linewidth"] = 2.5
+
+    # In case a single corner plot is desired, convert to lists to iterate.
+    if not isinstance(samples, list):
+        samples = [samples]
+    if not isinstance(weights, list):
+        weights = [weights]
+    if not isinstance(labels, list):
+        labels = [labels]
+
+    fig = None
+    handles = []
+    for i, (s, w, l) in enumerate(zip_longest(samples, weights, labels)):
+        color = mpl.colors.rgb2hex(plt.get_cmap(cmap)(i))
+        fig = corner.corner(
+            s.to_numpy(),
+            labels=s.columns,
+            weights=w,
+            color=color,
+            no_fill_contours=True,
+            fig=fig,
+            **corner_params
+        )
+        handles.append(
+            plt.Line2D([], [], color=color, label=l, linewidth=5, markersize=20)
+        )
+
+    # Eliminate spacing between the 2D plots
+    fig.subplots_adjust(wspace=0, hspace=0)
+
+    fig.legend(
+        handles=handles,
+        loc="upper right",
+        fontsize=50,
+        labelcolor="linecolor",
+    )
+
+    # Customize tick and label properties for each axis
+    for i, ax in enumerate(fig.get_axes()):
+        if ax.get_xlabel():
+            ax.tick_params(
+                axis="x", labelsize=14, length=6, width=1.5
+            )  # Adjust labelsize, length, and width
+            ax.xaxis.label.set_size(16)  # Adjust x-axis label font size
+        else:
+            ax.tick_params(axis="x", which="both", bottom=False)
+        if ax.get_ylabel():
+            ax.tick_params(
+                axis="y", labelsize=14, length=6, width=1.5
+            )  # Adjust labelsize, length, and width
+            ax.yaxis.label.set_size(16)  # Adjust x-axis label font size
+        else:
+            ax.tick_params(axis="y", which="both", left=False)
+
+        # Turn off grid
+        ax.grid()
+
+    # Save the figure
+    plt.savefig(filename)
+
+    # Reset rcParams to original values
+    mpl.rcParams["font.family"] = serif_old
+    mpl.rcParams["lines.linewidth"] = linewidth_old

--- a/dingo/core/utils/plotting.py
+++ b/dingo/core/utils/plotting.py
@@ -70,9 +70,9 @@ def plot_corner_multi(
             labels=common_parameters,
             weights=w,
             color=color,
-            no_fill_contours=False,
+            no_fill_contours=True,
             fig=fig,
-            **corner_params,
+            **corner_params
         )
         handles.append(
             plt.Line2D([], [], color=color, label=l, linewidth=5, markersize=20)

--- a/dingo/gw/importance_sampling/diagnostics.py
+++ b/dingo/gw/importance_sampling/diagnostics.py
@@ -3,9 +3,7 @@ import numpy as np
 import math
 import pandas as pd
 import matplotlib.pyplot as plt
-from chainconsumer import ChainConsumer
-import scipy
-from dingo.core.samplers import Sampler
+from dingo.core.utils.plotting import plot_corner_multi
 from dingo.gw.result import Result
 
 
@@ -20,7 +18,7 @@ def plot_posterior_slice2d(
 
     p0, p1 = theta[keys[0]], theta[keys[1]]
     theta_grid = pd.DataFrame(
-        np.repeat(np.array(theta)[np.newaxis], n_grid ** 2, axis=0),
+        np.repeat(np.array(theta)[np.newaxis], n_grid**2, axis=0),
         columns=theta.keys(),
     )
     theta_grid[keys[0]] = full_axis0.flatten()
@@ -225,21 +223,9 @@ def plot_diagnostics(
         f"Generating cornerplot with {len(theta_new)} out of {len(theta)} IS samples."
     )
 
-    c = ChainConsumer()
-    c.add_chain(theta[: len(theta_new)], weights=None, color="orange", name="dingo")
-    c.add_chain(theta_new, weights=weights_new, color="red", name="dingo-is")
-    N = 2
-    c.configure(
-        linestyles=["-"] * N,
-        linewidths=[1.5] * N,
-        sigmas=[np.sqrt(2) * scipy.special.erfinv(x) for x in [0.5, 0.9]],
-        shade=[False] + [True] * (N - 1),
-        shade_alpha=0.3,
-        bar_shade=False,
-        label_font_size=10,
-        tick_font_size=10,
-        usetex=False,
-        legend_kwargs={"fontsize": 30},
-        kde=0.7,
+    plot_corner_multi(
+        [theta[: len(theta_new)], theta_new],
+        weights=[None, weights_new],
+        labels=["Dingo", "Dingo-IS"],
+        filename=join(outdir, "cornerplot_dingo-is.pdf"),
     )
-    c.plotter.plot(filename=join(outdir, "cornerplot_dingo-is.pdf"))

--- a/dingo/gw/inference/inference_pipeline.py
+++ b/dingo/gw/inference/inference_pipeline.py
@@ -9,6 +9,7 @@ from pathlib import Path
 import yaml
 
 from dingo.core.models import PosteriorModel
+from dingo.core.utils.plotting import plot_corner_multi
 from dingo.gw.data.event_dataset import EventDataset
 from dingo.gw.inference.gw_samplers import GWSampler, GWSamplerGNPE
 from dingo.gw.data.data_preparation import get_event_data_and_domain, \
@@ -342,10 +343,10 @@ def analyze_event():
             ref_method = ref[time_event]["reference_samples"]["method"]
             sampler.to_hdf5(label=label, outdir=args.out_directory)
             ref_samples = load_ref_samples(ref_samples_file)
-            generate_cornerplot(
-                {"name": ref_method, "samples": ref_samples, "color": "blue"},
-                {"name": "dingo", "samples": sampler.samples, "color": "orange"},
-                filename=join(args.out_directory, f"cornerplot_{label}.pdf"),
+            plot_corner_multi(
+                [ref_samples, sampler.samples],
+                labels=[ref_method, "Dingo"],
+                filename=join(args.out_directory, f"cornerplot_{label}.pdf")
             )
     if args.exit_command:
         os.system(" ".join(args.exit_command))

--- a/dingo/gw/inference/inference_pipeline.py
+++ b/dingo/gw/inference/inference_pipeline.py
@@ -14,7 +14,7 @@ from dingo.gw.data.event_dataset import EventDataset
 from dingo.gw.inference.gw_samplers import GWSampler, GWSamplerGNPE
 from dingo.gw.data.data_preparation import get_event_data_and_domain, \
     parse_settings_for_raw_data
-from dingo.gw.inference.visualization import load_ref_samples, generate_cornerplot
+from dingo.gw.inference.visualization import load_ref_samples
 
 
 def parse_args():

--- a/dingo/gw/inference/visualization.py
+++ b/dingo/gw/inference/visualization.py
@@ -1,10 +1,14 @@
 import numpy as np
-from chainconsumer import ChainConsumer
 import scipy
 import pandas as pd
 
 
 def generate_cornerplot(*sample_sets, filename=None):
+    try:
+        from chainconsumer import ChainConsumer
+    except ImportError:
+        return
+
     parameters = [
         p
         for p in sample_sets[0]["samples"].keys()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,7 @@ dependencies = [
     "bilby",
     "bilby_pipe",
     "configargparse",
+    "corner",
     "astropy",
     "lalsuite>=7.11",
     "pesummary",
@@ -46,7 +47,6 @@ dependencies = [
     "pycbc",
     "pandas",
     "threadpoolctl",
-    "chainconsumer",
     "wandb",
     "scikit-learn",
 ]


### PR DESCRIPTION
This replaces chainconsumer with corner for making corner plot, as described in #166. It places a multiple-posterior corner plotting function in `dingo.core.utils.plotting`.

I have tested it in `dingo_pipe`, but not in `inference_pipeline.py` and `diagnostics.py`. Could someone who uses these please test it?