### PR TITLE
Fixing condor submission for dingo_train_condor on non-MPI-IS clusters

### DIFF
--- a/dingo/gw/training/train_pipeline_condor.py
+++ b/dingo/gw/training/train_pipeline_condor.py
@@ -84,9 +84,13 @@ def train_condor():
 
             local_settings = train_settings.pop("local")
             with open(os.path.join(args.train_dir, "local_settings.yaml"), "w") as f:
-                if local_settings.get("wandb", False) and "id" not in local_settings["wandb"].keys():
+                if (
+                    local_settings.get("wandb", False)
+                    and "id" not in local_settings["wandb"].keys()
+                ):
                     try:
                         import wandb
+
                         local_settings["wandb"]["id"] = wandb.util.generate_id()
                     except ImportError:
                         print("wandb not installed, cannot generate run id.")
@@ -144,9 +148,15 @@ def train_condor():
     # SUBMIT NEXT CONDOR JOB
     #
 
-    # There was no 'bid' in the sample settings file.
-    bid = condor_settings["bid"]
-    os.system(f"condor_submit_bid {bid} " f"{join(args.train_dir, submission_file)}")
+    if "bid" in condor_settings:
+        bid = condor_settings["bid"]
+        os.system(
+            f"condor_submit_bid {bid} " f"{join(args.train_dir, submission_file)}"
+        )
+    else:
+        # There was no 'bid' in the sample settings file.
+        # This is a specific settings for the MPI-IS cluster
+        os.system(f"condor_submit {join(args.train_dir, submission_file)}")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
At the moment `dingo_train_condor` expects a "bid" parameter during submission. This "bid" is for the `condor_submit_bid` functionality at the MPI-IS cluster. 

However, the AEI cluster or the CalTech cluster do not currently have this functionality. This is a fix that checks if the user has specified the "bid" option in the local settings file and if they do use the `condor_submit_bid` and if they don't uses the `condor_submit`. 

We could also check if `condor_submit_bid` exists on the machine or not and if it does then use the command. But I thought this was a simpler solution. 