### PR TITLE
Update `result.plot_corner()`

### DIFF
--- a/dingo/core/result.py
+++ b/dingo/core/result.py
@@ -588,9 +588,8 @@ class Result(DingoDataset):
         self,
         parameters: list = None,
         filename: str = "corner.pdf",
-        legend_font_size: int = 50,
         truths: dict = None,
-        truth_color: str = None,
+        **kwargs,
     ):
         """
         Generate a corner plot of the samples.
@@ -602,12 +601,16 @@ class Result(DingoDataset):
             (Default: None)
         filename : str
             Where to save samples.
-        legend_font_size: int
-            Font size of the legend.
         truths : dict
             Dictionary of truth values to include.
-        truth_color: str
+
+        Other Parameters
+        ----------------
+        truth_color : str
             Color of the truth values.
+        legend_font_size: int
+            Font size of the legend.
+
         """
         theta = self._cleaned_samples()
         # delta_log_prob_target is not interesting so never plot it.
@@ -630,18 +633,16 @@ class Result(DingoDataset):
                 weights=[None, weights.to_numpy()],
                 labels=["Dingo", "Dingo-IS"],
                 filename=filename,
-                legend_font_size=legend_font_size,
                 truths=truths,
-                truth_color=truth_color,
+                **kwargs,
             )
         else:
             plot_corner_multi(
                 theta,
                 labels=["Dingo"],
                 filename=filename,
-                legend_font_size=legend_font_size,
                 truths=truths,
-                truth_color=truth_color,
+                **kwargs
             )
 
     def plot_log_probs(self, filename="log_probs.png"):

--- a/dingo/core/result.py
+++ b/dingo/core/result.py
@@ -584,7 +584,14 @@ class Result(DingoDataset):
 
         return self.samples.replace(-np.inf, np.nan).dropna(axis=0)
 
-    def plot_corner(self, parameters=None, filename="corner.pdf"):
+    def plot_corner(
+        self,
+        parameters: list = None,
+        filename: str = "corner.pdf",
+        legend_font_size: int = 50,
+        truths: dict = None,
+        truth_color: str = None,
+    ):
         """
         Generate a corner plot of the samples.
 
@@ -595,27 +602,46 @@ class Result(DingoDataset):
             (Default: None)
         filename : str
             Where to save samples.
+        legend_font_size: int
+            Font size of the legend.
+        truths : dict
+            Dictionary of truth values to include.
+        truth_color: str
+            Color of the truth values.
         """
         theta = self._cleaned_samples()
         # delta_log_prob_target is not interesting so never plot it.
         theta = theta.drop(columns="delta_log_prob_target", errors="ignore")
 
+        if "weights" in theta:
+            weights = theta["weights"]
+        else:
+            weights = None
         # User option to plot specific parameters.
         if parameters:
             theta = theta[parameters]
 
-        if "weights" in theta:
+        if truths:
+            truths = [truths.get(k) for k in theta.columns]
+
+        if weights is not None:
             plot_corner_multi(
                 [theta, theta],
-                weights=[None, theta["weights"].to_numpy()],
+                weights=[None, weights.to_numpy()],
                 labels=["Dingo", "Dingo-IS"],
                 filename=filename,
+                legend_font_size=legend_font_size,
+                truths=truths,
+                truth_color=truth_color,
             )
         else:
             plot_corner_multi(
                 theta,
-                labels="Dingo",
+                labels=["Dingo"],
                 filename=filename,
+                legend_font_size=legend_font_size,
+                truths=truths,
+                truth_color=truth_color,
             )
 
     def plot_log_probs(self, filename="log_probs.png"):

--- a/dingo/core/utils/plotting.py
+++ b/dingo/core/utils/plotting.py
@@ -8,7 +8,12 @@ import pandas as pd
 
 
 def plot_corner_multi(
-    samples, weights=None, labels=None, filename="corner.pdf", **kwargs
+    samples,
+    weights=None,
+    labels=None,
+    filename: str = "corner.pdf",
+    legend_font_size: int = 50,
+    **kwargs,
 ):
     """
     Generate a corner plot for multiple posteriors.
@@ -24,6 +29,8 @@ def plot_corner_multi(
         Labels for the posteriors.
     filename : str
         Where to save samples.
+    legend_font_size: int
+        Font size used in legend. Defaults to 50.
     **kwargs :
         Forwarded to corner.corner.
     """
@@ -38,6 +45,8 @@ def plot_corner_multi(
         "levels": [0.5, 0.9],
         "bins": 30,
     }
+    if "truths" in kwargs and "truth_color" not in kwargs:
+        corner_params["truth_color"] = "black"
     corner_params.update(kwargs)
 
     serif_old = mpl.rcParams["font.family"]
@@ -72,7 +81,7 @@ def plot_corner_multi(
             color=color,
             no_fill_contours=True,
             fig=fig,
-            **corner_params
+            **corner_params,
         )
         handles.append(
             plt.Line2D([], [], color=color, label=l, linewidth=5, markersize=20)
@@ -85,10 +94,22 @@ def plot_corner_multi(
         space = 1 / (4 * len(common_parameters))
         fig.subplots_adjust(wspace=space, hspace=space)
 
+    if "truths" in corner_params:
+        handles.append(
+            plt.Line2D(
+                [],
+                [],
+                color=corner_params["truth_color"],
+                label="Truth",
+                linewidth=5,
+                markersize=20,
+            )
+        )
+
     fig.legend(
         handles=handles,
         loc="upper right",
-        fontsize=50,
+        fontsize=legend_font_size,
         labelcolor="linecolor",
     )
 

--- a/dingo/core/utils/plotting.py
+++ b/dingo/core/utils/plotting.py
@@ -12,7 +12,6 @@ def plot_corner_multi(
     weights=None,
     labels=None,
     filename: str = "corner.pdf",
-    legend_font_size: int = 50,
     **kwargs,
 ):
     """
@@ -29,10 +28,14 @@ def plot_corner_multi(
         Labels for the posteriors.
     filename : str
         Where to save samples.
+
+    Other Parameters
+    ----------------
+    truth_color : str
+        Color of the truth values. Defaults to black. 
     legend_font_size: int
         Font size used in legend. Defaults to 50.
-    **kwargs :
-        Forwarded to corner.corner.
+    Also contains additional parameters forwarded to corner.corner.
     """
     # Define plot properties
     cmap = "Dark2"
@@ -109,7 +112,7 @@ def plot_corner_multi(
     fig.legend(
         handles=handles,
         loc="upper right",
-        fontsize=legend_font_size,
+        fontsize=kwargs.get("legend_font_size", 50),
         labelcolor="linecolor",
     )
 

--- a/dingo/core/utils/plotting.py
+++ b/dingo/core/utils/plotting.py
@@ -45,7 +45,7 @@ def plot_corner_multi(
         "levels": [0.5, 0.9],
         "bins": 30,
     }
-    if "truths" in kwargs and "truth_color" not in kwargs:
+    if "truths" in kwargs and kwargs["truths"] is not None and "truth_color" not in kwargs:
         corner_params["truth_color"] = "black"
     corner_params.update(kwargs)
 
@@ -94,7 +94,7 @@ def plot_corner_multi(
         space = 1 / (4 * len(common_parameters))
         fig.subplots_adjust(wspace=space, hspace=space)
 
-    if "truths" in corner_params:
+    if "truths" in corner_params and corner_params["truths"] is not None:
         handles.append(
             plt.Line2D(
                 [],


### PR DESCRIPTION
This PR updates and adds some functionality of `result.plot_corner()`.

It addresses the following problems:
- Previously, the font size of the legend was fixed to 50 which was sufficient for a full 14 dimensional posterior plot. However, if only a few parameters are included via `parameters = ["chirp_mass", "mass_ratio"]`, the legend was so large that it overlapped completely with the corner plot.
- It was not possible to pass the truth values to the corner plot which is helpful for injections.
- So far, the `DINGO-IS` samples were not plotted when `weights` was not included in the parameters list. If the user wanted to only use e.g. `parameters = ["chirp_mass", "mass_ratio"]`, it would only plot the `DINGO` samples.

After this PR, the user can:
- specify the font size of the legend via `legend_font_size=...` and adjust it for a lower dimensional corner plot.
- visualize truth values via `truths=...` as well as the color `truth_color=...`.
- plot the `DINGO-IS` samples although weights are not specified as parameters.

Illustration of an example before the PR where the importance weighted samples are not shown due to the bug:
![image](https://github.com/dingo-gw/dingo/assets/116283499/84717249-52f0-4b46-bfbf-e2d20cb5f711)

How the plot looks after the PR (when specifying an appropriate font size for the legend):
![image](https://github.com/dingo-gw/dingo/assets/116283499/eaf9337d-9d37-4f3b-a9cb-cc6efdeb161f)
