### PR TITLE
Update to bilby pipe 1.2.1

### DIFF
--- a/dingo/pipe/data_generation.py
+++ b/dingo/pipe/data_generation.py
@@ -68,13 +68,13 @@ class DataGenerationInput(BilbyDataGenerationInput):
         self.zero_noise = False  # dingo mod
         self.resampling_method = args.resampling_method
 
-        # if args.timeslide_dict is not None:
-        #     self.timeslide_dict = convert_string_to_dict(args.timeslide_dict)
-        #     logger.info(f"Read-in timeslide dict directly: {self.timeslide_dict}")
-        # elif args.timeslide_file is not None:
-        #     self.gps_file = args.gps_file
-        #     self.timeslide_file = args.timeslide_file
-        #     self.timeslide_dict = self.get_timeslide_dict(self.idx)
+        if args.timeslide_dict is not None:
+            self.timeslide_dict = convert_string_to_dict(args.timeslide_dict)
+            logger.info(f"Read-in timeslide dict directly: {self.timeslide_dict}")
+        elif args.timeslide_file is not None:
+            self.gps_file = args.gps_file
+            self.timeslide_file = args.timeslide_file
+            self.timeslide_dict = self.get_timeslide_dict(self.idx)
 
         # Data duration arguments
         self.duration = args.duration

--- a/dingo/pipe/main.py
+++ b/dingo/pipe/main.py
@@ -142,6 +142,8 @@ class MainInput(BilbyMainInput):
         self.scheduler_env = args.scheduler_env
         self.scheduler_analysis_time = args.scheduler_analysis_time
         self.disable_hdf5_locking = args.disable_hdf5_locking
+        self.environment_variables = args.environment_variables
+        self.getenv = args.getenv
 
         # self.waveform_approximant = args.waveform_approximant
         #

--- a/dingo/pipe/main.py
+++ b/dingo/pipe/main.py
@@ -115,8 +115,13 @@ class MainInput(BilbyMainInput):
         self.coherence_test = (
             False  # dingo mod: Cannot use different sets of detectors.
         )
+        self.data_dict = args.data_dict
+        self.frame_type_dict = args.frame_type_dict
+        self.data_find_url = args.data_find_url
+        self.data_find_urltype = args.data_find_urltype
         self.n_parallel = args.n_parallel
-        # self.transfer_files = args.transfer_files
+        self.transfer_files = args.transfer_files
+        self.additional_transfer_paths = args.additional_transfer_paths
         self.osg = args.osg
         self.desired_sites = args.desired_sites
         # self.analysis_executable = args.analysis_executable
@@ -218,8 +223,13 @@ class MainInput(BilbyMainInput):
         # self.single_postprocessing_arguments = args.single_postprocessing_arguments
         #
         self.summarypages_arguments = args.summarypages_arguments
-        #
+
         self.psd_dict = args.psd_dict
+        self.psd_maximum_duration = args.psd_maximum_duration
+        self.psd_length = args.psd_length
+        self.psd_fractional_overlap = args.psd_fractional_overlap
+        self.psd_start_time = args.psd_start_time
+        self.spline_calibration_envelope_dict = args.spline_calibration_envelope_dict
 
         # self.check_source_model(args)
 

--- a/dingo/pipe/main.py
+++ b/dingo/pipe/main.py
@@ -166,8 +166,8 @@ class MainInput(BilbyMainInput):
         # self.ignore_gwpy_data_quality_check = args.ignore_gwpy_data_quality_check
         self.trigger_time = args.trigger_time
         # self.deltaT = args.deltaT
-        # self.gps_tuple = args.gps_tuple
-        # self.gps_file = args.gps_file
+        self.gps_tuple = args.gps_tuple
+        self.gps_file = args.gps_file
         self.timeslide_file = args.timeslide_file
         # self.gaussian_noise = args.gaussian_noise
         # self.zero_noise = args.zero_noise

--- a/dingo/pipe/main.py
+++ b/dingo/pipe/main.py
@@ -151,7 +151,7 @@ class MainInput(BilbyMainInput):
         # self.likelihood_type = args.likelihood_type
         self.duration = args.duration
         # self.phase_marginalization = args.phase_marginalization
-        # self.prior_file = args.prior_file
+        self.prior_file = None  # Dingo update. To change prior use the priod_dict.
         self.prior_dict = args.prior_dict
         self.default_prior = "PriorDict"
         self.minimum_frequency = args.minimum_frequency

--- a/dingo/pipe/parser.py
+++ b/dingo/pipe/parser.py
@@ -671,6 +671,23 @@ def create_parser(top_level=True):
         ),
     )
     submission_parser.add(
+        "--environment-variables",
+        default=None,
+        type=nonestr,
+        help=(
+            "Key value pairs for environment variables formatted as a json string, "
+            "e.g., '{'OMP_NUM_THREADS': 1, 'LAL_DATA_PATH'='/home/data'}'. These values "
+            f"take precedence over --getenv. The default values are {ENVIRONMENT_DEFAULTS}."
+        ),
+    )
+    submission_parser.add(
+        "--getenv",
+        default=None,
+        action="append",
+        type=nonestr,
+        help="List of environment variables to copy from the current session.",
+    )
+    submission_parser.add(
         "--additional-transfer-paths",
         action="append",
         default=None,

--- a/dingo/pipe/parser.py
+++ b/dingo/pipe/parser.py
@@ -704,11 +704,12 @@ def create_parser(top_level=True):
     submission_parser.add(
         "--disable-hdf5-locking",
         action=StoreBoolean,
-        default=True,
+        default=False,
         help=(
             "If true (default), disable HDF5 locking. This can improve "
             "stability on some clusters, but may cause issues if multiple "
             "processes are reading/writing to the same file."
+            "This argument is deprecated and should be passed through --environment-variables"
         ),
     )
     submission_parser.add(

--- a/dingo/pipe/parser.py
+++ b/dingo/pipe/parser.py
@@ -170,27 +170,27 @@ def create_parser(top_level=True):
             "noise) is obtained from time when the IFOs are in science mode."
         ),
     )
-    #
-    # data_gen_pars.add(
-    #     "--gps-tuple",
-    #     type=nonestr,
-    #     help=(
-    #         "Tuple of the (start, step, number) of GPS start times. For"
-    #         " example, (10, 1, 3) produces the gps start times [10, 11, 12]."
-    #         " If given, gps-file is ignored."
-    #     ),
-    #     default=None,
-    # )
-    # data_gen_pars.add(
-    #     "--gps-file",
-    #     type=nonestr,
-    #     help=(
-    #         "File containing segment GPS start times. This can be a multi-"
-    #         "column file if (a) it is comma-separated and (b) the zeroth "
-    #         "column contains the gps-times to use"
-    #     ),
-    #     default=None,
-    # )
+
+    data_gen_pars.add(
+        "--gps-tuple",
+        type=nonestr,
+        help=(
+            "Tuple of the (start, step, number) of GPS start times. For"
+            " example, (10, 1, 3) produces the gps start times [10, 11, 12]."
+            " If given, gps-file is ignored."
+        ),
+        default=None,
+    )
+    data_gen_pars.add(
+        "--gps-file",
+        type=nonestr,
+        help=(
+            "File containing segment GPS start times. This can be a multi-"
+            "column file if (a) it is comma-separated and (b) the zeroth "
+            "column contains the gps-times to use"
+        ),
+        default=None,
+    )
     data_gen_pars.add(
         "--timeslide-file",
         type=nonestr,
@@ -202,15 +202,15 @@ def create_parser(top_level=True):
         ),
         default=None,
     )
-    # data_gen_pars.add(
-    #     "--timeslide-dict",
-    #     type=nonestr,
-    #     help=(
-    #         "Dictionary containing detector timeslides: applies a fixed offset"
-    #         " per detector. E.g. to apply +1s in H1, {H1: 1}"
-    #     ),
-    #     default=None,
-    # )
+    data_gen_pars.add(
+        "--timeslide-dict",
+        type=nonestr,
+        help=(
+            "Dictionary containing detector timeslides: applies a fixed offset"
+            " per detector. E.g. to apply +1s in H1, {H1: 1}"
+        ),
+        default=None,
+    )
     data_gen_pars.add(
         "--trigger-time",
         default=None,

--- a/dingo/pipe/parser.py
+++ b/dingo/pipe/parser.py
@@ -266,6 +266,26 @@ def create_parser(top_level=True):
             "dictionary should follow basic python dict syntax."
         ),
     )
+    data_gen_pars.add(
+        "--frame-type-dict",
+        type=nonestr,
+        default=None,
+        help=(
+            "Frame type to use when finding data. If not given, defaults will "
+            "be used based on the gps time using bilby_pipe.utils.default_frame_type,"
+            " e.g., {H1: H1_HOFT_C00_AR}."
+        ),
+    )
+    data_gen_pars.add(
+        "--data-find-url",
+        default="https://datafind.ligo.org",
+        help="URL to use for datafind, default is https://datafind.ligo.org to query CVMFS",
+    )
+    data_gen_pars.add(
+        "--data-find-urltype",
+        default="osdf",
+        help="URL type to use for datafind, default is osdf",
+    )
     # data_type_pars = data_gen_pars.add_mutually_exclusive_group()
     # data_type_pars.add(
     #     "--gaussian-noise",
@@ -648,6 +668,19 @@ def create_parser(top_level=True):
             " Note: the log files are automatically synced, but to sync the "
             " results during the run (e.g. to inspect progress), use the "
             " executable bilby_pipe_htcondor_sync"
+        ),
+    )
+    submission_parser.add(
+        "--additional-transfer-paths",
+        action="append",
+        default=None,
+        type=nonestr,
+        help=(
+            "Additional files that should be transferred to the analysis jobs. "
+            "The default is not transferring any additional files. Additional "
+            "files can be specified as a list in the configuration file [a, b] "
+            "or on the command line as --additional-transfer-paths a "
+            "--additonal-transfer-paths b"
         ),
     )
     submission_parser.add(

--- a/dingo/pipe/parser.py
+++ b/dingo/pipe/parser.py
@@ -7,6 +7,7 @@ import argparse
 import configargparse
 from bilby_pipe.bilbyargparser import BilbyArgParser
 from bilby_pipe.utils import (
+    ENVIRONMENT_DEFAULTS,
     get_version_information,
     logger,
     nonefloat,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ classifiers = [
 dependencies = [
     "astropy",
     "bilby",
-    "bilby_pipe",
+    "bilby_pipe>=1.2.1",
     "configargparse",
     "corner",
     "cryptography",


### PR DESCRIPTION
This brings `dingo_pipe` up to date with `bilby_pipe==1.2.1`. The main change is that the data generation step now transfers files over from elsewhere.

Closes #221 

## Possible issues

1. When running, I get the following warning, although it still seems work:
```
10:01 dingo_pipe INFO    : Running: gwdatafind.find_urls(site='H', frametype='H1_HOFT_C02', gpsstart=1126259456.4, gpsend=1126259464.4, urltype='osdf', host='https://datafind.ligo.org', )
10:01 dingo_pipe WARNING : Failed to resolve frame files for detector H1
10:01 dingo_pipe INFO    : Running: gwdatafind.find_urls(site='L', frametype='L1_HOFT_C02', gpsstart=1126259456.4, gpsend=1126259464.4, urltype='osdf', host='https://datafind.ligo.org', )
10:01 dingo_pipe WARNING : Failed to resolve frame files for detector L1
```

2. Now now the environment variable `OMP_NUM_THREADS==1` by default. We were carefully managing our threads in Dingo, so we should be sure that this does not result in any slowdowns during multithreading. *Can @max-dax @jonaswildberger remember where this might be an issue?*

## Actions

@hectorestelles Please test to make sure this works for you with **both** the new and old versions of `bilby_pipe`. If it does not work with old `bilby_pipe`, then we should pin the version.
