### PR TITLE
Choose correct `wfg_domain` during importance sampling

### DIFF
--- a/dingo/gw/result.py
+++ b/dingo/gw/result.py
@@ -309,19 +309,25 @@ class Result(CoreResult):
         self.calibration_marginalization_kwargs = calibration_marginalization_kwargs
 
         # Choose the WaveformGenerator domain. This is ultimately projected to the data domain, but generally we
-        # allow it to be different, e.g., to start integrating from lower frequencies than
-        # the lower bound of the likelihood integral. Usually we use the same domain as that
-        # used for the WaveformDataset. However, if we make a change to certain settings during
-        # importance sampling, we need to ensure the projection is still compatible. In particular,
-        # delta_f (=1/T) cannot be changed in a domain projection, so update that at the level
-        # of the WaveformGenerator.
+        # allow it to be different, e.g., to start integrating from lower frequencies than the lower bound of the
+        # likelihood integral. Usually we use the same domain as that used for the WaveformDataset. However,
+        # if we make a change to certain settings during importance sampling, we need to ensure the projection is
+        # still compatible:
+        #
+        # * delta_f (=1/T): cannot be changed in a domain projection, so update at the level of the
+        #   WaveformGenerator.
+        #
+        # TODO: Add functionality to update other waveform settings, i.e., approximant, generation minimum and
+        #  maximumum frequencies, reference frequency, and starting frequency.
 
         wfg_domain_dict = self.base_metadata["dataset_settings"]["domain"].copy()
         if "updates" in self.importance_sampling_metadata:
             if "T" in self.importance_sampling_metadata["updates"]:
-                wfg_domain_dict["delta_f"] = (
-                    1 / self.importance_sampling_metadata["updates"]["T"]
+                delta_f_new = 1 / self.importance_sampling_metadata["updates"]["T"]
+                print(
+                    f'Updating waveform generation delta_f from {wfg_domain_dict["delta_f"]} to {delta_f_new}.'
                 )
+                wfg_domain_dict["delta_f"] = delta_f_new
         wfg_domain = build_domain(wfg_domain_dict)
 
         self.likelihood = StationaryGaussianGWLikelihood(

--- a/dingo/gw/result.py
+++ b/dingo/gw/result.py
@@ -318,7 +318,7 @@ class Result(CoreResult):
         #   WaveformGenerator.
         #
         # TODO: Add functionality to update other waveform settings, i.e., approximant, generation minimum and
-        #  maximumum frequencies, reference frequency, and starting frequency.
+        #  maximum frequencies, reference frequency, and starting frequency.
 
         wfg_domain_dict = self.base_metadata["dataset_settings"]["domain"].copy()
         if "updates" in self.importance_sampling_metadata:

--- a/dingo/pipe/main.py
+++ b/dingo/pipe/main.py
@@ -41,16 +41,13 @@ def fill_in_arguments_from_model(args):
         "tukey_roll_off": data_settings["window"]["roll_off"],
         "waveform_approximant": model_metadata["dataset_settings"][
             "waveform_generator"
-        ][
-            "approximant"
-        ],  # TODO: Update approximant in IS
+        ]["approximant"],
     }
 
     changed_args = {}
     for k, v in model_args.items():
         args_v = getattr(args, k)
         if args_v is not None:
-
             # Convert type from str to enable comparison.
             try:
                 if isinstance(v, float):
@@ -61,6 +58,10 @@ def fill_in_arguments_from_model(args):
                 pass
 
             if args_v != v:
+                if k in ["waveform_approximant"]:
+                    raise NotImplementedError(
+                        "Cannot change waveform approximant during importance sampling."
+                    )  # TODO: Implement this. Also no error if passed explicitly as an update.
                 logger.warning(
                     f"Argument {k} provided to dingo_pipe as {args_v} "
                     f"does not match value {v} in model file. Using model value for "
@@ -88,7 +89,6 @@ def fill_in_arguments_from_model(args):
 
 class MainInput(BilbyMainInput):
     def __init__(self, args, unknown_args, importance_sampling_updates):
-
         # Settings added for dingo.
 
         self.model = args.model


### PR DESCRIPTION
When we update data conditioning settings during importance sampling, we need to carefully update the domain objects.

There are **two** relevant domain objects in Dingo:
* The **waveform generator** domain is used first, when generating waveforms.
* The **data** domain is used when evaluating the likelihood. Waveforms generated in the `wfg_domain` must be suitably truncated, e.g., if `f_max` is reduced.
For most updates to data conditioning, we update the data domain. However, to maintain compatibility between the domains, we sometimes need to update the `wfg_domain`. This PR sets `wfg_domain.delta_f` to match that of the data domain.

Previously, we were simply using the data domain directly whenever making an update to data conditioning during importance sampling. This is clearly wrong, so it has been corrected.

Closes #222 

@hectorestelles Please test and confirm that the problem in #222 is resolved.
