### PR TITLE
added support for 1 detector networks

### DIFF
--- a/dingo/core/nn/nsf.py
+++ b/dingo/core/nn/nsf.py
@@ -2,6 +2,7 @@
 Implementation of the neural spline flow (NSF). Most of this code is adapted
 from the uci.py example from https://github.com/bayesiains/nsf.
 """
+
 import copy
 
 import torch
@@ -218,7 +219,7 @@ class FlowWrapper(nn.Module):
         if self.embedding_net is not None:
             x = torchutils.forward_pass_with_unpacked_tuple(self.embedding_net, x)
         if len(x) > 0:
-            sample = self.flow.sample(num_samples)
+            sample = self.flow.sample(num_samples, x)
             sl = list(range(sample.ndim - 1))
             return torch.squeeze(sample, dim=sl)
         else:

--- a/dingo/core/nn/nsf.py
+++ b/dingo/core/nn/nsf.py
@@ -218,21 +218,27 @@ class FlowWrapper(nn.Module):
         if self.embedding_net is not None:
             x = torchutils.forward_pass_with_unpacked_tuple(self.embedding_net, x)
         if len(x) > 0:
-            return torch.squeeze(self.flow.sample(num_samples, x))
+            sample = self.flow.sample(num_samples)
+            sl = list(range(sample.ndim - 1))
+            return torch.squeeze(sample, dim=sl)
         else:
             # if there is no context, omit the context argument
-            return torch.squeeze(self.flow.sample(num_samples))
+            sample = self.flow.sample(num_samples)
+            sl = list(range(sample.ndim - 1))
+            return torch.squeeze(sample, dim=sl)
 
     def sample_and_log_prob(self, *x, num_samples=1):
         if self.embedding_net is not None:
             x = torchutils.forward_pass_with_unpacked_tuple(self.embedding_net, x)
         if len(x) > 0:
             sample, log_prob = self.flow.sample_and_log_prob(num_samples, x)
-            return torch.squeeze(sample), torch.squeeze(log_prob)
+            sl = list(range(sample.ndim - 1))
+            return torch.squeeze(sample, dim=sl), torch.squeeze(log_prob, dim=sl)
         else:
             # if there is no context, omit the context argument
             sample, log_prob = self.flow.sample_and_log_prob(num_samples)
-            return torch.squeeze(sample), torch.squeeze(log_prob)
+            sl = list(range(sample.ndim - 1))
+            return torch.squeeze(sample, dim=sl), torch.squeeze(log_prob, dim=sl)
 
     def forward(self, y, *x):
         if len(x) > 0:

--- a/dingo/core/nn/nsf.py
+++ b/dingo/core/nn/nsf.py
@@ -219,27 +219,19 @@ class FlowWrapper(nn.Module):
         if self.embedding_net is not None:
             x = torchutils.forward_pass_with_unpacked_tuple(self.embedding_net, x)
         if len(x) > 0:
-            sample = self.flow.sample(num_samples, x)
-            sl = list(range(sample.ndim - 1))
-            return torch.squeeze(sample, dim=sl)
+            return self.flow.sample(num_samples, x)
         else:
             # if there is no context, omit the context argument
-            sample = self.flow.sample(num_samples)
-            sl = list(range(sample.ndim - 1))
-            return torch.squeeze(sample, dim=sl)
+            return self.flow.sample(num_samples)
 
     def sample_and_log_prob(self, *x, num_samples=1):
         if self.embedding_net is not None:
             x = torchutils.forward_pass_with_unpacked_tuple(self.embedding_net, x)
         if len(x) > 0:
-            sample, log_prob = self.flow.sample_and_log_prob(num_samples, x)
-            sl = list(range(sample.ndim - 1))
-            return torch.squeeze(sample, dim=sl), torch.squeeze(log_prob, dim=sl)
+            return self.flow.sample_and_log_prob(num_samples, x)
         else:
             # if there is no context, omit the context argument
-            sample, log_prob = self.flow.sample_and_log_prob(num_samples)
-            sl = list(range(sample.ndim - 1))
-            return torch.squeeze(sample, dim=sl), torch.squeeze(log_prob, dim=sl)
+            return self.flow.sample_and_log_prob(num_samples)
 
     def forward(self, y, *x):
         if len(x) > 0:

--- a/dingo/core/samplers.py
+++ b/dingo/core/samplers.py
@@ -494,12 +494,12 @@ class GNPESampler(Sampler):
             self.model.model.eval()
 
             with torch.no_grad():
-                if "context_parameters" not in x.keys():
-                    y, log_prob = self.model.model.sample_and_log_prob(x["data"])
-                else:
+                if "context_parameters" in x:
                     y, log_prob = self.model.model.sample_and_log_prob(
                         x["data"], x["context_parameters"]
                     )
+                else:
+                    y, log_prob = self.model.model.sample_and_log_prob(x["data"])
             time_sample_end = time.time()
 
             x["parameters"] = y

--- a/dingo/core/samplers.py
+++ b/dingo/core/samplers.py
@@ -145,14 +145,11 @@ class Sampler(object):
             x["extrinsic_parameters"] = {}
 
             # transforms_pre are expected to transform the data in the same way for each
-            # requested sample. We therefore expand it across the batch *after*
-            # pre-processing.
+            # requested sample. We therefore apply pre-processing only once.
             x = self.transform_pre(context)
-            x = x.expand(num_samples, *x.shape)
+            # Require a batch dimension for the embedding network.
+            x = x.unsqueeze(0)
             x = [x]
-            # The number of samples is expressed via the first dimension of x,
-            # so we must pass num_samples = 1 to sample_and_log_prob().
-            num_samples = 1
         else:
             if context is not None:
                 print("Unconditional model. Ignoring context.")
@@ -166,6 +163,11 @@ class Sampler(object):
             y, log_prob = self.model.model.sample_and_log_prob(
                 *x, num_samples=num_samples
             )
+
+        if not self.unconditional_model:
+            # Squeeze the batch dimension added earlier.
+            y = y.squeeze(0)
+            log_prob = log_prob.squeeze(0)
 
         samples = self.transform_post({"parameters": y, "log_prob": log_prob})
         result = samples["parameters"]
@@ -500,6 +502,11 @@ class GNPESampler(Sampler):
                     )
                 else:
                     y, log_prob = self.model.model.sample_and_log_prob(x["data"])
+
+            # Squeeze the extra dimension added by sample_and_log_prob(num_samples=1).
+            y = y.squeeze(1)
+            log_prob = log_prob.squeeze(1)
+
             time_sample_end = time.time()
 
             x["parameters"] = y

--- a/dingo/core/samplers.py
+++ b/dingo/core/samplers.py
@@ -492,10 +492,14 @@ class GNPESampler(Sampler):
 
             time_sample_start = time.time()
             self.model.model.eval()
+
             with torch.no_grad():
-                y, log_prob = self.model.model.sample_and_log_prob(
-                    x["data"], x["context_parameters"]
-                )
+                if "context_parameters" not in x.keys():
+                    y, log_prob = self.model.model.sample_and_log_prob(x["data"])
+                else:
+                    y, log_prob = self.model.model.sample_and_log_prob(
+                        x["data"], x["context_parameters"]
+                    )
             time_sample_end = time.time()
 
             x["parameters"] = y

--- a/dingo/gw/injection.py
+++ b/dingo/gw/injection.py
@@ -397,4 +397,7 @@ class Injection(GWSignal):
                 asd (if set): amplitude spectral density for each detector
         """
         theta = self.prior.sample()
+        theta = {
+            k: float(v) for k, v in theta.items()
+        }  # Some parameters are np.float64
         return self.injection(theta)

--- a/dingo/pipe/sampling.py
+++ b/dingo/pipe/sampling.py
@@ -148,13 +148,26 @@ class SamplingInput(Input):
             else:
                 self._density_recovery_settings.update(convert_string_to_dict(settings))
 
+        # If there is only one detector, and no context, we cannot use a coupling transform. In this case, we use an
+        # autoregressive transform for the density estimator.
+        # FIXME: If there are proxies other than time, the condition needs to be updated.
+        if len(self.detectors) == 1:
+            model_settings = self._density_recovery_settings["nde_settings"]["model"]
+            if model_settings["type"] == "nsf":
+                base_transform_kwargs = model_settings["base_transform_kwargs"]
+                if base_transform_kwargs["base_transform_type"] == "rq-coupling":
+                    logger.info(
+                        "Using autoregressive transform for density estimator since there is only one GNPE proxy "
+                        "parameter because there is only one detector."
+                    )
+                    base_transform_kwargs["base_transform_type"] = "rq-autoregressive"
+
     # @property
     # def result_directory(self):
     #     result_dir = os.path.join(self.outdir, "result")
     #     return os.path.relpath(result_dir)
 
     def run_sampler(self):
-
         if self.gnpe and self.recover_log_prob:
             logger.info(
                 "GNPE network does not provide log probability. Generating "

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ classifiers = [
 dependencies = [
     "astropy",
     "bilby",
-    "bilby_pipe>=1.2.1",
+    "bilby_pipe>=1.3",
     "configargparse",
     "corner",
     "glasflow",


### PR DESCRIPTION
This pull request enables support for 1 detector networks.

There are two current issues with one detector flows for Dingo.

1). https://github.com/dingo-gw/dingo/issues/216. Summarized, there is an issue when using a coupling layer with a 1D distribution with no context as there is no input to the neural network. This causes nflows to error out.

This PR fixes this by using an autoregressive flow to learn the 1D density of GNPE samples.

2). Currently, there is no way to pass no context during gibbs sampling

There is a simple fix to this which is in lines 503 of dingo.core.samplers.py.

This PR fixes the issues. It has been tested on GW190620 which is a L1 only event. It achieves a sample efficiency of 6.57% with 32_000 effective samples in this case.