### PR TITLE
Fix dingo pipe simple submission

### DIFF
--- a/dingo/pipe/dag_creator.py
+++ b/dingo/pipe/dag_creator.py
@@ -7,6 +7,7 @@ import copy
 from bilby_pipe.job_creation.dag import Dag
 from bilby_pipe.utils import BilbyPipeError, logger
 
+from dingo.pipe.utils import _strip_unwanted_submission_keys
 from dingo.pipe.nodes.generation_node import GenerationNode
 from .nodes.importance_sampling_node import ImportanceSamplingNode
 from .nodes.merge_node import MergeNode
@@ -48,6 +49,8 @@ def generate_dag(inputs, model_args):
     dag = Dag(inputs)
     trigger_times = get_trigger_time_list(inputs)
 
+    if inputs.simple_submission:
+        _strip_unwanted_submission_keys(dag.pycondor_dag)
     #
     # 1. Generate data for inference.
     #

--- a/dingo/pipe/utils.py
+++ b/dingo/pipe/utils.py
@@ -3,6 +3,6 @@ def _strip_unwanted_submission_keys(job):
     job.universe = None
     extra_lines = []
     for line in job.extra_lines:
-        if not line.startswith("priority") and not line.startswith("accounting_group"):
+        if not line.startswith("priority") and not line.startswith("accounting_group") and not line.startswith("ENV"):
             extra_lines.append(line)
     job.extra_lines = extra_lines

--- a/dingo/pipe/utils.py
+++ b/dingo/pipe/utils.py
@@ -3,6 +3,6 @@ def _strip_unwanted_submission_keys(job):
     job.universe = None
     extra_lines = []
     for line in job.extra_lines:
-        if not line.startswith("priority") and not line.startswith("accounting_group") and not line.startswith("ENV"):
+        if not line.startswith("priority") and not line.startswith("accounting_group") and not line.startswith("ENV GET HTGETTOKENOPTS"):
             extra_lines.append(line)
     job.extra_lines = extra_lines


### PR DESCRIPTION
Since the bilby_pipe update, dingo_pipe was automatically adding the line `ENV GET HTGETTOKENOPTS` in the main `dag_GWxxxxxx.submit`. This line is part of the LIGO authentication ([see LIGO documentation](https://lscsoft.docs.ligo.org/bilby_pipe/v1.3.0/data_acquisition.html)), resulting in an error for `simple-submission=True`.

This PR removes the line for simple submission.