### PR TITLE
Correct docs of tutorials

### DIFF
--- a/docs/source/example_gnpe_model.md
+++ b/docs/source/example_gnpe_model.md
@@ -81,14 +81,14 @@ As before we generate a fiducial ASD dataset containing a single ASD:
 
 ```
 dingo_generate_asd_dataset --settings_file asd_dataset_settings_fiducial.yaml --data_dir
-training_data/asd_dataset_fiducial -out_name training_data/asd_dataset_fiducial/asds_O1_fiducial.hdf5
+training_data/asd_dataset_fiducial --out_name training_data/asd_dataset_fiducial/asds_O1_fiducial.hdf5
 ```
 
 and a large ASD dataset:
 
 ```
 dingo_generate_asd_dataset --settings_file asd_dataset_settings.yaml --data_dir
-training_data/asd_dataset -out_name training_data/asd_dataset/asds_O1.hdf5
+training_data/asd_dataset --out_name training_data/asd_dataset/asds_O1.hdf5
 ```
 
 
@@ -103,14 +103,14 @@ become significantly easier. To do this we first need to train an initialization
 network which estimates the time of arrival in the detectors:
 
 ```
-dingo_train --settings_file train_settings_init.yaml --train_dir training/init_network
+dingo_train --settings_file train_settings_init.yaml --train_dir training/init_train_dir
 ```
 
 Notice that the inference parameters are only the `H1_time` and `L1_time`. Also notice that the embedding_net 
 is significantly smaller and the number of flow steps, `num_flow_steps` is reduced.
 
 ```
-dingo_train --settings_file train_settings_main.yaml --train_dir training/main_network
+dingo_train --settings_file train_settings.yaml --train_dir training/main_train_dir
 ```
 
 Notice the `data.gnpe_time_shifts` section. The `kernel` describes how much to blur the GNPE proxies and is specified in 

--- a/docs/source/example_injection.md
+++ b/docs/source/example_injection.md
@@ -9,7 +9,7 @@ one can take the fiducial asd dataset the network was trained on.
 ```
 from dingo.core.models import PosteriorModel
 import dingo.gw.injection as injection
-from dingo.gw.ASD_dataset.noise_dataset import ASDDataset
+from dingo.gw.noise.asd_dataset import ASDDataset
 
 main_pm = PosteriorModel(
     device="cuda",

--- a/docs/source/example_npe_model.md
+++ b/docs/source/example_npe_model.md
@@ -89,7 +89,7 @@ Step 2 Generating an ASD dataset
 To generate an ASD dataset we can run the same command as in the previous tutorial.
 
 ```
-dingo_generate_asd_dataset --settings_file asd_dataset_settings_fiducial.yaml --data_dir training_data/asd_dataset_fiducial -out_name training_data/asd_dataset_fiducial/asds_O1_fiducial.hdf5
+dingo_generate_asd_dataset --settings_file asd_dataset_settings_fiducial.yaml --data_dir training_data/asd_dataset_fiducial --out_name training_data/asd_dataset_fiducial/asds_O1_fiducial.hdf5
 ```
 
 However, this time, during training we will need two sets of ASDs. The first one will be
@@ -103,7 +103,7 @@ of ASDs from the observing run. We find this split leads to an improvement in
 overall performance. To generate this second dataset run
 
 ```
-dingo_generate_asd_dataset --settings_file asd_dataset_settings.yaml --data_dir training_data/asd_dataset -out_name training_data/asd_dataset/asds_O1.hdf5
+dingo_generate_asd_dataset --settings_file asd_dataset_settings.yaml --data_dir training_data/asd_dataset --out_name training_data/asd_dataset/asds_O1.hdf5
 ```
 
 We can see that in `asd_dataset_settings.yaml` the `num_psds_max`

--- a/examples/gnpe_model/train_settings.yaml
+++ b/examples/gnpe_model/train_settings.yaml
@@ -72,7 +72,7 @@ model:
 training:
   stage_0:
     epochs: 300
-    asd_dataset_path: training_data/asd_dataset_folder_fiducial/asds_O1_fiducial.hdf5 # this should just contain a single fiducial ASD per detector for pretraining
+    asd_dataset_path: training_data/asd_dataset_fiducial/asds_O1_fiducial.hdf5 # this should just contain a single fiducial ASD per detector for pretraining
     freeze_rb_layer: True
     optimizer:
       type: adam
@@ -84,7 +84,7 @@ training:
 
   stage_1:
     epochs: 150
-    asd_dataset_path: training_data/asd_dataset_folder/asds_O1.hdf5 # this should contain many different ASDS per detector for finetuning
+    asd_dataset_path: training_data/asd_dataset/asds_O1.hdf5 # this should contain many different ASDS per detector for finetuning
     freeze_rb_layer: False
     optimizer:
       type: adam

--- a/examples/npe_model/GW150914.ini
+++ b/examples/npe_model/GW150914.ini
@@ -28,7 +28,7 @@ luminosity_distance = bilby.gw.prior.UniformComovingVolume(minimum=100, maximum=
 
 trigger-time = GW150914
 label = GW150914
-outdir = outir_GW150914
+outdir = outdir_GW150914
 # channel-dict = {H1:DCS-CALIB_STRAIN_C02, L1:DCS-CALIB_STRAIN_C02}
 channel-dict = {H1:GWOSC, L1:GWOSC}
 psd-length = 128

--- a/examples/npe_model/GW150914.ini
+++ b/examples/npe_model/GW150914.ini
@@ -15,7 +15,6 @@ sampling-requirements = [TARGET.CUDAGlobalMemoryMb>40000]
 
 model = training/model_latest.pt
 device = 'cuda'
-num-gnpe-iterations = 30
 num-samples = 50000
 batch-size = 50000
 recover-log-prob = true
@@ -30,7 +29,8 @@ luminosity_distance = bilby.gw.prior.UniformComovingVolume(minimum=100, maximum=
 trigger-time = GW150914
 label = GW150914
 outdir = outir_GW150914
-channel-dict = {H1:DCS-CALIB_STRAIN_C02, L1:DCS-CALIB_STRAIN_C02}
+# channel-dict = {H1:DCS-CALIB_STRAIN_C02, L1:DCS-CALIB_STRAIN_C02}
+channel-dict = {H1:GWOSC, L1:GWOSC}
 psd-length = 128
 # sampling-frequency = 2048.0
 # importance-sampling-updates = {'duration': 4.0}


### PR DESCRIPTION
This PR fixes small bugs regarding the DINGO tutorials. The fixes include correcting typos in the docs and settings files, updating imports, correcting wrongly specified settings, and ensuring consistent naming of files and folders.