### PR TITLE
Set `spin_conversion_phase = 0.0` for NPE and GNPE examples

### DIFF
--- a/examples/gnpe_model/waveform_dataset_settings.yaml
+++ b/examples/gnpe_model/waveform_dataset_settings.yaml
@@ -8,6 +8,7 @@ waveform_generator:
   approximant: IMRPhenomXPHM  # SEOBNRv4PHM
   f_ref: 20.0
   # f_start: 15.0  # Optional setting useful for EOB waveforms. Overrides f_min when generating waveforms.
+  spin_conversion_phase: 0.0
 
 # Dataset only samples over intrinsic parameters. Extrinsic parameters are chosen at train time.
 intrinsic_prior:

--- a/examples/npe_model/waveform_dataset_settings.yaml
+++ b/examples/npe_model/waveform_dataset_settings.yaml
@@ -8,6 +8,7 @@ waveform_generator:
   approximant: IMRPhenomXPHM  # SEOBNRv4PHM
   f_ref: 20.0
   # f_start: 15.0  # Optional setting useful for EOB waveforms. Overrides f_min when generating waveforms.
+  spin_conversion_phase: 0.0
 
 # Dataset only samples over intrinsic parameters. Extrinsic parameters are chosen at train time.
 intrinsic_prior:


### PR DESCRIPTION
These examples fail when sampling the synthetic phase since they defaulted to `spin_conversion_phase = None`.