### PR TITLE
Trigger Offset Bug

### DIFF
--- a/dingo/gw/injection.py
+++ b/dingo/gw/injection.py
@@ -72,6 +72,7 @@ class GWSignal(object):
 
         self.t_ref = t_ref
         self.ifo_list = InterferometerList(ifo_list)
+        self.trigger_offset = None
 
         # When we set self.whiten, the projection transforms are automatically prepared.
         self._calibration_envelope = None
@@ -125,7 +126,7 @@ class GWSignal(object):
 
     def _initialize_transform(self):
         transforms = [
-            GetDetectorTimes(self.ifo_list, self.t_ref),
+            GetDetectorTimes(self.ifo_list, self.t_ref, self.trigger_offset),
             ProjectOntoDetectors(self.ifo_list, self.data_domain, self.t_ref),
         ]
         if self.calibration_marginalization_kwargs:
@@ -328,7 +329,7 @@ class Injection(GWSignal):
             t_ref=metadata["train_settings"]["data"]["ref_time"],
         )
 
-    def injection(self, theta):
+    def injection(self, theta, seed=None):
         """
         Generate an injection based on specified parameters.
 
@@ -364,6 +365,8 @@ class Injection(GWSignal):
             print("self.whiten was set to True. Resetting to False.")
             self.whiten = False
 
+        if seed is not None:
+            np.random.seed(seed)
         data = {}
         for ifo, s in signal["waveform"].items():
             noise = (

--- a/dingo/gw/likelihood.py
+++ b/dingo/gw/likelihood.py
@@ -31,6 +31,7 @@ class StationaryGaussianGWLikelihood(GWSignal, Likelihood):
         phase_marginalization_kwargs=None,
         calibration_marginalization_kwargs=None,
         phase_grid=None,
+        event_metadata=None,
     ):
         # TODO: Does the phase_grid argument ever get used?
         """
@@ -54,6 +55,9 @@ class StationaryGaussianGWLikelihood(GWSignal, Likelihood):
             Calibration marginalization parameters. If None, no calibration marginalization is used.
         phase_marginalization_kwargs: dict
             Phase marginalization parameters. If None, no phase marginalization is used.
+        event_metadata : dict
+            Metadata about the event. This is used to set the start times in the detectors
+            which may be different from the trigger time.
         """
         super().__init__(
             wfg_kwargs=wfg_kwargs,
@@ -62,6 +66,17 @@ class StationaryGaussianGWLikelihood(GWSignal, Likelihood):
             ifo_list=list(event_data["waveform"].keys()),
             t_ref=t_ref,
         )
+
+        # Updates interferometer start times depending on the start time of the detectors
+        # This is useful for simulating signals that are not
+        # co-located. Or if there are signals which don't start at the same time
+        # in each detector due to discretization of the signal.
+        # only does this if the start times are not all zero
+        if "trigger_offset" in event_metadata and not all(
+            np.abs(v) < 1e-12 for v in event_metadata["trigger_offset"].values()
+        ):
+            self.trigger_offset = event_metadata["trigger_offset"]
+            self._initialize_transform()
 
         self.asd = event_data["asds"]
 
@@ -262,6 +277,7 @@ class StationaryGaussianGWLikelihood(GWSignal, Likelihood):
                 for d_ifo, mu_ifo in zip(d.values(), mu.values())
             ],
         )
+
         return self.log_Zn + kappa2 - 1 / 2.0 * rho2opt
 
     def log_likelihood_phase_grid(self, theta, phases=None):
@@ -303,6 +319,7 @@ class StationaryGaussianGWLikelihood(GWSignal, Likelihood):
         #   (mu, mu) = sum(mu.conj() * mu).real,
         #
         # where the sum extends over frequency bins and detectors. Applying phase
+
         # transformations exp(-i * m * phi) to the individual modes will lead to
         # cross terms (the ^-symbol indicates the phase shift by phi)
         #
@@ -365,14 +382,14 @@ class StationaryGaussianGWLikelihood(GWSignal, Likelihood):
 
             log_likelihoods[idx] = self.log_Zn + kappa2 - 1 / 2.0 * rho2opt
 
-            # # comment out for cross check:
+            # comment out for cross check:
             # mu = sum_contributions_m(pol_m, phase_shift=phase)
             # rho2opt_ref = sum([inner_product(mu_ifo, mu_ifo) for mu_ifo in mu.values()])
             # kappa2_ref = sum(
-            #     [
-            #         inner_product(d_ifo, mu_ifo)
-            #         for d_ifo, mu_ifo in zip(d.values(), mu.values())
-            #     ]
+            # [
+            # inner_product(d_ifo, mu_ifo)
+            # for d_ifo, mu_ifo in zip(d.values(), mu.values())
+            # ]
             # )
             # assert rho2opt - rho2opt_ref < 1e-10
             # assert kappa2 - kappa2_ref < 1e-10

--- a/dingo/gw/result.py
+++ b/dingo/gw/result.py
@@ -327,6 +327,7 @@ class Result(CoreResult):
             phase_marginalization_kwargs=phase_marginalization_kwargs,
             calibration_marginalization_kwargs=calibration_marginalization_kwargs,
             phase_grid=phase_grid,
+            event_metadata=self.event_metadata
         )
 
     def sample_synthetic_phase(

--- a/dingo/gw/transforms/detector_transforms.py
+++ b/dingo/gw/transforms/detector_transforms.py
@@ -95,9 +95,14 @@ class GetDetectorTimes(object):
     position (ra, dec), the geocent_time and the ref_time.
     """
 
-    def __init__(self, ifo_list, ref_time):
+    def __init__(self, ifo_list, ref_time, trigger_offset=None):
         self.ifo_list = ifo_list
         self.ref_time = ref_time
+        
+        if trigger_offset is None:
+            self.trigger_offset = {ifo.name: 0.0 for ifo in self.ifo_list}
+        else:
+            self.trigger_offset = trigger_offset
 
     def __call__(self, input_sample):
         sample = input_sample.copy()
@@ -112,10 +117,13 @@ class GetDetectorTimes(object):
                 # computation does not work on gpu, so do it on cpu
                 ra = ra.cpu()
                 dec = dec.cpu()
+            # if one wants to be very precise this should be 
+            # dt = time_delay_from_geocenter(ifo, ra, dec, self.ref_time + geocent_time)
+            # but the error in the log likelihood is 1e-3 when not including this
             dt = time_delay_from_geocenter(ifo, ra, dec, self.ref_time)
             if type(dt) == torch.Tensor:
                 dt = dt.to(geocent_time.device)
-            ifo_time = geocent_time + dt
+            ifo_time = geocent_time + dt - self.trigger_offset[ifo.name]
             extrinsic_parameters[f"{ifo.name}_time"] = ifo_time
         sample["extrinsic_parameters"] = extrinsic_parameters
         return sample
@@ -170,8 +178,8 @@ class ProjectOntoDetectors(object):
         strains = {}
         for ifo in self.ifo_list:
             # (2) project strains onto the different detectors
-            fp = ifo.antenna_response(ra, dec, self.ref_time, psi, mode="plus")
-            fc = ifo.antenna_response(ra, dec, self.ref_time, psi, mode="cross")
+            fp = ifo.antenna_response(ra, dec, self.ref_time + tc_new, psi, mode="plus")
+            fc = ifo.antenna_response(ra, dec, self.ref_time + tc_new, psi, mode="cross")
             strain = fp * hp + fc * hc
 
             # (3) time shift the strain. If polarizations are timeshifted by

--- a/dingo/gw/waveform_generator/wfg_utils.py
+++ b/dingo/gw/waveform_generator/wfg_utils.py
@@ -106,7 +106,7 @@ def td_modes_to_fd_modes(hlm_td, domain):
 
     lal_fft_plan = lal.CreateForwardCOMPLEX16FFTPlan(chirplen, 0)
     for lm, h_td in hlm_td.items():
-        assert h_td.deltaT == delta_t
+        assert h_td.deltaT - delta_t < 1e-6
 
         # resize data to chirplen by zero-padding or truncating
         # if chirplen < h_td.data.length:
@@ -127,8 +127,8 @@ def td_modes_to_fd_modes(hlm_td, domain):
         )
         # apply FFT
         lal.COMPLEX16TimeFreqFFT(h_fd, h_td, lal_fft_plan)
-        assert h_fd.deltaF == delta_f
-        assert h_fd.f0 == -domain.f_max
+        assert h_fd.deltaF - delta_f < 1e-6
+        assert h_fd.f0 - -domain.f_max < 1e-6
 
         # time shift
         dt = (

--- a/dingo/pipe/data_generation.py
+++ b/dingo/pipe/data_generation.py
@@ -1,14 +1,30 @@
 import os
 import sys
+import ast
 
+import numpy as np
 from bilby_pipe.input import Input
 from bilby_pipe.main import parse_args
 from bilby_pipe.utils import logger, convert_string_to_dict
 from bilby_pipe.data_generation import DataGenerationInput as BilbyDataGenerationInput
+import numpy as np
+import lalsimulation as LS
+from bilby.gw.detector.psd import PowerSpectralDensity
 
 from dingo.gw.data.event_dataset import EventDataset
 from dingo.gw.domains import FrequencyDomain
 from dingo.pipe.parser import create_parser
+from dingo.gw.injection import Injection
+from dingo.core.models import PosteriorModel
+from dingo.gw.noise.asd_dataset import ASDDataset
+from dingo.gw.data.data_preparation import (
+    load_raw_data,
+    data_to_domain,
+    build_domain_from_model_metadata,
+    parse_settings_for_raw_data,
+)
+from dingo.gw.data.data_download import download_psd
+from dingo.gw.likelihood import inner_product
 
 logger.name = "dingo_pipe"
 
@@ -21,11 +37,10 @@ class DataGenerationInput(BilbyDataGenerationInput):
         self.meta_data = dict(
             command_line_args=args.__dict__,
             unknown_command_line_args=unknown_args,
-            injection_parameters=None,
+            injection_dict=args.injection_dict,
             # bilby_version=bilby.__version__,
             # bilby_pipe_version=get_version_information(),
         )
-        self.injection_parameters = None
 
         # Admin arguments
         self.ini = args.ini
@@ -33,7 +48,7 @@ class DataGenerationInput(BilbyDataGenerationInput):
         # Run index arguments
         self.idx = args.idx
         # self.generation_seed = args.generation_seed
-        self.trigger_time = args.trigger_time
+        self.trigger_time = float(args.trigger_time)
 
         # Naming arguments
         self.outdir = args.outdir
@@ -48,10 +63,19 @@ class DataGenerationInput(BilbyDataGenerationInput):
         # self.deltaT = args.deltaT
         # self.default_prior = args.default_prior
 
+        # Data duration arguments
+        self.duration = args.duration
+        self.post_trigger_duration = args.post_trigger_duration
+
+        self.zero_noise = args.zero_noise
+        if self.zero_noise:
+            self.num_noise_realizations = args.num_noise_realizations
+        else:
+            self.num_noise_realizations = 1
+
         # Whether to generate data for importance sampling. This must be done when
         # desired data settings differ from those used for network training. If this is
         # the case, save the new data to a different file name.
-
         self.importance_sampling = args.importance_sampling_generation
         self.importance_sampling_updates = args.importance_sampling_updates
         if self.importance_sampling:
@@ -65,8 +89,26 @@ class DataGenerationInput(BilbyDataGenerationInput):
         self.data_format = args.data_format
         self.allow_tape = args.allow_tape
         self.tukey_roll_off = args.tukey_roll_off
-        self.zero_noise = False  # dingo mod
         self.resampling_method = args.resampling_method
+
+        # Frequencies
+        self.sampling_frequency = args.sampling_frequency
+        self.minimum_frequency = args.minimum_frequency
+        self.maximum_frequency = args.maximum_frequency
+        # self.reference_frequency = args.reference_frequency
+
+        # If creating an injection no need for real data generation
+        if args.injection_dict is not None:
+            if args.asd_dataset is not None:
+                args.use_psd_of_trigger = False
+                logger.info("asd-dataset is set, not using psd of trigger")
+            self.injection_numbers = None
+            self.injection_dict = ast.literal_eval(args.injection_dict)
+            self.injection_dict = {
+                k.replace("-", "_"): v for k, v in self.injection_dict.items()
+            }
+            self.generate_injection(args)
+            return
 
         # if args.timeslide_dict is not None:
         #     self.timeslide_dict = convert_string_to_dict(args.timeslide_dict)
@@ -75,16 +117,6 @@ class DataGenerationInput(BilbyDataGenerationInput):
         #     self.gps_file = args.gps_file
         #     self.timeslide_file = args.timeslide_file
         #     self.timeslide_dict = self.get_timeslide_dict(self.idx)
-
-        # Data duration arguments
-        self.duration = args.duration
-        self.post_trigger_duration = args.post_trigger_duration
-
-        # Frequencies
-        self.sampling_frequency = args.sampling_frequency
-        self.minimum_frequency = args.minimum_frequency
-        self.maximum_frequency = args.maximum_frequency
-        # self.reference_frequency = args.reference_frequency
 
         # Waveform, source model and likelihood
         # self.waveform_generator_class = args.waveform_generator
@@ -97,7 +129,6 @@ class DataGenerationInput(BilbyDataGenerationInput):
         # self.mode_array = args.mode_array
         # self.waveform_arguments_dict = args.waveform_arguments_dict
         # self.numerical_relativity_file = args.numerical_relativity_file
-        # self.injection_waveform_approximant = args.injection_waveform_approximant
         # self.frequency_domain_source_model = args.frequency_domain_source_model
         # self.conversion_function = args.conversion_function
         # self.generation_function = args.generation_function
@@ -149,52 +180,174 @@ class DataGenerationInput(BilbyDataGenerationInput):
         # self.plot_injection = args.plot_injection
 
         if create_data:
-            # Added for dingo so that create_data runs. TODO: enable injections
+            # TODO what happens if we remove this??
             args.injection = False
             args.injection_numbers = None
             args.injection_file = None
             args.injection_dict = None
             args.gaussian_noise = False
             args.injection_waveform_arguments = None
-
             self.create_data(args)
 
-    def save_hdf5(self):
-        """Save frequency-domain strain and ASDs as DingoDataset HDF5 format."""
+    def generate_injection(self, args):
+        """Generate injection consistent with trained dingo model"""
+        # loading posterior model for which we want to generate injections
+        pm = PosteriorModel(model_filename=args.model, device="cpu")
+        injection_generator = Injection.from_posterior_model_metadata(pm.metadata)
+        injection_generator.t_ref = self.trigger_time
+        injection_generator._initialize_transform()
+        injection_generator.waveform_generator.f_ref = (
+            float(args.reference_frequency)
+            if args.reference_frequency is not None
+            else injection_generator.waveform_generator.f_ref
+        )
+        # NOTE FIXME this is a hack to get around the fact that the f_start is set to f_ref in the waveform generator
+        # for most approximants
+        injection_generator.waveform_generator.f_start = injection_generator.waveform_generator.f_ref
 
-        # PSD and strain data.
-        data = {"waveform": {}, "asds": {}}  # TODO: Rename these keys.
+        # selecting PSD
+        if args.use_psd_of_trigger:
+            domain = build_domain_from_model_metadata(pm.metadata)
+            settings_raw_data = parse_settings_for_raw_data(
+                pm.metadata, args.psd_length, args.psd_fractional_overlap
+            )
+            raw_data = load_raw_data(self.trigger_time, settings=settings_raw_data)
+
+            # Converting data to frequency series
+            event_data = data_to_domain(
+                raw_data,
+                settings_raw_data,
+                domain,
+                window=pm.metadata["train_settings"]["data"]["window"],
+            )
+            injection_generator.asd = event_data["asds"]
+        else:
+            asd_dataset = ASDDataset(args.asd_dataset)
+            randint = np.random.randint(
+                0, [v for v in asd_dataset.length_info.values()][0]
+            )
+            injection_generator.asd = {
+                k: v[randint]
+                for k, v in asd_dataset.asds.items()
+                if k in [ifo.name for ifo in injection_generator.ifo_list]
+            }
+
+        # allowing for changing waveform approximant injection
+        if args.injection_waveform_approximant is not None:
+            injection_generator.waveform_generator.approximant = (
+                LS.GetApproximantFromString(args.injection_waveform_approximant)
+            )
+            injection_generator.waveform_generator.approximant_str = (
+                args.injection_waveform_approximant
+            )
+            self.injection_waveform_approximant = args.injection_waveform_approximant
+        else:
+            self.injection_waveform_approximant = (
+                injection_generator.waveform_generator.approximant_str
+            )
+
+        self.detectors = [ifo.name for ifo in injection_generator.ifo_list]
+        self.sampling_frequency = (
+            injection_generator.waveform_generator.domain.sampling_rate
+        )
+        self.duration = injection_generator.data_domain.duration
+        self.minimum_frequency = injection_generator.data_domain.f_min
+        self.maximum_frequency = injection_generator.data_domain.f_max
+        self.window_type = pm.metadata["train_settings"]["data"]["window"]["type"]
+        self.tukey_roll_off = pm.metadata["train_settings"]["data"]["window"][
+            "roll_off"
+        ]
+        self.post_trigger_duration = args.post_trigger_duration
+
+        self.strain_data_list = []
+        # if importance sampling with zero-noise, don't add noise to injection
+        # the idea here is to reweight to the zero-noise likelihood
+        if self.zero_noise and self.importance_sampling:
+            self.strain_data_list.append(
+                injection_generator.signal(self.injection_dict)
+            )
+        else:
+            for i in range(self.num_noise_realizations):
+                # add i to the seed to get different noise realizations
+                # but keep consistent across zero noise seed
+                seed = (
+                    args.injection_random_seed + i
+                    if args.injection_random_seed is not None
+                    else None
+                )
+                self.strain_data_list.append(
+                    injection_generator.injection(
+                        self.injection_dict,
+                        seed=seed,
+                    )
+                )
+
+        # Compute optimal SNR
+        rho_opt_ifos, rho_opt = self.compute_optimal_snr(self.strain_data_list[0], injection_generator.data_domain)
+        logger.info(f"Network optimal SNR of injection: {rho_opt}")
+        logger.info(f"Detector optimal SNRs of injection: {rho_opt_ifos}")
+
+
+    def compute_optimal_snr(self, strain_data, data_domain):
+        """Compute network optimal signal-to-noise ratio for the first injected strain"""
+        mu = strain_data['waveform']
+        asds = strain_data['asds']
+        delta_f = data_domain.delta_f
+        noise_std = data_domain.noise_std
+
+        # In the inner products below explicitly divide by the window factor
+        window_factor = 4*delta_f * noise_std**2
+
+        # optimal network SNR
+        kappa2_list = [inner_product(mu_ifo, mu_ifo, delta_f=delta_f, psd=window_factor * asd_ifo**2)
+                     for mu_ifo, asd_ifo in zip(mu.values(), asds.values())]
+        rho_opt = np.sqrt(sum(kappa2_list))
+        rho_opt_ifos = np.sqrt(kappa2_list)
+
+        return rho_opt_ifos, rho_opt
+
+
+    def create_data(self, args):
+        super().create_data(args)
+
+        # check if there are nan's in the asd, if there are shift the detector segment used to generate the psd to an earlier time
         for ifo in self.interferometers:
-
-            strain = ifo.strain_data.frequency_domain_strain
             frequency_array = ifo.strain_data.frequency_array
             asd = ifo.power_spectral_density.get_amplitude_spectral_density_array(
                 frequency_array
             )
 
-            # These arrays extend up to self.sampling_frequency. Truncate them to
-            # self.maximum_frequency, and also set the asd to 1.0 below
-            # self.minimum_frequency.
-            domain = FrequencyDomain(
-                f_min=self.minimum_frequency,
-                f_max=self.maximum_frequency,
-                delta_f=1 / self.duration,
-            )
-            strain = domain.update_data(strain)
-            asd = domain.update_data(asd, low_value=1.0)
+            if np.max(np.isnan(asd)):
+                if args.shift_segment_for_psd_generation_if_nan:
+                    window = {
+                        "type": "tukey",
+                        "roll_off": self.tukey_roll_off,
+                        "T": self.duration,
+                        "f_s": self.sampling_frequency,
+                    }
+                    psd_array = download_psd(
+                        ifo.name,
+                        self.start_time + self.psd_start_time,
+                        self.psd_duration,
+                        window,
+                        self.sampling_frequency,
+                    )
+                    psd = PowerSpectralDensity(
+                        frequency_array=frequency_array, psd_array=psd_array
+                    )
+                    ifo.power_spectral_density = psd
+                else:
+                    logger.critical(
+                        f"""Nan encountered in strain data for PSD estimation for detector {ifo.name}. 
+                    Specify --shift-segment-for-psd-generation-if-nan to shift PSD segement to an earlier time without Nans. """
+                    )
+                    raise
 
-            # Dingo expects data to have trigger time 0, so we apply a cyclic time shift
-            # by the post-trigger duration.
-            strain = domain.time_translate_data(strain, self.post_trigger_duration)
+    def save_hdf5(self):
+        """Save frequency-domain strain and ASDs as DingoDataset HDF5 format."""
 
-            # Note that the ASD estimated by the Bilby Interferometer differs ever so
-            # slightly from the ASDs we computed before using pycbc. In addition,
-            # there is no handling of NaNs in the strain data from which the ASD is
-            # estimated.
-
-            data["waveform"][ifo.name] = strain
-            data["asds"][ifo.name] = asd
-
+        # if the data is created via an injection, we don't need to convert anything
+        # from the Bilby format
         # Data conditioning settings.
         settings = {
             "time_event": self.trigger_time,
@@ -206,38 +359,92 @@ class DataGenerationInput(BilbyDataGenerationInput):
             "f_max": self.maximum_frequency,
             "window_type": "tukey",
             "roll_off": self.tukey_roll_off,
+            "trigger_offset": {ifo.name: ifo.strain_data.start_time - (self.trigger_time - self.duration + self.post_trigger_duration) for ifo in self.interferometers}
         }
+        if hasattr(self, "strain_data_list"):
+            for strain_data, event_data_file in zip(
+                self.strain_data_list, self.event_data_files
+            ):
+                dataset = EventDataset(
+                    dictionary={
+                        "data": strain_data,
+                        "injection_waveform_approximant": self.injection_waveform_approximant,
+                        "injection_dict": self.injection_dict,
+                        "settings": settings,
+                    }
+                )
+                dataset.to_file(event_data_file)
 
-        for k in [
-            "psd_duration",
-            "psd_dict",
-            "psd_fractional_overlap",
-            "psd_start_time",
-            "psd_method",
-            "channel_dict",
-            "data_dict",
-        ]:
-            try:
-                v = getattr(self, k)
-            except AttributeError:
-                continue
-            if v is not None:
-                settings[k] = v
+        else:
+            # PSD and strain data.
+            data = {"waveform": {}, "asds": {}}  # TODO: Rename these keys.
+            for ifo in self.interferometers:
+                strain = ifo.strain_data.frequency_domain_strain
+                frequency_array = ifo.strain_data.frequency_array
+                asd = ifo.power_spectral_density.get_amplitude_spectral_density_array(
+                    frequency_array
+                )
 
-        dataset = EventDataset(
-            dictionary={
-                "data": data,
-                # "event_metadata": event_metadata,
-                "settings": settings,
-            }
-        )
-        dataset.to_file(self.event_data_file)
+                # These arrays extend up to self.sampling_frequency. Truncate them to
+                # self.maximum_frequency, and also set the asd to 1.0 below
+                # self.minimum_frequency.
+                domain = FrequencyDomain(
+                    f_min=self.minimum_frequency,
+                    f_max=self.maximum_frequency,
+                    delta_f=1 / self.duration,
+                )
+                strain = domain.update_data(strain)
+                asd = domain.update_data(asd, low_value=1.0)
+
+                # Dingo expects data to have trigger time 0, so we apply a cyclic time shift
+                # by the post-trigger duration.
+                strain = domain.time_translate_data(strain, self.post_trigger_duration)
+
+                # Note that the ASD estimated by the Bilby Interferometer differs ever so
+                # slightly from the ASDs we computed before using pycbc. In addition,
+                # there is no handling of NaNs in the strain data from which the ASD is
+                # estimated.
+
+                data["waveform"][ifo.name] = strain
+                data["asds"][ifo.name] = asd
+
+            for k in [
+                "psd_duration",
+                "psd_dict",
+                "psd_fractional_overlap",
+                "psd_start_time",
+                "psd_method",
+                "channel_dict",
+                "data_dict",
+            ]:
+                try:
+                    v = getattr(self, k)
+                except AttributeError:
+                    continue
+                if v is not None:
+                    settings[k] = v
+
+            dataset = EventDataset(
+                dictionary={
+                    "data": data,
+                    # "event_metadata": event_metadata,
+                    "settings": settings,
+                }
+            )
+
+            dataset.to_file(self.event_data_files[0])
 
     @property
-    def event_data_file(self):
-        return os.path.join(
-            self.data_directory, "_".join([self.label, "event_data.hdf5"])
-        )
+    def event_data_files(self):
+        if self.zero_noise:
+            return [
+                os.path.join(
+                    self.data_directory, "_".join([self.label, f"event_data_{i}.hdf5"])
+                )
+                for i in range(self.num_noise_realizations)
+            ]
+        else:
+            return [os.path.join(self.data_directory, "_".join([self.label, f"event_data.hdf5"]))]
 
     @property
     def importance_sampling_updates(self):


### PR DESCRIPTION
When downloading data with gwpy, one has to specify the start time of the detector. In dingo pipe, this is set to the trigger time. Usually, this is fine, but there are cases where one specifies a start time of say 1264316116.4 but because of the discretization of the signal, the actual start time is 1264316110.3999023. 

This is important as when one projects the waveforms onto the detector, one should be using the correct start time of the detector. Otherwise, this will create an incorrect log likelihood (or at least a log likelihood which is consistent with the trigger time but not the start time). 

This patch aims to fix this by specifying a trigger offset which changes the time translation of the signal according to the start time of the detector. 