### PR TITLE
Load model in meta state

### DIFF
--- a/dingo/core/models/posterior_model.py
+++ b/dingo/core/models/posterior_model.py
@@ -263,7 +263,6 @@ class PosteriorModel:
 
         self.model_kwargs = d["model_kwargs"]
         self.initialize_model()
-        self.model.load_state_dict(d["model_state_dict"])
 
         self.epoch = d["epoch"]
 
@@ -275,23 +274,26 @@ class PosteriorModel:
         if "event_metadata" in d:
             self.event_metadata = d["event_metadata"]
 
-        self.model_to_device(device)
+        if device != "meta":
+            self.model.load_state_dict(d["model_state_dict"])
 
-        if load_training_info:
-            if "optimizer_kwargs" in d:
-                self.optimizer_kwargs = d["optimizer_kwargs"]
-            if "scheduler_kwargs" in d:
-                self.scheduler_kwargs = d["scheduler_kwargs"]
-            # initialize optimizer and scheduler
-            self.initialize_optimizer_and_scheduler()
-            # load optimizer and scheduler state dict
-            if "optimizer_state_dict" in d:
-                self.optimizer.load_state_dict(d["optimizer_state_dict"])
-            if "scheduler_state_dict" in d:
-                self.scheduler.load_state_dict(d["scheduler_state_dict"])
-        else:
-            # put model in evaluation mode
-            self.model.eval()
+            self.model_to_device(device)
+
+            if load_training_info:
+                if "optimizer_kwargs" in d:
+                    self.optimizer_kwargs = d["optimizer_kwargs"]
+                if "scheduler_kwargs" in d:
+                    self.scheduler_kwargs = d["scheduler_kwargs"]
+                # initialize optimizer and scheduler
+                self.initialize_optimizer_and_scheduler()
+                # load optimizer and scheduler state dict
+                if "optimizer_state_dict" in d:
+                    self.optimizer.load_state_dict(d["optimizer_state_dict"])
+                if "scheduler_state_dict" in d:
+                    self.scheduler.load_state_dict(d["scheduler_state_dict"])
+            else:
+                # put model in evaluation mode
+                self.model.eval()
 
     def train(
         self,

--- a/dingo/gw/ls_cli.py
+++ b/dingo/gw/ls_cli.py
@@ -23,7 +23,6 @@ def ls():
     if path.suffix == ".pt":
         print("Extracting information about torch model.\n")
         d = torch.load(path, map_location="meta")
-        print(d.keys())
         print(f"Version: {d.get('version')}\n")
         print(f"Model epoch: {d['epoch']}\n")
         print("Model metadata:")

--- a/dingo/gw/ls_cli.py
+++ b/dingo/gw/ls_cli.py
@@ -22,7 +22,8 @@ def ls():
     path = Path(args.file_name)
     if path.suffix == ".pt":
         print("Extracting information about torch model.\n")
-        d = torch.load(path, map_location=torch.device("cpu"))
+        d = torch.load(path, map_location="meta")
+        print(d.keys())
         print(f"Version: {d.get('version')}\n")
         print(f"Model epoch: {d['epoch']}\n")
         print("Model metadata:")

--- a/dingo/pipe/main.py
+++ b/dingo/pipe/main.py
@@ -22,10 +22,8 @@ logger.name = "dingo_pipe"
 
 
 def fill_in_arguments_from_model(args):
-    # FIXME: It would be better if we did not have to load an entire model just to
-    #  gain access to the metadata. Store a copy of metadata separately?
     logger.info(f"Loading dingo model from {args.model} in order to access settings.")
-    model = PosteriorModel(args.model, device="cpu", load_training_info=False)
+    model = PosteriorModel(args.model, device="meta", load_training_info=False)
     model_metadata = model.metadata
 
     domain = build_domain_from_model_metadata(model_metadata)


### PR DESCRIPTION
This PR addresses the problem of loading the full DINGO model just to get access to its metadata. 
PyTorch provides the option of loading a model to the ["meta" device](https://pytorch.org/docs/stable/meta.html) which allows users to load a representation of the model without loading the actual parameters into memory. As a result, we can access the metadata of the model with lower memory requirements than before.

The model is loaded to `map_location="meta"` 
- at the beginning of `dingo_pipe` where `model.metadata` is accessed
- in `ls_cli.py` where the `model.metadata` is extracted.

Loading the model to `map_location="meta"` requires changes to `dingo/core/models/posterior_model.py` since operations like `model.to(device)` and `model.load_state_dict(d["model_state_dict"])` cannot be performed for a model on "meta" devices.

This PR was tested on the NPE tutorial example and runs without problems.
