### PR TITLE
Rename the imported logger to "dingo_pipe"

### DIFF
--- a/dingo/pipe/dag_creator.py
+++ b/dingo/pipe/dag_creator.py
@@ -6,6 +6,7 @@ import copy
 
 from bilby_pipe.job_creation.dag import Dag
 from bilby_pipe.utils import BilbyPipeError, logger
+logger.name = "dingo_pipe"
 
 from dingo.pipe.nodes.generation_node import GenerationNode
 from .nodes.importance_sampling_node import ImportanceSamplingNode

--- a/dingo/pipe/dag_creator.py
+++ b/dingo/pipe/dag_creator.py
@@ -6,13 +6,14 @@ import copy
 
 from bilby_pipe.job_creation.dag import Dag
 from bilby_pipe.utils import BilbyPipeError, logger
-logger.name = "dingo_pipe"
 
 from dingo.pipe.nodes.generation_node import GenerationNode
 from .nodes.importance_sampling_node import ImportanceSamplingNode
 from .nodes.merge_node import MergeNode
 from .nodes.plot_node import PlotNode
 from .nodes.sampling_node import SamplingNode
+
+logger.name = "dingo_pipe"
 
 
 def get_trigger_time_list(inputs):

--- a/dingo/pipe/data_generation.py
+++ b/dingo/pipe/data_generation.py
@@ -4,12 +4,13 @@ import sys
 from bilby_pipe.input import Input
 from bilby_pipe.main import parse_args
 from bilby_pipe.utils import logger, convert_string_to_dict
-logger.name = "dingo_pipe"
 from bilby_pipe.data_generation import DataGenerationInput as BilbyDataGenerationInput
 
 from dingo.gw.data.event_dataset import EventDataset
 from dingo.gw.domains import FrequencyDomain
 from dingo.pipe.parser import create_parser
+
+logger.name = "dingo_pipe"
 
 
 class DataGenerationInput(BilbyDataGenerationInput):

--- a/dingo/pipe/data_generation.py
+++ b/dingo/pipe/data_generation.py
@@ -4,6 +4,7 @@ import sys
 from bilby_pipe.input import Input
 from bilby_pipe.main import parse_args
 from bilby_pipe.utils import logger, convert_string_to_dict
+logger.name = "dingo_pipe"
 from bilby_pipe.data_generation import DataGenerationInput as BilbyDataGenerationInput
 
 from dingo.gw.data.event_dataset import EventDataset

--- a/dingo/pipe/importance_sampling.py
+++ b/dingo/pipe/importance_sampling.py
@@ -7,6 +7,7 @@ import sys
 import yaml
 from bilby_pipe.input import Input
 from bilby_pipe.utils import parse_args, logger, convert_string_to_dict
+logger.name = "dingo_pipe"
 
 from dingo.gw.data.event_dataset import EventDataset
 from dingo.pipe.default_settings import IMPORTANCE_SAMPLING_SETTINGS

--- a/dingo/pipe/importance_sampling.py
+++ b/dingo/pipe/importance_sampling.py
@@ -7,12 +7,13 @@ import sys
 import yaml
 from bilby_pipe.input import Input
 from bilby_pipe.utils import parse_args, logger, convert_string_to_dict
-logger.name = "dingo_pipe"
 
 from dingo.gw.data.event_dataset import EventDataset
 from dingo.pipe.default_settings import IMPORTANCE_SAMPLING_SETTINGS
 from dingo.pipe.parser import create_parser
 from dingo.gw.result import Result
+
+logger.name = "dingo_pipe"
 
 
 class ImportanceSamplingInput(Input):

--- a/dingo/pipe/main.py
+++ b/dingo/pipe/main.py
@@ -11,6 +11,7 @@ from bilby_pipe.utils import (
     logger,
     convert_string_to_dict,
 )
+logger.name = "dingo_pipe"
 
 from .dag_creator import generate_dag
 from .parser import create_parser

--- a/dingo/pipe/main.py
+++ b/dingo/pipe/main.py
@@ -11,13 +11,14 @@ from bilby_pipe.utils import (
     logger,
     convert_string_to_dict,
 )
-logger.name = "dingo_pipe"
 
 from .dag_creator import generate_dag
 from .parser import create_parser
 
 from dingo.gw.domains import build_domain_from_model_metadata
 from dingo.core.models import PosteriorModel
+
+logger.name = "dingo_pipe"
 
 
 def fill_in_arguments_from_model(args):

--- a/dingo/pipe/parser.py
+++ b/dingo/pipe/parser.py
@@ -13,6 +13,7 @@ from bilby_pipe.utils import (
     noneint,
     nonestr,
 )
+logger.name = "dingo_pipe"
 
 
 class StoreBoolean(argparse.Action):

--- a/dingo/pipe/parser.py
+++ b/dingo/pipe/parser.py
@@ -13,6 +13,7 @@ from bilby_pipe.utils import (
     noneint,
     nonestr,
 )
+
 logger.name = "dingo_pipe"
 
 

--- a/dingo/pipe/plot.py
+++ b/dingo/pipe/plot.py
@@ -2,9 +2,10 @@ from pathlib import Path
 
 from bilby_pipe.bilbyargparser import BilbyArgParser
 from bilby_pipe.utils import get_command_line_arguments, logger, parse_args
-logger.name = "dingo_pipe"
 
 from dingo.gw.result import Result
+
+logger.name = "dingo_pipe"
 
 
 def create_parser():

--- a/dingo/pipe/plot.py
+++ b/dingo/pipe/plot.py
@@ -2,6 +2,7 @@ from pathlib import Path
 
 from bilby_pipe.bilbyargparser import BilbyArgParser
 from bilby_pipe.utils import get_command_line_arguments, logger, parse_args
+logger.name = "dingo_pipe"
 
 from dingo.gw.result import Result
 

--- a/dingo/pipe/sampling.py
+++ b/dingo/pipe/sampling.py
@@ -5,7 +5,6 @@ from pathlib import Path
 
 from bilby_pipe.input import Input
 from bilby_pipe.utils import parse_args, logger, convert_string_to_dict
-logger.name = "dingo_pipe"
 
 from dingo.core.models import PosteriorModel
 from dingo.gw.data.event_dataset import EventDataset
@@ -13,6 +12,8 @@ from dingo.gw.inference.gw_samplers import GWSampler, GWSamplerGNPE
 from dingo.gw.inference.inference_pipeline import prepare_log_prob
 from dingo.pipe.default_settings import DENSITY_RECOVERY_SETTINGS
 from dingo.pipe.parser import create_parser
+
+logger.name = "dingo_pipe"
 
 
 class SamplingInput(Input):

--- a/dingo/pipe/sampling.py
+++ b/dingo/pipe/sampling.py
@@ -5,6 +5,7 @@ from pathlib import Path
 
 from bilby_pipe.input import Input
 from bilby_pipe.utils import parse_args, logger, convert_string_to_dict
+logger.name = "dingo_pipe"
 
 from dingo.core.models import PosteriorModel
 from dingo.gw.data.event_dataset import EventDataset


### PR DESCRIPTION
The change made here is a bit lazy, but simply replacing the (bilby_pipe) `logger` with a new one in dingo_pipe code would lead to inconsistent output because we are calling bilby_pipe code in many places and that is using it's own logger. So, to leave the bilby_pipe code unchanged we take their logger and simply rename it.