### PR TITLE
Corrected for calibration marginalized likelihood

### DIFF
--- a/dingo/gw/likelihood.py
+++ b/dingo/gw/likelihood.py
@@ -547,7 +547,7 @@ class StationaryGaussianGWLikelihood(GWSignal, Likelihood):
 
         likelihoods = self.log_Zn + kappa2 - 1 / 2.0 * rho2opt
         # Return the average over calibration envelopes
-        return np.mean(likelihoods)
+        return logsumexp(likelihoods) - np.log(len(likelihoods))
 
     def d_inner_h_complex_multi(
         self, theta: pd.DataFrame, num_processes: int = 1


### PR DESCRIPTION
There was a slight mistake in calculating the calibration marginalized likelihood which showed up in a difference between the offiical bilby samples and dingo's samples. This has now been corrected, the reason for this bug is included in the following calculation: 

![image](https://user-images.githubusercontent.com/40392612/232761989-14739bbb-3330-405c-888b-bd48f49fa3a9.png)
