### PR TITLE
Compute SNR posteriors

### DIFF
--- a/dingo/core/likelihood.py
+++ b/dingo/core/likelihood.py
@@ -42,4 +42,7 @@ class Likelihood(object):
             else:
                 log_likelihood = list(map(self.log_likelihood, theta_generator))
 
-        return np.array(log_likelihood)
+        log_L, rho_opt, rho_coh = np.array(log_likelihood).T
+
+        return log_L, rho_opt, rho_coh
+

--- a/dingo/core/result.py
+++ b/dingo/core/result.py
@@ -278,7 +278,7 @@ class Result(DingoDataset):
 
         print(f"Calculating {len(theta)} likelihoods.")
         t0 = time.time()
-        log_likelihood = self.likelihood.log_likelihood_multi(
+        log_likelihood, rho_opt, rho_coh = self.likelihood.log_likelihood_multi(
             theta, num_processes=num_processes
         )
         print(f"Done. This took {time.time() - t0:.2f} seconds.")
@@ -286,6 +286,8 @@ class Result(DingoDataset):
         self.log_noise_evidence = self.likelihood.log_Zn
         self.samples["log_prior"] = log_prior
         self.samples.loc[valid_samples, "log_likelihood"] = log_likelihood
+        self.samples.loc[valid_samples, "rho_opt"] = rho_opt
+        self.samples.loc[valid_samples, "rho_coh"] = rho_coh
         self._calculate_evidence()
 
     def _calculate_evidence(self):

--- a/dingo/gw/importance_sampling/diagnostics.py
+++ b/dingo/gw/importance_sampling/diagnostics.py
@@ -26,7 +26,7 @@ def plot_posterior_slice2d(
 
     # compute log_prob
     log_probs_target = (
-        sampler.likelihood.log_likelihood_multi(theta_grid, num_processes)
+        sampler.likelihood.log_likelihood_multi(theta_grid, num_processes)[0]
         # + sampler.prior.ln_prob(theta_grid, axis=0)
         - sampler.log_evidence
     )


### PR DESCRIPTION
* Implement SNR posteriors for standard likelihood
* `log_likelihood()` now returns 3 floats (logL, rho_opt, rho_coh) and similarly `log_likelihood_multi()` will now return arrays of these quantities.

TODO:
  * implement the SNRs for the marginalized likelihoods
  * add tests