### PR TITLE
Add ability to turn off importance sampling, create summary pages

### DIFF
--- a/dingo/core/result.py
+++ b/dingo/core/result.py
@@ -649,6 +649,8 @@ class Result(DingoDataset):
             plt.plot([y_upper - 20, y_upper], [y_upper - 20, y_upper], color="black")
             plt.tight_layout()
             plt.savefig(filename)
+        else:
+            print("Results not importance sampled. Cannot produce log_prob plot.")
 
     def plot_weights(self, filename="weights.png"):
         """Make a scatter plot of samples weights vs log proposal."""
@@ -676,6 +678,8 @@ class Result(DingoDataset):
             plt.scatter(x, y, s=0.5)
             plt.tight_layout()
             plt.savefig(filename)
+        else:
+            print("Results not importance sampled. Cannot plot weights.")
 
 
 def check_equal_dict_of_arrays(a, b):

--- a/dingo/pipe/dag_creator.py
+++ b/dingo/pipe/dag_creator.py
@@ -10,6 +10,7 @@ from bilby_pipe.utils import BilbyPipeError, logger
 from dingo.pipe.nodes.generation_node import GenerationNode
 from .nodes.importance_sampling_node import ImportanceSamplingNode
 from .nodes.merge_node import MergeNode
+from .nodes.pe_summary_node import PESummaryNode
 from .nodes.plot_node import PlotNode
 from .nodes.sampling_node import SamplingNode
 
@@ -42,7 +43,7 @@ def get_parallel_list(inputs):
         return [f"part{idx}" for idx in range(inputs.n_parallel)]
 
 
-def generate_dag(inputs):
+def generate_dag(inputs, model_args):
     inputs = copy.deepcopy(inputs)
     dag = Dag(inputs)
     trigger_times = get_trigger_time_list(inputs)
@@ -152,6 +153,11 @@ def generate_dag(inputs):
     #
     # 6. PESummary
     #
+
+    if inputs.create_summary:
+        # Add the waveform approximant to inputs, so that it can be fed to PESummary.
+        inputs.waveform_approximant = model_args["waveform_approximant"]
+        PESummaryNode(inputs, merged_importance_sampling_node_list, generation_node_list, dag=dag)
 
     dag.build()
     # create_overview(

--- a/dingo/pipe/main.py
+++ b/dingo/pipe/main.py
@@ -83,7 +83,7 @@ def fill_in_arguments_from_model(args):
         importance_sampling_updates = {
             k.replace("-", "_"): v for k, v in importance_sampling_updates.items()
         }
-    return {**changed_args, **importance_sampling_updates}
+    return {**changed_args, **importance_sampling_updates}, model_args
 
 
 class MainInput(BilbyMainInput):
@@ -125,11 +125,11 @@ class MainInput(BilbyMainInput):
         self.final_result = args.final_result
         self.final_result_nsamples = args.final_result_nsamples
 
-        # self.webdir = args.webdir
+        self.webdir = args.webdir
         self.email = args.email
         self.notification = args.notification
         self.queue = args.queue
-        # self.existing_dir = args.existing_dir
+        self.existing_dir = args.existing_dir
 
         self.scheduler = args.scheduler
         self.scheduler_args = args.scheduler_args
@@ -216,7 +216,7 @@ class MainInput(BilbyMainInput):
         # self.single_postprocessing_executable = args.single_postprocessing_executable
         # self.single_postprocessing_arguments = args.single_postprocessing_arguments
         #
-        # self.summarypages_arguments = args.summarypages_arguments
+        self.summarypages_arguments = args.summarypages_arguments
         #
         self.psd_dict = args.psd_dict
 
@@ -316,14 +316,14 @@ def main():
     parser = create_parser(top_level=True)
     args, unknown_args = parse_args(get_command_line_arguments(), parser)
 
-    importance_sampling_updates = fill_in_arguments_from_model(args)
+    importance_sampling_updates, model_args = fill_in_arguments_from_model(args)
     inputs = MainInput(args, unknown_args, importance_sampling_updates)
     write_complete_config_file(parser, args, inputs)
 
     # TODO: Use two sets of inputs! The first must match the network; the second is
     #  used in importance sampling.
 
-    generate_dag(inputs)
+    generate_dag(inputs, model_args)
 
     if len(unknown_args) > 0:
         print(f"Unrecognized arguments {unknown_args}")

--- a/dingo/pipe/main.py
+++ b/dingo/pipe/main.py
@@ -177,6 +177,8 @@ class MainInput(BilbyMainInput):
         # if self.injection:
         #     self.check_injection()
 
+        self.importance_sample = args.importance_sample
+
         self.request_disk = args.request_disk
         self.request_memory = args.request_memory
         self.request_memory_generation = args.request_memory_generation

--- a/dingo/pipe/nodes/pe_summary_node.py
+++ b/dingo/pipe/nodes/pe_summary_node.py
@@ -1,0 +1,87 @@
+from bilby_pipe.job_creation.nodes import PESummaryNode as BilbyPESummaryNode
+from bilby_pipe.utils import BilbyPipeError, logger
+
+logger.name = "dingo_pipe"
+
+
+class PESummaryNode(BilbyPESummaryNode):
+    def __init__(self, inputs, merged_node_list, generation_node_list, dag):
+        super(BilbyPESummaryNode, self).__init__(inputs)
+        self.dag = dag
+        self.job_name = f"{inputs.label}_pesummary"
+        self.request_cpus = 1
+
+        n_results = len(merged_node_list)
+        result_files = [merged_node.result_file for merged_node in merged_node_list]
+        labels = [merged_node.label for merged_node in merged_node_list]
+
+        self.setup_arguments(
+            add_ini=False, add_unknown_args=False, add_command_line_args=False
+        )
+        self.arguments.add("webdir", self.inputs.webdir)
+        if self.inputs.email is not None:
+            self.arguments.add("email", self.inputs.email)
+        self.arguments.add(
+            "config", " ".join([self.inputs.complete_ini_file] * n_results)
+        )
+        self.arguments.add("samples", f"{' '.join(result_files)}")
+
+        # Using append here as summary pages doesn't take a full name for approximant
+        self.arguments.append("-a")
+        self.arguments.append(" ".join([self.inputs.waveform_approximant] * n_results))
+
+        # if len(generation_node_list) == 1:
+        #     self.arguments.add("gwdata", generation_node_list[0].data_dump_file)
+        # elif len(generation_node_list) > 1:
+        #     logger.info(
+        #         "Not adding --gwdata to PESummary job as there are multiple files"
+        #     )
+        existing_dir = self.inputs.existing_dir
+        if existing_dir is not None:
+            self.arguments.add("existing_webdir", existing_dir)
+
+        if isinstance(self.inputs.summarypages_arguments, dict):
+            if "labels" not in self.inputs.summarypages_arguments.keys():
+                self.arguments.append(f"--labels {' '.join(labels)}")
+            else:
+                if len(labels) != len(result_files):
+                    raise BilbyPipeError(
+                        "Please provide the same number of labels for postprocessing "
+                        "as result files"
+                    )
+            not_recognised_arguments = {}
+            for key, val in self.inputs.summarypages_arguments.items():
+                if key == "nsamples_for_skymap":
+                    self.arguments.add("nsamples_for_skymap", val)
+                elif key == "gw":
+                    self.arguments.add_flag("gw")
+                elif key == "no_ligo_skymap":
+                    self.arguments.add_flag("no_ligo_skymap")
+                elif key == "burnin":
+                    self.arguments.add("burnin", val)
+                elif key == "kde_plot":
+                    self.arguments.add_flag("kde_plot")
+                elif key == "gracedb":
+                    self.arguments.add("gracedb", val)
+                elif key == "palette":
+                    self.arguments.add("palette", val)
+                elif key == "include_prior":
+                    self.arguments.add_flag("include_prior")
+                elif key == "notes":
+                    self.arguments.add("notes", val)
+                elif key == "publication":
+                    self.arguments.add_flag("publication")
+                elif key == "labels":
+                    self.arguments.add("labels", f"{' '.join(val)}")
+                else:
+                    not_recognised_arguments[key] = val
+            if not_recognised_arguments != {}:
+                logger.warn(
+                    "Did not recognise the summarypages_arguments {}. To find "
+                    "the full list of available arguments, please run "
+                    "summarypages --help".format(not_recognised_arguments)
+                )
+
+        self.process_node()
+        for merged_node in merged_node_list:
+            self.job.add_parent(merged_node.job)

--- a/dingo/pipe/nodes/sampling_node.py
+++ b/dingo/pipe/nodes/sampling_node.py
@@ -65,3 +65,7 @@ class SamplingNode(AnalysisNode):
         return os.path.join(
             self.inputs.result_directory, self.label + ".hdf5"
         )
+
+    @property
+    def result_file(self):
+        return self.samples_file

--- a/dingo/pipe/parser.py
+++ b/dingo/pipe/parser.py
@@ -1232,6 +1232,14 @@ def create_parser(top_level=True):
         ),
     )
     sampler_parser.add(
+        "--importance-sample",
+        action=StoreBoolean,
+        default=True,
+        help=(
+            "Whether to perform importance sampling on result. (Default: True)"
+        ),
+    )
+    sampler_parser.add(
         "--importance-sampling-settings",
         type=str,
         default="Default",

--- a/docs/source/dingo_pipe.md
+++ b/docs/source/dingo_pipe.md
@@ -33,6 +33,7 @@ num-gnpe-iterations = 30
 num-samples = 50000
 batch-size = 50000
 recover-log-prob = true
+importance-sample = true
 prior-dict = {
 luminosity_distance = bilby.gw.prior.UniformComovingVolume(minimum=100, maximum=2000, name='luminosity_distance'),
 }
@@ -102,7 +103,7 @@ If a `prior-dict` is specified in the `.ini` file, then this will be used for th
 If extending the prior support during importance sampling, be sure that the posterior does not rail up against the prior boundary being extended.
 ```
 
-By default, dingo_pipe assumes that it is necessary to sample the phase synthetically, so it will do so before importance sampling. This can be turned off by passing an empty dictionary to `importance-sampling-settings`.
+By default, dingo_pipe assumes that it is necessary to sample the phase synthetically, so it will do so before importance sampling. This can be turned off by passing an empty dictionary to `importance-sampling-settings`. Note that importance sampling itself can be switched off by setting the `importance-sample` flag to False (it defaults to True). 
 
 Importance sampling (including synthetic phase sampling) is an expensive step, so dingo_pipe allows for parallelization: this step is split over `n-parallel` jobs, each of which uses `request-cpus-importance-sampling` processes. In the backend, this makes use of the Result [split()](dingo.core.result.Result.split) and [merge()](dingo.core.result.Result.merge) methods.
 


### PR DESCRIPTION
This makes two additions to dingo_pipe:

* `importance-sample` option (default True). By setting this to False, we can turn off importance sampling.
* `create-summary`. This is taken over from bilby_pipe. It calls PESummary at the end of the run.