### PR TITLE
Fix bug in `get_mismatch`

### DIFF
--- a/dingo/gw/gwutils.py
+++ b/dingo/gw/gwutils.py
@@ -67,12 +67,12 @@ def get_mismatch(a, b, domain, asd_file=None):
             psd.frequency_array, psd.asd_array, bounds_error=False, fill_value=np.inf
         )
         asd_array = asd_interp(domain.sample_frequencies)
-        a /= asd_array
-        b /= asd_array
+        a = a / asd_array
+        b = b / asd_array
     min_idx = domain.min_idx
-    inner_ab = np.sum((a.conj() * b)[min_idx:], axis=0).real
-    inner_aa = np.sum((a.conj() * a)[min_idx:], axis=0).real
-    inner_bb = np.sum((b.conj() * b)[min_idx:], axis=0).real
+    inner_ab = np.sum((a.conj() * b)[...,min_idx:], axis=-1).real
+    inner_aa = np.sum((a.conj() * a)[...,min_idx:], axis=-1).real
+    inner_bb = np.sum((b.conj() * b)[...,min_idx:], axis=-1).real
     overlap = inner_ab / np.sqrt(inner_aa * inner_bb)
     return 1 - overlap
 


### PR DESCRIPTION
Our `get_mismatch` function `dingo.gw.gwutils` would permanently whiten the input when an ASD was provided, which would lead to downstream bugs if the waveform data is used for anything else after whitening. I fixed this, and also added support for batched data (frequency axis is as always -1).