### PR TITLE
Hotfix for dingo_pipe data_generation

### DIFF
--- a/dingo/pipe/data_generation.py
+++ b/dingo/pipe/data_generation.py
@@ -156,8 +156,8 @@ class DataGenerationInput(BilbyDataGenerationInput):
             args.injection_dict = None
             args.injection_waveform_arguments = None
             args.injection_frequency_domain_source_model = None
+            args.gaussian_noise = False
             self.frequency_domain_source_model = None
-            self.gaussian_noise = False
 
             self.create_data(args)
 


### PR DESCRIPTION
I am not sure when this bug got introduced, but with the current and previous versions of bilby_pipe, we need to specify args.gaussian_noise and not self.gaussian_noise to be False. Otherwise, this will trigger an error in the data_generation. Namely, see the following line of the bilby source code which is called after running self.create_data https://github.com/lscsoft/bilby_pipe/blob/master/bilby_pipe/data_generation.py#L211. 