### PR TITLE
Allow asimov to automatically detect the template config file

### DIFF
--- a/dingo/asimov/asimov.py
+++ b/dingo/asimov/asimov.py
@@ -26,7 +26,7 @@ class Dingo(Pipeline):
         Defaults to "C01_offline".
     """
 
-    with importlib.resources.path("dingo.asimov", "datafind_template.yml") as template_file:
+    with importlib.resources.path("dingo.asimov", "datafind_template.ini") as template_file:
         config_template = template_file
 
     name = "dingo"

--- a/dingo/asimov/asimov.py
+++ b/dingo/asimov/asimov.py
@@ -26,7 +26,9 @@ class Dingo(Pipeline):
         Defaults to "C01_offline".
     """
 
-    # config_template = importlib.resources.path(__name__, 'dingo.ini')
+    with importlib.resources.path("dingo.asimov", "datafind_template.yml") as template_file:
+        config_template = template_file
+
     name = "dingo"
     STATUS = {"wait", "stuck", "stopped", "running", "finished"}
 


### PR DESCRIPTION
This MR allows bilby to automatically detect the config file template for asimov inside the python package so that it does not need to be specified as a separate template in the `asimov.conf` file.