### PR TITLE
adding new conditioning for td modes

### DIFF
--- a/dingo/gw/waveform_generator/waveform_generator.py
+++ b/dingo/gw/waveform_generator/waveform_generator.py
@@ -1173,16 +1173,19 @@ class NewInterfaceWaveformGenerator(WaveformGenerator):
 
     def generate_TD_modes_L0_conditioned_extra_time(self, parameters):
         """
-        Generate TD modes in the L0 frame applying a conditioning routine which mimicks the behaviour of the standard LALSimulation conditioning (https://lscsoft.docs.ligo.org/lalsuite/lalsimulation/_l_a_l_sim_inspiral_generator_conditioning_8c.html#ac78b5fcdabf8922a3ac479da20185c85)
+        Generate TD modes in the L0 frame applying a conditioning routine which mimics the behaviour of the standard
+        LALSimulation conditioning
+        (https://lscsoft.docs.ligo.org/lalsuite/lalsimulation/_l_a_l_sim_inspiral_generator_conditioning_8c.html#ac78b5fcdabf8922a3ac479da20185c85)
 
-        Essentially, a new starting frequency is computed to have some extra cycles that will be tapered.
-        Some extra buffer time is also added to ensure that the waveform at the requested starting frequency is not modified, while still having a tapered timeseries suited for clean FFT.
+        Essentially, a new starting frequency is computed to have some extra cycles that will be tapered. Some extra
+        buffer time is also added to ensure that the waveform at the requested starting frequency is not modified,
+        while still having a tapered timeseries suited for clean FFT.
 
         Parameters
         ----------
         parameters: dict
             Dictionary of parameters for the waveform.
-            For details see see self.generate_hplus_hcross.
+            For details see self.generate_hplus_hcross.
 
         Returns
         -------

--- a/dingo/gw/waveform_generator/waveform_generator.py
+++ b/dingo/gw/waveform_generator/waveform_generator.py
@@ -83,12 +83,11 @@ class WaveformGenerator:
         else:
             self.approximant_str = approximant
             self.lal_params = None
-            try:
+            if "SEOBNRv5" not in approximant:
+                # This LAL function does not work with waveforms using the new interface. TODO: Improve the check.
                 self.approximant = LS.GetApproximantFromString(approximant)
                 if mode_list is not None:
                     self.lal_params = self.setup_mode_array(mode_list)
-            except:
-                pass
 
         if not issubclass(type(domain), Domain):
             raise ValueError(

--- a/dingo/gw/waveform_generator/waveform_generator.py
+++ b/dingo/gw/waveform_generator/waveform_generator.py
@@ -791,8 +791,8 @@ class NewInterfaceWaveformGenerator(WaveformGenerator):
         p, _ = convert_to_lal_binary_black_hole_parameters(parameter_dict)
 
         # Convert to SI units
-        p["mass_1"] *= lal.MSUN_SI
-        p["mass_2"] *= lal.MSUN_SI
+        #p["mass_1"] *= lal.MSUN_SI
+        #p["mass_2"] *= lal.MSUN_SI
     
         # Transform to lal source frame: iota and Cartesian spin components
         param_keys_in = (
@@ -809,6 +809,8 @@ class NewInterfaceWaveformGenerator(WaveformGenerator):
             "phase",
         )
         param_values_in = [p[k] for k in param_keys_in]
+        param_values_in[7] *= lal.MSUN_SI
+        param_values_in[8] *= lal.MSUN_SI
         # if spin_conversion_phase is set, use this as fixed phiRef when computing the
         # cartesian spins instead of using the phase parameter
         if self.spin_conversion_phase is not None:
@@ -829,8 +831,8 @@ class NewInterfaceWaveformGenerator(WaveformGenerator):
         delta_t = 0.5 / self.domain.f_max
 
         params_gwsignal = {
-            "mass1": p["mass_1"] * u.kg,
-            "mass2": p["mass_2"] * u.kg,
+            "mass1": p["mass_1"] * u.solMass,
+            "mass2": p["mass_2"] * u.solMass,
             "spin1x": s1x * u.dimensionless_unscaled,
             "spin1y": s1y * u.dimensionless_unscaled,
             "spin1z": s1z * u.dimensionless_unscaled,

--- a/dingo/gw/waveform_generator/waveform_generator.py
+++ b/dingo/gw/waveform_generator/waveform_generator.py
@@ -790,10 +790,6 @@ class NewInterfaceWaveformGenerator(WaveformGenerator):
         # Transform mass, spin, and distance parameters
         p, _ = convert_to_lal_binary_black_hole_parameters(parameter_dict)
 
-        # Convert to SI units
-        # p["mass_1"] *= lal.MSUN_SI
-        # p["mass_2"] *= lal.MSUN_SI
-
         # Transform to lal source frame: iota and Cartesian spin components
         param_keys_in = (
             "theta_jn",
@@ -809,8 +805,13 @@ class NewInterfaceWaveformGenerator(WaveformGenerator):
             "phase",
         )
         param_values_in = [p[k] for k in param_keys_in]
+
+        # Masses for spin conversion must be in SI units. However, for waveform generation, they must remain in solar
+        # masses due to sensitive dependence of SEOBNRv5 waveforms to small changes in the mass. Hence, we only convert
+        # units here.
         param_values_in[7] *= lal.MSUN_SI
         param_values_in[8] *= lal.MSUN_SI
+
         # if spin_conversion_phase is set, use this as fixed phiRef when computing the
         # cartesian spins instead of using the phase parameter
         if self.spin_conversion_phase is not None:

--- a/dingo/gw/waveform_generator/wfg_utils.py
+++ b/dingo/gw/waveform_generator/wfg_utils.py
@@ -146,7 +146,6 @@ def get_polarizations_from_fd_modes_m(hlm_fd, iota, phase):
     polarizations = ["h_plus", "h_cross"]
 
     for (l, m), h in hlm_fd.items():
-
         if m not in pol_m:
             pol_m[m] = {k: 0.0 for k in polarizations}
             pol_m[-m] = {k: 0.0 for k in polarizations}
@@ -177,14 +176,35 @@ def get_polarizations_from_fd_modes_m(hlm_fd, iota, phase):
 
     return pol_m
 
-def get_starting_frequency_for_conditioning(parameters):
+
+def get_starting_frequency_for_SEOBRNRv5_conditioning(parameters):
+    """
+    Compute starting frequency needed for having 3 extra cycles for tapering the TD modes.
+    It returns the needed quantities to apply the standard LALSimulation conditioning routines to the TD modes.
+
+    Parameters
+    ----------
+    parameters: dict
+        Dictionary of parameters suited for GWSignal (obtained with NewInterfaceWaveformGenerator._convert_parameters)
+
+    Returns
+    ----------
+    f_min: float
+      Waveform starting frequency
+    f_start: float
+      New waveform starting frequency
+    extra_time: float
+      Extra time to take care of situations where the frequency is close to merger
+    original_f_min: float
+      Initial waveform starting frequency
+    f_isco: float
+      ISCO frequency
+    """
 
     extra_time_fraction = (
         0.1  # fraction of waveform duration to add as extra time for tapering
     )
-    extra_cycles = (
-        3.0  # more extra time measured in cycles at the starting frequency
-    )
+    extra_cycles = 3.0  # more extra time measured in cycles at the starting frequency
 
     f_min = parameters["f22_start"].value
     m1 = parameters["mass1"].value
@@ -193,63 +213,92 @@ def get_starting_frequency_for_conditioning(parameters):
     S2z = parameters["spin2z"].value
     original_f_min = f_min
 
-    fisco = 1.0 / (pow(9.0, 1.5) * np.pi * (m1 + m2) * lal.MTSUN_SI)
-    if f_min > fisco:
-        f_min = fisco
+    f_isco = 1.0 / (pow(9.0, 1.5) * np.pi * (m1 + m2) * lal.MTSUN_SI)
+    if f_min > f_isco:
+        f_min = f_isco
 
     # upper bound on the chirp time starting at f_min
     tchirp = LS.SimInspiralChirpTimeBound(
-        f_min, m1*lal.MSUN_SI, m2*lal.MSUN_SI, S1z, S2z
+        f_min, m1 * lal.MSUN_SI, m2 * lal.MSUN_SI, S1z, S2z
     )
     # upper bound on the final black hole spin */
     spinkerr = LS.SimInspiralFinalBlackHoleSpinBound(S1z, S2z)
     # upper bound on the final plunge, merger, and ringdown time */
     tmerge = LS.SimInspiralMergeTimeBound(
-        m1*lal.MSUN_SI , m2 *lal.MSUN_SI
-    ) + LS.SimInspiralRingdownTimeBound((m1 + m2)*lal.MSUN_SI , spinkerr)
+        m1 * lal.MSUN_SI, m2 * lal.MSUN_SI
+    ) + LS.SimInspiralRingdownTimeBound((m1 + m2) * lal.MSUN_SI, spinkerr)
 
     # extra time to include for all waveforms to take care of situations where the frequency is close to merger (and is sweeping rapidly): this is a few cycles at the low frequency
     textra = extra_cycles / f_min
     # compute a new lower frequency
-    fstart = LS.SimInspiralChirpStartFrequencyBound(
+    f_start = LS.SimInspiralChirpStartFrequencyBound(
         (1.0 + extra_time_fraction) * tchirp + tmerge + textra,
-        m1*lal.MSUN_SI ,
-        m2*lal.MSUN_SI ,
+        m1 * lal.MSUN_SI,
+        m2 * lal.MSUN_SI,
     )
 
-    fisco = 1.0 / (pow(6.0, 1.5) * np.pi * (m1 + m2) * lal.MTSUN_SI)
+    f_isco = 1.0 / (pow(6.0, 1.5) * np.pi * (m1 + m2) * lal.MTSUN_SI)
 
-    return f_min, fstart, extra_time_fraction * tchirp + textra, original_f_min, fisco
+    return f_min, f_start, extra_time_fraction * tchirp + textra, original_f_min, f_isco
 
-def taper_td_modes_extra_time(h, extra_time, f_min, original_fmin, f_isco):
+
+def taper_td_modes_for_SEOBRNRv5_extra_time(
+    h, extra_time, f_min, original_f_min, f_isco
+):
+    """
+    Apply standard tapering procedure mimicking LALSimulation routine (https://lscsoft.docs.ligo.org/lalsuite/lalsimulation/_l_a_l_sim_inspiral_generator_conditioning_8c.html#ac78b5fcdabf8922a3ac479da20185c85)
+
+    Parameters
+    ----------
+    h:
+        complex gwpy TimeSeries object
+    extra_time: float
+        Extra time to take care of situations where the frequency is close to merger
+    f_min: float
+        Starting frequency employed in waveform generation
+    original_f_min: float
+        Initial starting frequency requested by the user
+    f_isco:
+        ISCO frequency
+
+    Returns
+    ----------
+    h_return
+        complex lal timeseries object
+    """
 
     # Split in real and imaginary parts, since LAL conditioning routines are for real timeseries
-    h_tapered = lal.CreateREAL8TimeSeries(
+    h_tapered_re = lal.CreateREAL8TimeSeries(
         "h_tapered", h.epoch.value, 0, h.dt.value, None, len(h)
     )
-    h_tapered.data.data = h.value.copy().real
+    h_tapered_re.data.data = h.value.copy().real
 
     h_tapered_im = lal.CreateREAL8TimeSeries(
         "h_tapered_im", h.epoch.value, 0, h.dt.value, None, len(h)
     )
     h_tapered_im.data.data = h.value.copy().imag
-    
+
     # condition the time domain waveform by tapering in the extra time at the beginning and high-pass filtering above original f_min
     LS.SimInspiralTDConditionStage1(
-        h_tapered, h_tapered_im, extra_time, original_fmin
+        h_tapered_re, h_tapered_im, extra_time, original_f_min
     )
     # final tapering at the beginning and at the end to remove filter transients
     # waveform should terminate at a frequency >= Schwarzschild ISCO
     # so taper one cycle at this frequency at the end; should not make
     # any difference to IMR waveforms */
-    LS.SimInspiralTDConditionStage2(h_tapered, h_tapered_im, f_min, f_isco)
+    LS.SimInspiralTDConditionStage2(h_tapered_re, h_tapered_im, f_min, f_isco)
 
-    #Construct complex timeseries
+    # Construct complex timeseries
     h_return = lal.CreateCOMPLEX16TimeSeries(
-        "h_return", h_tapered.epoch, 0, h_tapered.deltaT, None, h_tapered.data.length
+        "h_return",
+        h_tapered_re.epoch,
+        0,
+        h_tapered_re.deltaT,
+        None,
+        h_tapered_re.data.length,
     )
 
-    h_return.data.data = h_tapered.data.data + 1j*h_tapered_im.data.data
+    h_return.data.data = h_tapered_re.data.data + 1j * h_tapered_im.data.data
 
     # return timeseries
     return h_return

--- a/dingo/gw/waveform_generator/wfg_utils.py
+++ b/dingo/gw/waveform_generator/wfg_utils.py
@@ -193,31 +193,31 @@ def get_starting_frequency_for_conditioning(parameters):
     S2z = parameters["spin2z"].value
     original_f_min = f_min
 
-    fisco = 1.0 / (pow(9.0, 1.5) * np.pi * (m1 + m2) * lal.MTSUN_SI/lal.MSUN_SI)
+    fisco = 1.0 / (pow(9.0, 1.5) * np.pi * (m1 + m2) * lal.MTSUN_SI)
     if f_min > fisco:
         f_min = fisco
 
     # upper bound on the chirp time starting at f_min
     tchirp = LS.SimInspiralChirpTimeBound(
-        f_min, m1, m2, S1z, S2z
+        f_min, m1*lal.MSUN_SI, m2*lal.MSUN_SI, S1z, S2z
     )
     # upper bound on the final black hole spin */
     spinkerr = LS.SimInspiralFinalBlackHoleSpinBound(S1z, S2z)
     # upper bound on the final plunge, merger, and ringdown time */
     tmerge = LS.SimInspiralMergeTimeBound(
-        m1 , m2 
-    ) + LS.SimInspiralRingdownTimeBound((m1 + m2) , spinkerr)
+        m1*lal.MSUN_SI , m2 *lal.MSUN_SI
+    ) + LS.SimInspiralRingdownTimeBound((m1 + m2)*lal.MSUN_SI , spinkerr)
 
     # extra time to include for all waveforms to take care of situations where the frequency is close to merger (and is sweeping rapidly): this is a few cycles at the low frequency
     textra = extra_cycles / f_min
     # compute a new lower frequency
     fstart = LS.SimInspiralChirpStartFrequencyBound(
         (1.0 + extra_time_fraction) * tchirp + tmerge + textra,
-        m1 ,
-        m2 ,
+        m1*lal.MSUN_SI ,
+        m2*lal.MSUN_SI ,
     )
 
-    fisco = 1.0 / (pow(6.0, 1.5) * np.pi * (m1 + m2) * lal.MTSUN_SI/lal.MSUN_SI)
+    fisco = 1.0 / (pow(6.0, 1.5) * np.pi * (m1 + m2) * lal.MTSUN_SI)
 
     return f_min, fstart, extra_time_fraction * tchirp + textra, original_f_min, fisco
 

--- a/dingo/gw/waveform_generator/wfg_utils.py
+++ b/dingo/gw/waveform_generator/wfg_utils.py
@@ -106,7 +106,7 @@ def td_modes_to_fd_modes(hlm_td, domain):
 
     lal_fft_plan = lal.CreateForwardCOMPLEX16FFTPlan(chirplen, 0)
     for lm, h_td in hlm_td.items():
-        assert h_td.deltaT == delta_t
+        assert np.abs(h_td.deltaT - delta_t) < 1e-12
 
         # resize data to chirplen by zero-padding or truncating
         # if chirplen < h_td.data.length:
@@ -127,8 +127,8 @@ def td_modes_to_fd_modes(hlm_td, domain):
         )
         # apply FFT
         lal.COMPLEX16TimeFreqFFT(h_fd, h_td, lal_fft_plan)
-        assert h_fd.deltaF == delta_f
-        assert h_fd.f0 == -domain.f_max
+        assert np.abs(h_fd.deltaF - delta_f) < 1e-10
+        assert np.abs(h_fd.f0 + domain.f_max) < 1e-6
 
         # time shift
         dt = (
@@ -176,3 +176,80 @@ def get_polarizations_from_fd_modes_m(hlm_fd, iota, phase):
         pol_m[-m]["h_cross"] += -0.5 * 1j * h2 * ylmstar
 
     return pol_m
+
+def get_starting_frequency_for_conditioning(parameters):
+
+    extra_time_fraction = (
+        0.1  # fraction of waveform duration to add as extra time for tapering
+    )
+    extra_cycles = (
+        3.0  # more extra time measured in cycles at the starting frequency
+    )
+
+    f_min = parameters["f22_start"].value
+    m1 = parameters["mass1"].value
+    m2 = parameters["mass2"].value
+    S1z = parameters["spin1z"].value
+    S2z = parameters["spin2z"].value
+    original_f_min = f_min
+
+    fisco = 1.0 / (pow(9.0, 1.5) * np.pi * (m1 + m2) * lal.MTSUN_SI/lal.MSUN_SI)
+    if f_min > fisco:
+        f_min = fisco
+
+    # upper bound on the chirp time starting at f_min
+    tchirp = LS.SimInspiralChirpTimeBound(
+        f_min, m1, m2, S1z, S2z
+    )
+    # upper bound on the final black hole spin */
+    spinkerr = LS.SimInspiralFinalBlackHoleSpinBound(S1z, S2z)
+    # upper bound on the final plunge, merger, and ringdown time */
+    tmerge = LS.SimInspiralMergeTimeBound(
+        m1 , m2 
+    ) + LS.SimInspiralRingdownTimeBound((m1 + m2) , spinkerr)
+
+    # extra time to include for all waveforms to take care of situations where the frequency is close to merger (and is sweeping rapidly): this is a few cycles at the low frequency
+    textra = extra_cycles / f_min
+    # compute a new lower frequency
+    fstart = LS.SimInspiralChirpStartFrequencyBound(
+        (1.0 + extra_time_fraction) * tchirp + tmerge + textra,
+        m1 ,
+        m2 ,
+    )
+
+    fisco = 1.0 / (pow(6.0, 1.5) * np.pi * (m1 + m2) * lal.MTSUN_SI/lal.MSUN_SI)
+
+    return f_min, fstart, extra_time_fraction * tchirp + textra, original_f_min, fisco
+
+def taper_td_modes_extra_time(h, extra_time, f_min, original_fmin, f_isco):
+
+    # Split in real and imaginary parts, since LAL conditioning routines are for real timeseries
+    h_tapered = lal.CreateREAL8TimeSeries(
+        "h_tapered", h.epoch.value, 0, h.dt.value, None, len(h)
+    )
+    h_tapered.data.data = h.value.copy().real
+
+    h_tapered_im = lal.CreateREAL8TimeSeries(
+        "h_tapered_im", h.epoch.value, 0, h.dt.value, None, len(h)
+    )
+    h_tapered_im.data.data = h.value.copy().imag
+    
+    # condition the time domain waveform by tapering in the extra time at the beginning and high-pass filtering above original f_min
+    LS.SimInspiralTDConditionStage1(
+        h_tapered, h_tapered_im, extra_time, original_fmin
+    )
+    # final tapering at the beginning and at the end to remove filter transients
+    # waveform should terminate at a frequency >= Schwarzschild ISCO
+    # so taper one cycle at this frequency at the end; should not make
+    # any difference to IMR waveforms */
+    LS.SimInspiralTDConditionStage2(h_tapered, h_tapered_im, f_min, f_isco)
+
+    #Construct complex timeseries
+    h_return = lal.CreateCOMPLEX16TimeSeries(
+        "h_return", h_tapered.epoch, 0, h_tapered.deltaT, None, h_tapered.data.length
+    )
+
+    h_return.data.data = h_tapered.data.data + 1j*h_tapered_im.data.data
+
+    # return timeseries
+    return h_return

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ dependencies = [
     "glasflow",
     "gwpy",
     "h5py",
-    "lalsuite>=7.11",
+    "lalsuite>=7.15",
     "numpy",
     "pandas",
     "pesummary",

--- a/tests/gw/waveform_generator/test_wfg_m.py
+++ b/tests/gw/waveform_generator/test_wfg_m.py
@@ -124,16 +124,16 @@ def tolerances(approximant):
         # was 7e-4, while almost all mismatches were of order 1e-5.
         return 5e-4, 5e-4
 
-    elif approximant == "SEOBNRv5PHM":
-        # Tested on 1000 mismatches, max mismatch was 3e-8.
-        return 1e-7, 1e-10
+    elif approximant in ["SEOBNRv5PHM", "SEOBNRv5HM"]:
+        # Tested on 1000 mismatches.
+        return 1e-9, 1e-12
 
     else:
-        return 1e-1, 1e-7
+        return 1e-5, 1e-5
 
 
 # Uncomment to test only one approximant.
-@pytest.mark.parametrize("approximant", ["IMRPhenomXPHM"])
+# @pytest.mark.parametrize("approximant", ["IMRPhenomXPHM"])
 def test_generate_hplus_hcross_m(intrinsic_prior, wfg, num_evaluations, tolerances):
     mismatches = []
     for idx in range(num_evaluations):

--- a/tests/gw/waveform_generator/test_wfg_m.py
+++ b/tests/gw/waveform_generator/test_wfg_m.py
@@ -13,8 +13,13 @@ wfg.spin_conversion_phase = 0.0.
 """
 import pytest
 import numpy as np
+from matplotlib import pyplot as plt
 
-from dingo.gw.waveform_generator import WaveformGenerator, sum_contributions_m
+from dingo.gw.waveform_generator import (
+    WaveformGenerator,
+    sum_contributions_m,
+    NewInterfaceWaveformGenerator,
+)
 from dingo.gw.gwutils import get_mismatch
 from dingo.gw.domains import build_domain
 from dingo.gw.prior import build_prior_with_defaults
@@ -130,3 +135,53 @@ def test_generate_hplus_hcross_m_IMRPhenomXPHM(uniform_fd_domain, intrinsic_prio
     mismatches = np.array(mismatches)
     assert np.max(mismatches) < 1e-1
     assert np.median(mismatches) < 1e-6
+
+def test_generate_hplus_hcross_m_SEOBNRv5PHM(uniform_fd_domain, intrinsic_prior):
+    domain = uniform_fd_domain
+    prior = intrinsic_prior
+    wfg = NewInterfaceWaveformGenerator(
+        approximant="SEOBNRv5PHM",
+        domain=domain,
+        f_ref=10.0,
+        f_start=10.0,
+        spin_conversion_phase=0.0,
+    )
+
+    p = prior.sample()
+    phase_shift = np.random.uniform(high=2 * np.pi)
+    pol_m = wfg.generate_hplus_hcross_m(p)
+    pol = sum_contributions_m(pol_m, phase_shift=phase_shift)
+    pol_ref = wfg.generate_hplus_hcross({**p, "phase": p["phase"] + phase_shift})
+
+    mismatches = [
+        get_mismatch(
+            pol[pol_name],
+            pol_ref[pol_name],
+            wfg.domain,
+            asd_file="aLIGO_ZERO_DET_high_P_asd.txt",
+        )
+        for pol_name in pol
+    ]
+
+    debug = False
+    if debug:
+        maxval = max(mismatches)
+        idx = mismatches.index(maxval)
+        p = list(pol.keys())[idx]
+        plt.figure(figsize=(10, 7))
+        plt.plot(domain.sample_frequencies, pol[p], label="reconstructed")
+        plt.plot(domain.sample_frequencies, pol_ref[p], label="ref")
+        plt.plot(domain.sample_frequencies, pol_ref[p] - pol[p], label="diff")
+        plt.legend()
+        plt.xscale("log")
+        plt.xlim((5, 128))
+        plt.title(f"{p}, mismatch={maxval}")
+        plt.show()
+
+    # The mismatches are typically be of order 1e-5. This is exclusively due to
+    # different tapering. The reference polarizations are tapered and FFTed on the
+    # level of polarizations, while for generate_hplus_hcross_m, the tapering and FFT
+    # happens on the level of complex modes.
+    # We tested the mismatches for 20k waveforms, and the largest mismatch encountered
+    # was 7e-4, while almost all mismatches were of order 1e-5.
+    assert max(mismatches) < 5e-4

--- a/tests/gw/waveform_generator/test_wfg_m.py
+++ b/tests/gw/waveform_generator/test_wfg_m.py
@@ -113,7 +113,7 @@ def tolerances(approximant):
         # to a different order the IMRPhenomXPHM. It's tricky to get this exactly right,
         # since there are many different methods for this. But the small mismatches we do
         # get should not have a big effect in practice.
-        return 1e-1, 1e-6
+        return 2e-2, 1e-6
 
     elif approximant == "SEOBNRv4PHM":
         # The mismatches are typically be of order 1e-5. This is exclusively due to
@@ -133,7 +133,7 @@ def tolerances(approximant):
 
 
 # Uncomment to test only one approximant.
-# @pytest.mark.parametrize("approximant", ["SEOBNRv5HM"])
+@pytest.mark.parametrize("approximant", ["IMRPhenomXPHM"])
 def test_generate_hplus_hcross_m(intrinsic_prior, wfg, num_evaluations, tolerances):
     mismatches = []
     for idx in range(num_evaluations):

--- a/tests/gw/waveform_generator/test_wfg_m.py
+++ b/tests/gw/waveform_generator/test_wfg_m.py
@@ -37,78 +37,107 @@ def uniform_fd_domain():
     return domain
 
 
+@pytest.fixture(params=["IMRPhenomXPHM", "SEOBNRv4PHM", "SEOBNRv5PHM", "SEOBNRv5HM"])
+def approximant(request):
+    return request.param
+
+
 @pytest.fixture
-def intrinsic_prior():
-    intrinsic_dict = {
-        "mass_1": "bilby.core.prior.Constraint(minimum=10.0, maximum=80.0)",
-        "mass_2": "bilby.core.prior.Constraint(minimum=10.0, maximum=80.0)",
-        "mass_ratio": "bilby.gw.prior.UniformInComponentsMassRatio(minimum=0.125, maximum=1.0)",
-        "chirp_mass": "bilby.gw.prior.UniformInComponentsChirpMass(minimum=25.0, maximum=100.0)",
-        "luminosity_distance": 1000.0,
-        "theta_jn": "bilby.core.prior.Sine(minimum=0.0, maximum=np.pi)",
-        "phase": 'bilby.core.prior.Uniform(minimum=0.0, maximum=2*np.pi, boundary="periodic")',
-        "a_1": "bilby.core.prior.Uniform(minimum=0.0, maximum=0.99)",
-        "a_2": "bilby.core.prior.Uniform(minimum=0.0, maximum=0.99)",
-        "tilt_1": "bilby.core.prior.Sine(minimum=0.0, maximum=np.pi)",
-        "tilt_2": "bilby.core.prior.Sine(minimum=0.0, maximum=np.pi)",
-        "phi_12": 'bilby.core.prior.Uniform(minimum=0.0, maximum=2*np.pi, boundary="periodic")',
-        "phi_jl": 'bilby.core.prior.Uniform(minimum=0.0, maximum=2*np.pi, boundary="periodic")',
-        "geocent_time": 0.0,
-    }
+def intrinsic_prior(approximant):
+    if "PHM" in approximant:
+        intrinsic_dict = {
+            "mass_1": "bilby.core.prior.Constraint(minimum=10.0, maximum=80.0)",
+            "mass_2": "bilby.core.prior.Constraint(minimum=10.0, maximum=80.0)",
+            "mass_ratio": "bilby.gw.prior.UniformInComponentsMassRatio(minimum=0.125, maximum=1.0)",
+            "chirp_mass": "bilby.gw.prior.UniformInComponentsChirpMass(minimum=25.0, maximum=100.0)",
+            "luminosity_distance": 1000.0,
+            "theta_jn": "bilby.core.prior.Sine(minimum=0.0, maximum=np.pi)",
+            "phase": 'bilby.core.prior.Uniform(minimum=0.0, maximum=2*np.pi, boundary="periodic")',
+            "a_1": "bilby.core.prior.Uniform(minimum=0.0, maximum=0.99)",
+            "a_2": "bilby.core.prior.Uniform(minimum=0.0, maximum=0.99)",
+            "tilt_1": "bilby.core.prior.Sine(minimum=0.0, maximum=np.pi)",
+            "tilt_2": "bilby.core.prior.Sine(minimum=0.0, maximum=np.pi)",
+            "phi_12": 'bilby.core.prior.Uniform(minimum=0.0, maximum=2*np.pi, boundary="periodic")',
+            "phi_jl": 'bilby.core.prior.Uniform(minimum=0.0, maximum=2*np.pi, boundary="periodic")',
+            "geocent_time": 0.0,
+        }
+    else:
+        # Aligned spins
+        intrinsic_dict = {
+            "mass_1": "bilby.core.prior.Constraint(minimum=10.0, maximum=80.0)",
+            "mass_2": "bilby.core.prior.Constraint(minimum=10.0, maximum=80.0)",
+            "mass_ratio": "bilby.gw.prior.UniformInComponentsMassRatio(minimum=0.125, maximum=1.0)",
+            "chirp_mass": "bilby.gw.prior.UniformInComponentsChirpMass(minimum=25.0, maximum=100.0)",
+            "luminosity_distance": 1000.0,
+            "theta_jn": "bilby.core.prior.Sine(minimum=0.0, maximum=np.pi)",
+            "phase": 'bilby.core.prior.Uniform(minimum=0.0, maximum=2*np.pi, boundary="periodic")',
+            "chi_1": 'bilby.gw.prior.AlignedSpin(name="chi_1", a_prior=Uniform(minimum=0, maximum=0.99))',
+            "chi_2": 'bilby.gw.prior.AlignedSpin(name="chi_2", a_prior=Uniform(minimum=0, maximum=0.99))',
+            "geocent_time": 0.0,
+        }
     prior = build_prior_with_defaults(intrinsic_dict)
     return prior
 
 
-def test_generate_hplus_hcross_m_SEOBNRv4PHM(uniform_fd_domain, intrinsic_prior):
-    domain = uniform_fd_domain
-    prior = intrinsic_prior
-    wfg = WaveformGenerator(
-        "SEOBNRv4PHM",
-        domain,
-        10.0,
+@pytest.fixture
+def wfg(uniform_fd_domain, approximant):
+    if approximant in ["SEOBNRv5PHM", "SEOBNRv5HM"]:
+        wfg_class = NewInterfaceWaveformGenerator
+    else:
+        wfg_class = WaveformGenerator
+    return wfg_class(
+        approximant=approximant,
+        domain=uniform_fd_domain,
+        f_ref=10.0,
         f_start=10.0,
         spin_conversion_phase=0.0,
     )
 
-    p = prior.sample()
-    phase_shift = np.random.uniform(high=2 * np.pi)
-    pol_m = wfg.generate_hplus_hcross_m(p)
-    pol = sum_contributions_m(pol_m, phase_shift=phase_shift)
-    pol_ref = wfg.generate_hplus_hcross({**p, "phase": p["phase"] + phase_shift})
 
-    mismatches = [
-        get_mismatch(
-            pol[pol_name],
-            pol_ref[pol_name],
-            wfg.domain,
-            asd_file="aLIGO_ZERO_DET_high_P_asd.txt",
-        )
-        for pol_name in pol
-    ]
-
-    # The mismatches are typically be of order 1e-5. This is exclusively due to
-    # different tapering. The reference polarizations are tapered and FFTed on the
-    # level of polarizations, while for generate_hplus_hcross_m, the tapering and FFT
-    # happens on the level of complex modes.
-    # We tested the mismatches for 20k waveforms, and the largest mismatch encountered
-    # was 7e-4, while almost all mismatches were of order 1e-5.
-    assert max(mismatches) < 5e-4
+@pytest.fixture
+def num_evaluations(approximant):
+    if "Phenom" in approximant:
+        return 10
+    elif approximant == "SEOBNRv4PHM":
+        return 1
+    else:
+        return 10
 
 
-def test_generate_hplus_hcross_m_IMRPhenomXPHM(uniform_fd_domain, intrinsic_prior):
-    domain = uniform_fd_domain
-    prior = intrinsic_prior
-    wfg = WaveformGenerator(
-        "IMRPhenomXPHM",
-        domain,
-        20.0,
-        f_start=10.0,
-        spin_conversion_phase=0.0,
-    )
+@pytest.fixture
+def tolerances(approximant):
+    # Return (max, median) mismatches expected.
+    if approximant == "IMRPhenomXPHM":
+        # The mismatches are typically be of order 1e-5 to 1e-9. This comes from the
+        # calculation of the magnitude of the orbital angular momentum, which we calculate
+        # to a different order the IMRPhenomXPHM. It's tricky to get this exactly right,
+        # since there are many different methods for this. But the small mismatches we do
+        # get should not have a big effect in practice.
+        return 1e-1, 1e-6
 
+    elif approximant == "SEOBNRv4PHM":
+        # The mismatches are typically be of order 1e-5. This is exclusively due to
+        # different tapering. The reference polarizations are tapered and FFTed on the
+        # level of polarizations, while for generate_hplus_hcross_m, the tapering and FFT
+        # happens on the level of complex modes.
+        # We tested the mismatches for 20k waveforms, and the largest mismatch encountered
+        # was 7e-4, while almost all mismatches were of order 1e-5.
+        return 5e-4, 5e-4
+
+    elif approximant == "SEOBNRv5PHM":
+        # Tested on 1000 mismatches, max mismatch was 3e-8.
+        return 1e-7, 1e-10
+
+    else:
+        return 1e-1, 1e-7
+
+
+# Uncomment to test only one approximant.
+# @pytest.mark.parametrize("approximant", ["SEOBNRv5HM"])
+def test_generate_hplus_hcross_m(intrinsic_prior, wfg, num_evaluations, tolerances):
     mismatches = []
-    for idx in range(10):
-        p = prior.sample()
+    for idx in range(num_evaluations):
+        p = intrinsic_prior.sample()
         phase_shift = np.random.uniform(high=2 * np.pi)
 
         pol_m = wfg.generate_hplus_hcross_m(p)
@@ -127,61 +156,22 @@ def test_generate_hplus_hcross_m_IMRPhenomXPHM(uniform_fd_domain, intrinsic_prio
             ]
         )
 
-    # The mismatches are typically be of order 1e-5 to 1e-9. This comes from the
-    # calculation of the magnitude of the orbital angular momentum, which we calculate
-    # to a different order the IMRPhenomXPHM. It's tricky to get this exactly right,
-    # since there are many different methods for this. But the small mismatches we do
-    # get should not have a big effect in practice.
+        debug = False
+        if debug:
+            maxval = max(mismatches[-1])
+            idx = mismatches[-1].index(maxval)
+            p = list(pol.keys())[idx]
+            plt.figure(figsize=(10, 7))
+            plt.plot(wfg.domain.sample_frequencies, pol[p], label="reconstructed")
+            plt.plot(wfg.domain.sample_frequencies, pol_ref[p], label="ref")
+            plt.plot(wfg.domain.sample_frequencies, pol_ref[p] - pol[p], label="diff")
+            plt.legend()
+            plt.xscale("log")
+            plt.xlim((5, 128))
+            plt.title(f"{p}, mismatch={maxval}")
+            plt.show()
+
     mismatches = np.array(mismatches)
-    assert np.max(mismatches) < 1e-1
-    assert np.median(mismatches) < 1e-6
 
-def test_generate_hplus_hcross_m_SEOBNRv5PHM(uniform_fd_domain, intrinsic_prior):
-    domain = uniform_fd_domain
-    prior = intrinsic_prior
-    wfg = NewInterfaceWaveformGenerator(
-        approximant="SEOBNRv5PHM",
-        domain=domain,
-        f_ref=10.0,
-        f_start=10.0,
-        spin_conversion_phase=0.0,
-    )
-
-    p = prior.sample()
-    phase_shift = np.random.uniform(high=2 * np.pi)
-    pol_m = wfg.generate_hplus_hcross_m(p)
-    pol = sum_contributions_m(pol_m, phase_shift=phase_shift)
-    pol_ref = wfg.generate_hplus_hcross({**p, "phase": p["phase"] + phase_shift})
-
-    mismatches = [
-        get_mismatch(
-            pol[pol_name],
-            pol_ref[pol_name],
-            wfg.domain,
-            asd_file="aLIGO_ZERO_DET_high_P_asd.txt",
-        )
-        for pol_name in pol
-    ]
-
-    debug = False
-    if debug:
-        maxval = max(mismatches)
-        idx = mismatches.index(maxval)
-        p = list(pol.keys())[idx]
-        plt.figure(figsize=(10, 7))
-        plt.plot(domain.sample_frequencies, pol[p], label="reconstructed")
-        plt.plot(domain.sample_frequencies, pol_ref[p], label="ref")
-        plt.plot(domain.sample_frequencies, pol_ref[p] - pol[p], label="diff")
-        plt.legend()
-        plt.xscale("log")
-        plt.xlim((5, 128))
-        plt.title(f"{p}, mismatch={maxval}")
-        plt.show()
-
-    # The mismatches are typically be of order 1e-5. This is exclusively due to
-    # different tapering. The reference polarizations are tapered and FFTed on the
-    # level of polarizations, while for generate_hplus_hcross_m, the tapering and FFT
-    # happens on the level of complex modes.
-    # We tested the mismatches for 20k waveforms, and the largest mismatch encountered
-    # was 7e-4, while almost all mismatches were of order 1e-5.
-    assert max(mismatches) < 5e-4
+    assert np.max(mismatches) < tolerances[0]
+    assert np.median(mismatches) < tolerances[1]


### PR DESCRIPTION
This PR adds a conditioning method for TD modes mimicking the standard behaviour of conditioning routines in LAL and GWSignal, i.e, starting the modes at a lower frequency for tapering not-in-band cycles and adding some extra buffer times.