### PR TITLE
Checking for nans in dingo_pipe PSD generation

### DIFF
--- a/dingo/pipe/data_generation.py
+++ b/dingo/pipe/data_generation.py
@@ -1,14 +1,17 @@
 import os
 import sys
 
+import numpy as np
 from bilby_pipe.input import Input
 from bilby_pipe.main import parse_args
 from bilby_pipe.utils import logger, convert_string_to_dict
 from bilby_pipe.data_generation import DataGenerationInput as BilbyDataGenerationInput
+from bilby.gw.detector.psd import PowerSpectralDensity
 
 from dingo.gw.data.event_dataset import EventDataset
 from dingo.gw.domains import FrequencyDomain
 from dingo.pipe.parser import create_parser
+from dingo.gw.data.data_download import download_psd
 
 logger.name = "dingo_pipe"
 
@@ -158,6 +161,33 @@ class DataGenerationInput(BilbyDataGenerationInput):
             args.injection_waveform_arguments = None
 
             self.create_data(args)
+
+    def create_data(self, args):
+        super().create_data(args)
+
+        # check if there are nan's in the asd, if there are shift the detector segment used to generate the psd to an earlier time 
+        for ifo in self.interferometers:
+            frequency_array = ifo.strain_data.frequency_array
+            asd = ifo.power_spectral_density.get_amplitude_spectral_density_array(
+                frequency_array
+            )
+
+            if np.max(np.isnan(asd)):
+                if args.shift_segment_for_psd_generation_if_nan:
+                    window = {
+                        "type": "tukey",
+                        "roll_off":self.tukey_roll_off, 
+                        "T": self.duration,
+                        "f_s": self.sampling_frequency
+                    }
+                    psd_array = download_psd(ifo.name, self.start_time + self.psd_start_time, self.psd_duration, window, self.sampling_frequency)
+                    psd = PowerSpectralDensity(frequency_array=frequency_array, psd_array=psd_array)
+                    ifo.power_spectral_density = psd
+                else:
+                    logger.critical(f"""Nan encountered in strain data for PSD estimation for detector {ifo.name}. 
+                    Specify --shift-segment-for-psd-generation-if-nan to shift PSD segement to an earlier time without Nans. """)
+                    raise
+
 
     def save_hdf5(self):
         """Save frequency-domain strain and ASDs as DingoDataset HDF5 format."""

--- a/dingo/pipe/parser.py
+++ b/dingo/pipe/parser.py
@@ -170,6 +170,17 @@ def create_parser(top_level=True):
             "noise) is obtained from time when the IFOs are in science mode."
         ),
     )
+
+    data_gen_pars.add(
+        "--shift-segment-for-psd-generation-if-nan",
+        action=StoreBoolean,
+        default=False,
+        help=(
+            "Occasionally there are Nans stored in the strain data from which the PSD is generated. "
+            "If this method is activated, it will roll back the strain data which is being analyzed to "
+            "a segement which contains no Nans."
+        ),
+    )
     #
     # data_gen_pars.add(
     #     "--gps-tuple",

--- a/dingo/pipe/sampling.py
+++ b/dingo/pipe/sampling.py
@@ -106,8 +106,6 @@ class SamplingInput(Input):
 
     def _load_sampler(self):
         """Load the sampler and set its context based on event data."""
-        import torch
-        print(self.device, torch.cuda.is_available(), torch.cuda.current_device())
         model = PosteriorModel(self.model, device=self.device, load_training_info=False)
 
         if self.model_init is not None:

--- a/dingo/pipe/sampling.py
+++ b/dingo/pipe/sampling.py
@@ -106,6 +106,8 @@ class SamplingInput(Input):
 
     def _load_sampler(self):
         """Load the sampler and set its context based on event data."""
+        import torch
+        print(self.device, torch.cuda.is_available(), torch.cuda.current_device())
         model = PosteriorModel(self.model, device=self.device, load_training_info=False)
 
         if self.model_init is not None:


### PR DESCRIPTION
Currently, the PSD routine used in dingo pipe is determined by Bilby's DataGeneration. However, occasionally for events in O3 (e.g. GW190517) there will be nans in the data stream. We would still like to analyze these events, so we roll back the PSD segment until it does not contain nans. This is done in dingo.gw.data.data_download.download_psd. This PR adds a flag "--shift-segment-for-psd-generation-if-nan" which if True will use the dingo routinte when Nans are detected in the PSD.

The one part I'm a bit unhappy with is the logging since calling `download_psd` has some print statements which get outputted to stdout when they should be outputted to stderr. 

TODO: update documentation