### PR TITLE
Fixing dingo_pipe to be compatible with bilby_pipe==1.3

### DIFF
--- a/dingo/pipe/data_generation.py
+++ b/dingo/pipe/data_generation.py
@@ -156,7 +156,7 @@ class DataGenerationInput(BilbyDataGenerationInput):
             args.injection_dict = None
             args.injection_waveform_arguments = None
             args.injection_frequency_domain_source_model = None
-            self._frequency_domain_source_model = None
+            self.frequency_domain_source_model = None
             self.gaussian_noise = False
 
             self.create_data(args)

--- a/dingo/pipe/data_generation.py
+++ b/dingo/pipe/data_generation.py
@@ -154,8 +154,10 @@ class DataGenerationInput(BilbyDataGenerationInput):
             args.injection_numbers = None
             args.injection_file = None
             args.injection_dict = None
-            args.gaussian_noise = False
             args.injection_waveform_arguments = None
+            args.injection_frequency_domain_source_model = None
+            self._frequency_domain_source_model = None
+            self.gaussian_noise = False
 
             self.create_data(args)
 

--- a/dingo/pipe/main.py
+++ b/dingo/pipe/main.py
@@ -116,6 +116,7 @@ class MainInput(BilbyMainInput):
             False  # dingo mod: Cannot use different sets of detectors.
         )
         self.data_dict = args.data_dict
+        self.channel_dict = args.channel_dict
         self.frame_type_dict = args.frame_type_dict
         self.data_find_url = args.data_find_url
         self.data_find_urltype = args.data_find_urltype
@@ -171,8 +172,8 @@ class MainInput(BilbyMainInput):
         self.gps_tuple = args.gps_tuple
         self.gps_file = args.gps_file
         self.timeslide_file = args.timeslide_file
-        # self.gaussian_noise = args.gaussian_noise
-        # self.zero_noise = args.zero_noise
+        self.gaussian_noise = False  # DINGO MOD: Cannot use different noise types.
+        self.zero_noise = False  # DINGO MOD: does not support zero noise yet
         # self.n_simulation = args.n_simulation
         #
         # self.injection = args.injection

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ classifiers = [
 dependencies = [
     "astropy",
     "bilby",
-    "bilby_pipe>=1.2.1",
+    "bilby_pipe>=1.3",
     "configargparse",
     "corner",
     "glasflow",


### PR DESCRIPTION
The newest MR of bilby_pipe: https://git.ligo.org/lscsoft/bilby_pipe/-/merge_requests/580/diffs?commit_id=fec7dd7f4df06c2fd2686042fd97ab7773f198af has broken the current version of dingo_pipe. This PR modifies dingo_pipe to be consistent with bilby_pipe==1.3. This would involve adding extra arguments which are required by the new version of bilby_pipe. 