### PR TITLE
Update pyproject.toml to require pyseobnr

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -11,10 +11,11 @@ build:
   tools:
     python: "3.10"
     # You can also specify other tool versions:
-    gsl: "2.7"
     # nodejs: "19"
     # rust: "1.64"
     # golang: "1.19"
+  apt-packages:
+    - gsl
   jobs:
     post_install:
       - pip install --force-reinstall "docutils<0.17"

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -15,7 +15,7 @@ build:
     # rust: "1.64"
     # golang: "1.19"
   apt_packages:
-    - gsl
+    - libgsl-dev
   jobs:
     post_install:
       - pip install --force-reinstall "docutils<0.17"

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -11,6 +11,7 @@ build:
   tools:
     python: "3.10"
     # You can also specify other tool versions:
+    gsl: "2.7"
     # nodejs: "19"
     # rust: "1.64"
     # golang: "1.19"

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -14,7 +14,7 @@ build:
     # nodejs: "19"
     # rust: "1.64"
     # golang: "1.19"
-  apt-packages:
+  apt_packages:
     - gsl
   jobs:
     post_install:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,7 @@ dependencies = [
     "pycbc",
     "pycondor",
     "pyopenssl",
-    "pyseobnr",
+    "pygsl",
     "pyyaml",
     "scikit-learn",
     "scipy",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,6 +41,7 @@ dependencies = [
     "pycbc",
     "pycondor",
     "pyopenssl",
+    "pyseobnr",
     "pyyaml",
     "scikit-learn",
     "scipy",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,7 @@ dependencies = [
     "pycbc",
     "pycondor",
     "pyopenssl",
-    "pygsl",
+    "pyseobnr",
     "pyyaml",
     "scikit-learn",
     "scipy",


### PR DESCRIPTION
This dependency is needed to generate SEOBNRv5 waveforms.

pyseobnr requires pygsl_lite, which in turn requires gsl. gsl is a non-Python package, so it is not available on pypi (although it is available on conda-forge). Consequently, for the docs to compile, we have to update .readthedocs.yaml to install gsl with apt-get.