### PR TITLE
Changed datatype of waveforms when they fail to generate to complex

### DIFF
--- a/dingo/gw/waveform_generator/waveform_generator.py
+++ b/dingo/gw/waveform_generator/waveform_generator.py
@@ -202,7 +202,7 @@ class WaveformGenerator:
                         f"Evaluating the waveform failed with error: {e}\n"
                         f"The parameters were {parameters_generator}\n"
                     )
-                    pol_nan = np.ones(len(self.domain)) * np.nan
+                    pol_nan = np.ones(len(self.domain), dtype=complex) * np.nan
                     wf_dict = {"h_plus": pol_nan, "h_cross": pol_nan}
                 else:
                     raise


### PR DESCRIPTION
Occasionally some waveforms fail to generate due to errors with the underlying LAL routines. The solution to this is to set np.nansfor these waveforms which will translate to np.nan later down in the pipeline. (For example when computing log likelihoods). However, the datatype of this nan array should be complex otherwise there will be places in the code like: https://github.com/dingo-gw/dingo/blob/main/dingo/gw/domains.py#L295 will trigger an error. This fixes the issue so that now if the log_likelihood of a invalid configuration is requested, np.nan will correctly be returned instead of a TypeError: https://github.com/dingo-gw/dingo/blob/main/dingo/gw/domains.py#L327