### PR TITLE
Fixing import of lalsimulation.gwsignal to allow for debuggers

### DIFF
--- a/dingo/gw/waveform_generator/waveform_generator.py
+++ b/dingo/gw/waveform_generator/waveform_generator.py
@@ -12,9 +12,6 @@ import pandas as pd
 import lal
 import lalsimulation as LS
 
-from lalsimulation.gwsignal.core import waveform
-from lalsimulation.gwsignal.models import gwsignal_get_waveform_generator
-
 from bilby.gw.conversion import (
     convert_to_lal_binary_black_hole_parameters,
     bilby_to_lalsimulation_spins,
@@ -775,20 +772,17 @@ class NewInterfaceWaveformGenerator(WaveformGenerator):
     def __init__(self, **kwargs):
         WaveformGenerator.__init__(self, **kwargs)
 
-        try:
-            # we want to import the new interface, but we don't want to import it 
-            # for all users because just importing the module causes unintended side effects
-            # for example, you cannot pass the debugger through the import statement.
-            # Thus we only import it when the class is instantiated.
-            # However, we don't want to reimport the module every time we need to 
-            # use the function as this is costly. Therefore, we import it once 
-            # when the class is instantiated and store it in the global namespace
-            from lalsimulation.gwsignal.core import waveform
-            from lalsimulation.gwsignal.models import gwsignal_get_waveform_generator
-            globals()['gws_wfm'] = waveform
-            globals()["new_interface_get_waveform_generator"] = gwsignal_get_waveform_generator 
-        except ImportError:
-            raise ImportError("The new interface is not available, please install lalsimulation")
+        # we want to import the new interface, but we don't want to import it 
+        # for all users because just importing the module causes unintended side effects
+        # for example, you cannot pass the debugger through the import statement.
+        # Thus we only import it when the class is instantiated.
+        # However, we don't want to reimport the module every time we need to 
+        # use the function as this is costly. Therefore, we import it once 
+        # when the class is instantiated and store it in the global namespace
+        from lalsimulation.gwsignal.core import waveform
+        from lalsimulation.gwsignal.models import gwsignal_get_waveform_generator
+        globals()['gws_wfm'] = waveform
+        globals()["new_interface_get_waveform_generator"] = gwsignal_get_waveform_generator 
 
 
         self.mode_list = kwargs.get("mode_list", None)

--- a/dingo/gw/waveform_generator/waveform_generator.py
+++ b/dingo/gw/waveform_generator/waveform_generator.py
@@ -7,17 +7,10 @@ import astropy.units as u
 from typing import Dict, List, Tuple, Union
 from numbers import Number
 import warnings
-import lal
-import lalsimulation as LS
 import pandas as pd
 
-try:
-    from lalsimulation.gwsignal.core import waveform as gws_wfm
-    from lalsimulation.gwsignal.models import (
-        gwsignal_get_waveform_generator as new_interface_get_waveform_generator,
-    )
-except ImportError:
-    pass
+import lal
+import lalsimulation as LS
 
 from bilby.gw.conversion import (
     convert_to_lal_binary_black_hole_parameters,
@@ -776,9 +769,24 @@ class NewInterfaceWaveformGenerator(WaveformGenerator):
     """Generate polarizations using GWSignal routines in the specified domain for a
     single GW coalescence given a set of waveform parameters.
     """
-
     def __init__(self, **kwargs):
         WaveformGenerator.__init__(self, **kwargs)
+
+        try:
+            # we want to import the new interface, but we don't want to import it 
+            # for all users because just importing the module causes unintended side effects
+            # for example, you cannot pass the debugger through the import statement.
+            # Thus we only import it when the class is instantiated.
+            # However, we don't want to reimport the module every time we need to 
+            # use the function as this is costly. Therefore, we import it once 
+            # when the class is instantiated and store it in the global namespace
+            from lalsimulation.gwsignal.core import waveform
+            from lalsimulation.gwsignal.models import gwsignal_get_waveform_generator
+            globals()['gws_wfm'] = waveform
+            globals()["new_interface_get_waveform_generator"] = gwsignal_get_waveform_generator 
+        except ImportError:
+            raise ImportError("The new interface is not available, please install lalsimulation")
+
 
         self.mode_list = kwargs.get("mode_list", None)
 

--- a/dingo/gw/waveform_generator/waveform_generator.py
+++ b/dingo/gw/waveform_generator/waveform_generator.py
@@ -12,6 +12,9 @@ import pandas as pd
 import lal
 import lalsimulation as LS
 
+from lalsimulation.gwsignal.core import waveform
+from lalsimulation.gwsignal.models import gwsignal_get_waveform_generator
+
 from bilby.gw.conversion import (
     convert_to_lal_binary_black_hole_parameters,
     bilby_to_lalsimulation_spins,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,6 @@ dependencies = [
     "pesummary",
     "pycbc",
     "pycondor",
-    "pyseobnr",
     "pyyaml",
     "requests",
     "scikit-learn",
@@ -79,6 +78,10 @@ dev = [
     "sphinxcontrib-mermaid",
     "sphinxcontrib-bibtex",
     "wandb",
+]
+
+pyseobnr = [
+    "pyseobnr",
 ]
 
 


### PR DESCRIPTION
For some reason, when stepping through `import lalsimulation.gwsignal`, the debugger hangs and is unable to step over the import. This is despite when disconnecting the debugger (or alternatively just running the file with regular python) the import works fine. 

* This fix moves the location of the import so that `lalsimulation.gwsignal` is only imported when the `NewInterfaceWaveformGenerator` is instantiated. The functions from `lalsimulation.gwsignal` are then sent to the global namespace. 

* This PR also removes pyseobnr as a required dependency for installation. You can install dingo with pyseobnr by running pip install dingo-gw[pyseobnr]. 

With conda my suggestion would be to not ship pyseobnr with dingo by default and just tell the user they need to install it on their own if they want to use v5. 