### PR TITLE
Fixed bug in NotImplementedError message

### DIFF
--- a/dingo/gw/waveform_generator/waveform_generator.py
+++ b/dingo/gw/waveform_generator/waveform_generator.py
@@ -691,7 +691,7 @@ class WaveformGenerator:
             return hlm_fd, iota
         else:
             raise NotImplementedError(
-                f"Approximant {LS.GetApproximantFromString(self.approximant)} not "
+                f"Approximant {self.approximant_str} not "
                 f"implemented. When adding this approximant to this method, make sure "
                 f"the the output dict hlm_td contains the TD modes in the *L0 frame*. "
                 f"In particular, adding an approximant that is implemented in the same "


### PR DESCRIPTION
This PR fixes a bug in a NotImplementedError message.

When running importance sampling without phase marginalization and a waveform model other than IMRPhenomXPHM, a `NotImplementedError` should be hit in `generate_FD_modes_LO()` of `dingo/gw/waveform_generator/waveform_generator.py` .

However, the error message itself throws the error
`TypeError: in method 'GetApproximantFromString', argument 1 of type 'char const *'*`
in line https://github.com/dingo-gw/dingo/blob/fa032dbfb3494118868fa9ac5efd88992fbd1416/dingo/gw/waveform_generator/waveform_generator.py#L694

This error occurs because `self.approximant` is an integer while the function `LS.GetApproximantFromString(self.approximant)` only takes strings/char-type inputs.

The command is replaced by `self.approximant_str` and the error message now prints correctly.