### PR TITLE
Restore compatibility for bilby_pipe < 1.0.9

### DIFF
--- a/dingo/pipe/nodes/importance_sampling_node.py
+++ b/dingo/pipe/nodes/importance_sampling_node.py
@@ -53,7 +53,7 @@ class ImportanceSamplingNode(AnalysisNode):
         env_vars = []
         # if self.request_cpus > 1:
         #     env_vars.append("OMP_NUM_THREADS=1")
-        if self.disable_hdf5_locking:
+        if getattr(self, "disable_hdf5_locking", None):
             env_vars.append("USE_HDF5_FILE_LOCKING=FALSE")
         if env_vars:
             self.extra_lines.append(f"environment = \"{' '.join(env_vars)}\"")

--- a/dingo/pipe/nodes/plot_node.py
+++ b/dingo/pipe/nodes/plot_node.py
@@ -21,7 +21,7 @@ class PlotNode(BilbyPlotNode):
                 self.arguments.add_flag(plot_type)
         # self.arguments.add("format", inputs.plot_format)
 
-        if self.disable_hdf5_locking:
+        if getattr(self, "disable_hdf5_locking", None):
             self.extra_lines.append('environment = "HDF5_USE_FILE_LOCKING=FALSE"')
 
         self.process_node()

--- a/dingo/pipe/nodes/sampling_node.py
+++ b/dingo/pipe/nodes/sampling_node.py
@@ -42,7 +42,7 @@ class SamplingNode(AnalysisNode):
         env_vars = []
         # if self.request_cpus > 1:
         #     env_vars.append("OMP_NUM_THREADS=1")
-        if self.disable_hdf5_locking:
+        if getattr(self, "disable_hdf5_locking", None):
             env_vars.append("USE_HDF5_FILE_LOCKING=FALSE")
         if env_vars:
             self.extra_lines.append(f"environment = \"{' '.join(env_vars)}\"")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ classifiers = [
 dependencies = [
     "astropy",
     "bilby",
-    "bilby_pipe>=1.0.9",
+    "bilby_pipe",
     "configargparse",
     "corner",
     "cryptography",


### PR DESCRIPTION
For compatibility with `bilby_pipe >= 1.0.9`, we assumed an attribute of the `Input` class called `disable_hdf5_locking` in #192. However, this introduced an incompatibility with older version of `bilby_pipe`. This new PR simply gives a default attribute value of `None` by accessing via `getattr()`.

I am currently testing with `bilby_pipe = 1.0.7` and `bilby_pipe = 1.1.0`.