### PR TITLE
Added saving of psds as external .txt files

### DIFF
--- a/dingo/pipe/data_generation.py
+++ b/dingo/pipe/data_generation.py
@@ -165,8 +165,9 @@ class DataGenerationInput(BilbyDataGenerationInput):
     def save_hdf5(self):
         """
         Save frequency-domain strain and ASDs as DingoDataset HDF5 format.
+
         This method will also save the PSDs as .txt files in the data directory
-        for easy reading by pesummary and Bilby
+        for easy reading by pesummary and Bilby.
         """
 
         # PSD and strain data.

--- a/dingo/pipe/data_generation.py
+++ b/dingo/pipe/data_generation.py
@@ -5,6 +5,7 @@ from bilby_pipe.input import Input
 from bilby_pipe.main import parse_args
 from bilby_pipe.utils import logger, convert_string_to_dict
 from bilby_pipe.data_generation import DataGenerationInput as BilbyDataGenerationInput
+import numpy as np
 
 from dingo.gw.data.event_dataset import EventDataset
 from dingo.gw.domains import FrequencyDomain
@@ -234,6 +235,14 @@ class DataGenerationInput(BilbyDataGenerationInput):
             }
         )
         dataset.to_file(self.event_data_file)
+
+        # also saving the psd as a .dat file which can be read in
+        # easily by pesummary or bilby
+        for ifo in self.interferometers:
+            np.savetxt(
+                os.path.join(self.data_directory, f"{ifo.name}_psd.txt"),
+                np.vstack([domain(), data["asds"][ifo.name]]).T,
+            )
 
     @property
     def event_data_file(self):

--- a/dingo/pipe/data_generation.py
+++ b/dingo/pipe/data_generation.py
@@ -163,7 +163,11 @@ class DataGenerationInput(BilbyDataGenerationInput):
             self.create_data(args)
 
     def save_hdf5(self):
-        """Save frequency-domain strain and ASDs as DingoDataset HDF5 format."""
+        """
+        Save frequency-domain strain and ASDs as DingoDataset HDF5 format.
+        This method will also save the PSDs as .txt files in the data directory
+        for easy reading by pesummary and Bilby
+        """
 
         # PSD and strain data.
         data = {"waveform": {}, "asds": {}}  # TODO: Rename these keys.
@@ -241,7 +245,7 @@ class DataGenerationInput(BilbyDataGenerationInput):
         for ifo in self.interferometers:
             np.savetxt(
                 os.path.join(self.data_directory, f"{ifo.name}_psd.txt"),
-                np.vstack([domain(), data["asds"][ifo.name]]).T,
+                np.vstack([domain(), data["asds"][ifo.name] ** 2]).T,
             )
 
     @property


### PR DESCRIPTION
In order to run summarypages on dingo and not have the "preliminary" watermark, one has to specify the PSD explicitly. However, with dingo_pipe, the PSD is saved in an event dataset which is not ingestable by bilby or pesummary. 

This PR additionally saves the PSD as a .txt file which can be passed to pesummary. An example CLI to pesummary would be 

```
summarypages --webdir ./outdir_GW150914/webpage --samples ./outdir_GW150914/dingo_importance_sampling.hdf5 --config ./outdir_GW150914/GW150914_config_complete.ini --gw --disable_expert --disable_interactive --no_ligo_skymap --psd H1:./outdir_GW150914/H1_psd.txt L1:./outdir_GW150914/L1_psd.txt
```