### PR TITLE
Add lal import in `dingo/gw/__init__.py`

### DIFF
--- a/dingo/gw/__init__.py
+++ b/dingo/gw/__init__.py
@@ -1,0 +1,3 @@
+# This import is to try to resolve an incompatibility between lal and pytorch, which
+# involves MKL. See https://git.ligo.org/lscsoft/lalsuite/-/issues/300#note_680778.
+import lal


### PR DESCRIPTION
This is intended to try to resolve an incompatibility between lal / MKL / pytorch, see https://git.ligo.org/lscsoft/lalsuite/-/issues/300#note_680778.