### PR TITLE
Fix import bug in synthetic noise package

### DIFF
--- a/dingo/gw/noise/synthetic/asd_parameterization.py
+++ b/dingo/gw/noise/synthetic/asd_parameterization.py
@@ -7,7 +7,7 @@ import tqdm
 import scipy.optimize
 from threadpoolctl import threadpool_limits
 
-from dingo.gw.noise.synthetic_noise.utils import get_index_for_elem, lorentzian_eval
+from dingo.gw.noise.synthetic.utils import get_index_for_elem, lorentzian_eval
 
 P0_A, P0_Q = 5, 100
 MIN_A, MIN_Q = 0, 10

--- a/dingo/gw/noise/synthetic/asd_sampling.py
+++ b/dingo/gw/noise/synthetic/asd_sampling.py
@@ -2,9 +2,9 @@ import copy
 
 import numpy as np
 from scipy import stats
-from dingo.gw.noise.synthetic_noise.asd_parameterization import fit_broadband_noise
+from dingo.gw.noise.synthetic.asd_parameterization import fit_broadband_noise
 from dingo.gw.noise.asd_dataset import ASDDataset
-from dingo.gw.noise.synthetic_noise.utils import (
+from dingo.gw.noise.synthetic.utils import (
     get_index_for_elem,
 )
 

--- a/dingo/gw/noise/synthetic/generate_dataset.py
+++ b/dingo/gw/noise/synthetic/generate_dataset.py
@@ -6,11 +6,10 @@ from typing import Dict
 
 import yaml
 
-from dingo.gw.dataset import DingoDataset
 from dingo.gw.noise.asd_dataset import ASDDataset
-from dingo.gw.noise.synthetic_noise.asd_parameterization import parameterize_asd_dataset
-from dingo.gw.noise.synthetic_noise.asd_sampling import KDE, get_rescaling_params
-from dingo.gw.noise.synthetic_noise.utils import reconstruct_psds_from_parameters
+from dingo.gw.noise.synthetic.asd_parameterization import parameterize_asd_dataset
+from dingo.gw.noise.synthetic.asd_sampling import KDE, get_rescaling_params
+from dingo.gw.noise.synthetic.utils import reconstruct_psds_from_parameters
 
 
 def parse_args():


### PR DESCRIPTION
When the package got renamed from `dingo.gw.noise.synthetic_noise` -> `dingo.gw.noise.synthetic`, the import statements did not get repointed properly.