### PR TITLE
Update test_domains.py

### DIFF
--- a/tests/gw/test_domains.py
+++ b/tests/gw/test_domains.py
@@ -160,7 +160,7 @@ def test_FD_time_translation_torch(uniform_FD_params):
     result = domain.time_translate_data(data, -dt)
     assert result.dtype == torch.float32
     assert result.shape == data.shape
-    assert torch.allclose(result[..., 0, :], torch.tensor(1.0), atol=1e-6)
+    assert torch.allclose(result[..., 0, :], torch.tensor(1.0), atol=1e-5)
     # Tolerance of 1e-2 is required in the imaginary part, likely because we are
     # checking that it *vanishes*. This is a consequence of single-precision floats.
     # TODO: Is there a way to improve on this?


### PR DESCRIPTION
Allow for larger tolerance in `allclose` test. The previous tolerance of `1e-6` was too tight; changing it to `1-e5`.