### PR TITLE
Wandb import

### DIFF
--- a/dingo/core/models/posterior_model.py
+++ b/dingo/core/models/posterior_model.py
@@ -10,7 +10,6 @@ import time
 from threadpoolctl import threadpool_limits
 import dingo.core.utils.trainutils
 import math
-import wandb
 
 from dingo.core.nn.nsf import (
     create_nsf_with_rb_projection_embedding_net,
@@ -72,7 +71,7 @@ class PosteriorModel:
         metadata: dict = None
             dict with metadata, used to save dataset_settings and train_settings
         """
-        self.version = f"dingo={get_version()}" # dingo version
+        self.version = f"dingo={get_version()}"  # dingo version
 
         self.optimizer_kwargs = None
         self.model_kwargs = None
@@ -275,8 +274,6 @@ class PosteriorModel:
             print(f"test loss: {test_loss:.3f}")
 
         else:
-            # if use_wandb:
-            #     wandb.watch(self.model, log="all", log_freq=10)
             while not runtime_limits.limits_exceeded(self.epoch):
                 self.epoch += 1
 
@@ -313,16 +310,21 @@ class PosteriorModel:
                 utils.write_history(train_dir, self.epoch, train_loss, test_loss, lr)
                 utils.save_model(self, train_dir, checkpoint_epochs=checkpoint_epochs)
                 if use_wandb:
-                    wandb.log(
-                        {
-                            "epoch": self.epoch,
-                            "learning_rate": lr[0],
-                            "train_loss": train_loss,
-                            "test_loss": test_loss,
-                            "train_time": train_time,
-                            "test_time": test_time,
-                        }
-                    )
+                    try:
+                        import wandb
+                        wandb.log(
+                            {
+                                "epoch": self.epoch,
+                                "learning_rate": lr[0],
+                                "train_loss": train_loss,
+                                "test_loss": test_loss,
+                                "train_time": train_time,
+                                "test_time": test_time,
+                            }
+                        )
+                    except ImportError:
+                        print("wandb not installed. Skipping logging to wandb.")
+
                 print(f"Finished training epoch {self.epoch}.\n")
 
     def sample(

--- a/dingo/core/models/posterior_model.py
+++ b/dingo/core/models/posterior_model.py
@@ -312,6 +312,8 @@ class PosteriorModel:
                 if use_wandb:
                     try:
                         import wandb
+                        wandb.define_metric("epoch")
+                        wandb.define_metric("*", step_metric="epoch")
                         wandb.log(
                             {
                                 "epoch": self.epoch,

--- a/dingo/gw/training/train_pipeline.py
+++ b/dingo/gw/training/train_pipeline.py
@@ -101,13 +101,10 @@ def prepare_training_new(train_settings: dict, train_dir: str, local_settings: d
     if local_settings.get("wandb", False):
         try:
             import wandb
-            run_id = local_settings["wandb_run_id"]
             wandb.init(
-                project="dingo-devel",
-                id=run_id,
                 config=full_settings,
-                group="hyperparameter_tuning",
                 dir=train_dir,
+                **local_settings["wandb"],
             )
         except ImportError:
             print("WandB is enabled but not installed.")
@@ -137,20 +134,15 @@ def prepare_training_resume(checkpoint_name, local_settings, train_dir):
     wfd = build_dataset(pm.metadata["train_settings"]["data"])
 
     if local_settings.get("wandb", False):
-
         try:
             import wandb
             wandb.init(
-                project=local_settings["wandb"].get("project", "dingo-devel"),
-                id=local_settings["wandb"]["run_id"],
-                group=local_settings["wandb"].get("group", "hyperparameter_tuning"),
                 resume="must",
                 dir=train_dir,
+                **local_settings["wandb"],
             )
-        except (ImportError, KeyError):
-            print(
-                "WandB is enabled but not installed or no run_id has been provided for resuming the run."
-            )
+        except ImportError:
+            print("WandB is enabled but not installed.")
 
     return pm, wfd
 
@@ -354,10 +346,10 @@ def train_local():
 
         local_settings = train_settings.pop("local")
         with open(os.path.join(args.train_dir, "local_settings.yaml"), "w") as f:
-            if local_settings.get("wandb", False) and "wandb_run_id" not in local_settings.keys():
+            if local_settings.get("wandb", False) and "id" not in local_settings["wandb"].keys():
                 try:
                     import wandb
-                    local_settings["wandb_run_id"] = wandb.util.generate_id()
+                    local_settings["wandb"]["id"] = wandb.util.generate_id()
                 except ImportError:
                     print("wandb not installed, cannot generate run id.")
             yaml.dump(local_settings, f, default_flow_style=False, sort_keys=False)

--- a/dingo/gw/training/train_pipeline_condor.py
+++ b/dingo/gw/training/train_pipeline_condor.py
@@ -1,9 +1,8 @@
 import os
 import sys
-from os.path import join, isfile, dirname
+from os.path import join, isfile
 import yaml
 import argparse
-import wandb
 
 from dingo.gw.training import (
     prepare_training_new,
@@ -70,7 +69,6 @@ def train_condor():
     # else:
 
     if not args.start_submission:
-
         #
         # TRAIN
         #
@@ -86,14 +84,16 @@ def train_condor():
 
             local_settings = train_settings.pop("local")
             with open(os.path.join(args.train_dir, "local_settings.yaml"), "w") as f:
-                if local_settings.get("use_wandb", False):
-                    if "WANDB_API_KEY" not in os.environ.keys():
-                        os.environ["WANDB_API_KEY"] = local_settings["wandb_api_key"]
                 if (
-                    local_settings.get("use_wandb", False)
+                    local_settings.get("wandb", False)
                     and "wandb_run_id" not in local_settings.keys()
                 ):
-                    local_settings["wandb_run_id"] = wandb.util.generate_id()
+                    try:
+                        import wandb
+
+                        local_settings["wandb_run_id"] = wandb.util.generate_id()
+                    except ImportError:
+                        print("wandb not installed, cannot generate run id.")
                 yaml.dump(local_settings, f, default_flow_style=False, sort_keys=False)
 
             pm, wfd = prepare_training_new(
@@ -127,7 +127,6 @@ def train_condor():
             condor_arguments = f"--train_dir {args.train_dir}"
 
     else:
-
         #
         # PREPARE FIRST SUBMISSION
         #

--- a/dingo/gw/training/train_pipeline_condor.py
+++ b/dingo/gw/training/train_pipeline_condor.py
@@ -84,14 +84,10 @@ def train_condor():
 
             local_settings = train_settings.pop("local")
             with open(os.path.join(args.train_dir, "local_settings.yaml"), "w") as f:
-                if (
-                    local_settings.get("wandb", False)
-                    and "wandb_run_id" not in local_settings.keys()
-                ):
+                if local_settings.get("wandb", False) and "id" not in local_settings["wandb"].keys():
                     try:
                         import wandb
-
-                        local_settings["wandb_run_id"] = wandb.util.generate_id()
+                        local_settings["wandb"]["id"] = wandb.util.generate_id()
                     except ImportError:
                         print("wandb not installed, cannot generate run id.")
                 yaml.dump(local_settings, f, default_flow_style=False, sort_keys=False)

--- a/docs/source/training.md
+++ b/docs/source/training.md
@@ -93,6 +93,9 @@ training:
 local:
   device: cpu  # Change this to 'cuda' for training on a GPU.
   num_workers: 6
+#  wandb:
+#    project: dingo
+#    group: O4
   runtime_limits:
     max_time_per_run: 36000
     max_epochs_per_run: 500
@@ -150,6 +153,9 @@ device
 
 num_workers
 : Number of CPU worker processes to use for pre-processing training data before copying to the GPU. Data pre-processing (inluding decompression, projection to detectors, and noise generation) is quite expensive, so using 16 or 32 processes is recommended, otherwise this can become a bottleneck. We recommend monitoring the GPU utilization percentage as well as time spent on pre-processing (output during training) to fine-tune this number.
+
+wandb
+: Settings for [Weights & Biases](https://wandb.ai/site). If you have an account, you can use this to track your training progress and compare different runs.
 
 runtime_limits
 : Maximum time (in seconds) or maximum number of epochs per run. Using this could make sense in a cluster environment.

--- a/examples/training/train_settings_init_production.yaml
+++ b/examples/training/train_settings_init_production.yaml
@@ -83,8 +83,9 @@ training:
 local:
   device: cpu  # Change this to 'cuda' for training on a GPU.
   num_workers: 6  # num_workers >0 does not work on Mac, see https://stackoverflow.com/questions/64772335/pytorch-w-parallelnative-cpp206
-  use_wandb: True
-  wandb_api_key:  # insert_here for monitoring many runs. Can be obtained from https://wandb.ai/settings
+  #  wandb:
+  #    project: dingo
+  #    group: O4
   runtime_limits:
     max_time_per_run: 36000
     max_epochs_per_run: 500

--- a/examples/training/train_settings_init_toy.yaml
+++ b/examples/training/train_settings_init_toy.yaml
@@ -80,8 +80,9 @@ training:
 local:
   device: cpu  # Change this to 'cuda' for training on a GPU.
   num_workers: 6  # num_workers >0 does not work on Mac, see https://stackoverflow.com/questions/64772335/pytorch-w-parallelnative-cpp206
-  use_wandb: True
-  wandb_api_key:  # insert_here for monitoring many runs. Can be obtained from https://wandb.ai/settings
+  #  wandb:
+  #    project: dingo
+  #    group: O4
   runtime_limits:
     max_time_per_run: 36000
     max_epochs_per_run: 500

--- a/examples/training/train_settings_no_gnpe_production.yaml
+++ b/examples/training/train_settings_no_gnpe_production.yaml
@@ -81,8 +81,9 @@ training:
 local:
   device: cpu  # Change this to 'cuda' for training on a GPU.
   num_workers: 32  # num_workers >0 does not work on Mac, see https://stackoverflow.com/questions/64772335/pytorch-w-parallelnative-cpp206
-  use_wandb: False
-  wandb_api_key: # insert_here. Can be obtained from https://wandb.ai/settings
+  #  wandb:
+  #    project: dingo
+  #    group: O4
   runtime_limits:
     max_time_per_run: 36000
     max_epochs_per_run: 500

--- a/examples/training/train_settings_no_gnpe_toy.yaml
+++ b/examples/training/train_settings_no_gnpe_toy.yaml
@@ -81,8 +81,9 @@ training:
 local:
   device: cpu  # Change this to 'cuda' for training on a GPU.
   num_workers: 6  # num_workers >0 does not work on Mac, see https://stackoverflow.com/questions/64772335/pytorch-w-parallelnative-cpp206
-  use_wandb: False
-  wandb_api_key: # insert_here. Can be obtained from https://wandb.ai/settings
+#  wandb:
+#    project: dingo
+#    group: O4
   runtime_limits:
     max_time_per_run: 36000
     max_epochs_per_run: 500

--- a/examples/training/train_settings_production.yaml
+++ b/examples/training/train_settings_production.yaml
@@ -84,8 +84,9 @@ training:
 local:
   device: cpu  # Change this to 'cuda' for training on a GPU.
   num_workers: 32  # num_workers >0 does not work on Mac, see https://stackoverflow.com/questions/64772335/pytorch-w-parallelnative-cpp206
-  use_wandb: False
-  wandb_api_key: # insert_here. Can be obtained from https://wandb.ai/settings
+#  wandb:
+#    project: dingo
+#    group: O4
   runtime_limits:
     max_time_per_run: 36000
     max_epochs_per_run: 500

--- a/examples/training/train_settings_toy.yaml
+++ b/examples/training/train_settings_toy.yaml
@@ -81,8 +81,9 @@ training:
 local:
   device: cpu  # Change this to 'cuda' for training on a GPU.
   num_workers: 6  # num_workers >0 does not work on Mac, see https://stackoverflow.com/questions/64772335/pytorch-w-parallelnative-cpp206
-  use_wandb: False
-  wandb_api_key: # insert_here. Can be obtained from https://wandb.ai/settings
+#  wandb:
+#    project: dingo
+#    group: O4
   runtime_limits:
     max_time_per_run: 36000
     max_epochs_per_run: 500

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,6 @@ dependencies = [
     "pycbc",
     "pandas",
     "threadpoolctl",
-    "wandb",
     "scikit-learn",
 ]
 
@@ -76,7 +75,8 @@ dev = [
     "sphinxcontrib-mermaid",
     "sphinxcontrib-bibtex",
     "myst-parser",
-    "linkify-it-py"
+    "linkify-it-py",
+    "wandb",
 ]
 
 


### PR DESCRIPTION
Moved all calls to the `wandb` library into `try`, `except` statements, therefore dropping the requirement to have it installed. Some further improvements were made to use it in a more generic way