### PR TITLE
Fix bug related to random seeds

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -17,8 +17,6 @@ build:
   apt_packages:
     - libgsl-dev
   jobs:
-    post_install:
-      - pip install --force-reinstall "docutils<0.17"
     pre_build:
       - sphinx-apidoc -o docs/source dingo
 

--- a/dingo/core/utils/torchutils.py
+++ b/dingo/core/utils/torchutils.py
@@ -8,9 +8,12 @@ import bilby
 
 
 def fix_random_seeds(_):
-    """Util function to set random seeds when using multiple workers for Dataloader."""
+    """Utility function to set random seeds when using multiple workers for DataLoader."""
     np.random.seed(int(torch.initial_seed()) % (2 ** 32 - 1))
-    bilby.core.utils.random.seed(int(torch.initial_seed()) % (2 ** 32 - 1))
+    try:
+        bilby.core.utils.random.seed(int(torch.initial_seed()) % (2 ** 32 - 1))
+    except AttributeError:  # In case using an old version of Bilby.
+        pass
 
 
 def get_activation_function_from_string(activation_name: str):

--- a/dingo/core/utils/torchutils.py
+++ b/dingo/core/utils/torchutils.py
@@ -4,6 +4,13 @@ import torch.nn as nn
 from torch.nn import functional as F
 from torch.utils.data import DataLoader
 from typing import Union, Tuple, Iterable
+import bilby
+
+
+def fix_random_seeds(_):
+    """Util function to set random seeds when using multiple workers for Dataloader."""
+    np.random.seed(int(torch.initial_seed()) % (2 ** 32 - 1))
+    bilby.core.utils.random.seed(int(torch.initial_seed()) % (2 ** 32 - 1))
 
 
 def get_activation_function_from_string(activation_name: str):
@@ -230,9 +237,7 @@ def build_train_and_test_loaders(
         shuffle=True,
         pin_memory=True,
         num_workers=num_workers,
-        worker_init_fn=lambda _: np.random.seed(
-            int(torch.initial_seed()) % (2 ** 32 - 1)
-        ),
+        worker_init_fn=fix_random_seeds,
     )
     test_loader = DataLoader(
         test_dataset,
@@ -240,9 +245,7 @@ def build_train_and_test_loaders(
         shuffle=False,
         pin_memory=True,
         num_workers=num_workers,
-        worker_init_fn=lambda _: np.random.seed(
-            int(torch.initial_seed()) % (2 ** 32 - 1)
-        ),
+        worker_init_fn=fix_random_seeds,
     )
 
     return train_loader, test_loader

--- a/dingo/gw/training/train_builders.py
+++ b/dingo/gw/training/train_builders.py
@@ -271,9 +271,7 @@ def build_svd_for_embedding_network(
         wfd,
         batch_size=batch_size,
         num_workers=num_workers,
-        worker_init_fn=lambda _: np.random.seed(
-            int(torch.initial_seed()) % (2 ** 32 - 1)
-        ),
+        worker_init_fn=fix_random_seeds,
     )
     with threadpool_limits(limits=1, user_api="blas"):
         for idx, data in enumerate(loader):


### PR DESCRIPTION
This fixes a bug, where each worker was initialised with the same random seed due to a change made in [bilby](https://git.ligo.org/lscsoft/bilby/-/merge_requests/1273). 

This bug likely lead to identical samples for extrinsic parameters, which corrupted the neural network training in the following way. The network could just memorise the parameters from the previous workers, without looking at the strain data. With `N` data loader workers, this resulted in a pattern where the loss would rapidly decrease over `N` iterations, as the network memorised the parameters. In iteration `N+1`, the loss steeply increased (as all workers would generate new random numbers), and then rapidly decrease again until iteration `2N`.