### PR TITLE
Tapering modes extra time

### DIFF
--- a/dingo/gw/waveform_generator/waveform_generator.py
+++ b/dingo/gw/waveform_generator/waveform_generator.py
@@ -829,7 +829,6 @@ class NewInterfaceWaveformGenerator(WaveformGenerator):
         # parameters needed for TD waveforms
         delta_t = 0.5 / self.domain.f_max
 
-        conditioning = parameter_dict.get("conditioning",2)
         params_gwsignal = {
             "mass1": p["mass_1"] * u.kg,
             "mass2": p["mass_2"] * u.kg,
@@ -849,7 +848,6 @@ class NewInterfaceWaveformGenerator(WaveformGenerator):
             "inclination": iota * u.rad,
             "ModeArray": self.mode_list,
             "condition": 1,
-            #"conditioning": conditioning
         }
 
         # SEOBNRv5 specific parameters

--- a/dingo/gw/waveform_generator/wfg_utils.py
+++ b/dingo/gw/waveform_generator/wfg_utils.py
@@ -106,7 +106,7 @@ def td_modes_to_fd_modes(hlm_td, domain):
 
     lal_fft_plan = lal.CreateForwardCOMPLEX16FFTPlan(chirplen, 0)
     for lm, h_td in hlm_td.items():
-        assert h_td.deltaT == delta_t
+        assert np.abs(h_td.deltaT - delta_t) < 1e-12
 
         # resize data to chirplen by zero-padding or truncating
         # if chirplen < h_td.data.length:
@@ -127,8 +127,8 @@ def td_modes_to_fd_modes(hlm_td, domain):
         )
         # apply FFT
         lal.COMPLEX16TimeFreqFFT(h_fd, h_td, lal_fft_plan)
-        assert h_fd.deltaF == delta_f
-        assert h_fd.f0 == -domain.f_max
+        assert np.abs(h_fd.deltaF - delta_f) < 1e-10
+        assert np.abs(h_fd.f0 + domain.f_max) < 1e-6
 
         # time shift
         dt = (

--- a/dingo/gw/waveform_generator/wfg_utils.py
+++ b/dingo/gw/waveform_generator/wfg_utils.py
@@ -15,8 +15,7 @@ def linked_list_modes_to_dict_modes(hlm_ll):
 
     return hlm_dict
 
-
-def get_tapering_window_for_complex_time_series(h, tapering_flag: int = 1):
+def get_tapering_window_for_complex_time_series(h, tapering_flag: int = 1, standard_tapering: int = 0, extra_time: float = 0.0, f_min: float = 0.0, original_fmin: float = 0.0, f_isco: float = 0.0):
     """
     Get window for tapering of a complex time series from the lal backend. This is done
     by  tapering the time series with lal, and dividing tapered output by untapered
@@ -39,18 +38,37 @@ def get_tapering_window_for_complex_time_series(h, tapering_flag: int = 1):
     window: np.ndarray
         Array of length h.data.length, with the window used for tapering.
     """
+    
     h_tapered = lal.CreateREAL8TimeSeries(
         "h_tapered", h.epoch, 0, h.deltaT, None, h.data.length
     )
     h_tapered.data.data = h.data.data.copy().real
-    LS.SimInspiralREAL8WaveTaper(h_tapered.data, tapering_flag)
+
+    if standard_tapering:
+        h_tapered_im = lal.CreateREAL8TimeSeries(
+            "h_tapered", h.epoch, 0, h.deltaT, None, h.data.length
+        )
+        h_tapered_im.data.data = h.data.data.copy().imag
+        # condition the time domain waveform by tapering in the extra time at the beginning and high-pass filtering above original f_min
+
+        LS.SimInspiralTDConditionStage1(
+            h_tapered, h_tapered_im, extra_time, original_fmin
+        )
+
+        # final tapering at the beginning and at the end to remove filter transients
+        # waveform should terminate at a frequency >= Schwarzschild ISCO
+        # so taper one cycle at this frequency at the end; should not make
+        # any difference to IMR waveforms */
+        LS.SimInspiralTDConditionStage2(h_tapered, h_tapered_im, f_min, f_isco)
+    else:
+        LS.SimInspiralREAL8WaveTaper(h_tapered.data, tapering_flag)
     eps = 1e-20 * np.max(np.abs(h.data.data))
     window = (np.abs(h_tapered.data.data) + eps) / (np.abs(h.data.data.real) + eps)
     # FIXME: using eps for numerical stability is not really robust here
     return window
 
 
-def taper_td_modes_in_place(hlm_td, tapering_flag: int = 1):
+def taper_td_modes_in_place(hlm_td, tapering_flag: int = 1, standard_tapering: int = 0, extra_time: float = 0.0, f_min: float = 0.0, original_fmin: float = 0.0, f_isco: float = 0.0):
     """
     Taper the time domain modes in place.
 


### PR DESCRIPTION
This PR incorporates a way to compute the tapering window using the standard conditioning procedure in LALSimulation: https://lscsoft.docs.ligo.org/lalsuite/lalsimulation/_l_a_l_sim_inspiral_generator_conditioning_8c.html#ac78b5fcdabf8922a3ac479da20185c85 

Essentially, this method adds some extra time to the beginning of the waveform employed for tapering.

It also includes some tolerances for some previous Assertions that are not always fulfilled due to the process of gwsignal of some quantities.