### PR TITLE
Add fixed parameters in the GWSampler

### DIFF
--- a/dingo/core/result.py
+++ b/dingo/core/result.py
@@ -589,6 +589,7 @@ class Result(DingoDataset):
         parameters: list = None,
         filename: str = "corner.pdf",
         truths: dict = None,
+        include_fixed_parameters: bool = False,
         **kwargs,
     ):
         """
@@ -603,6 +604,8 @@ class Result(DingoDataset):
             Where to save samples.
         truths : dict
             Dictionary of truth values to include.
+        include_fixed_parameters : bool
+            Whether to plot parameters that have delta-function priors. (Default: False)
 
         Other Parameters
         ----------------
@@ -615,6 +618,9 @@ class Result(DingoDataset):
         theta = self._cleaned_samples()
         # delta_log_prob_target is not interesting so never plot it.
         theta = theta.drop(columns="delta_log_prob_target", errors="ignore")
+
+        if not include_fixed_parameters:
+            theta = theta.drop(columns=self.fixed_parameter_keys, errors="ignore")
 
         if "weights" in theta:
             weights = theta["weights"]
@@ -638,11 +644,7 @@ class Result(DingoDataset):
             )
         else:
             plot_corner_multi(
-                theta,
-                labels=["Dingo"],
-                filename=filename,
-                truths=truths,
-                **kwargs
+                theta, labels=["Dingo"], filename=filename, truths=truths, **kwargs
             )
 
     def plot_log_probs(self, filename="log_probs.png"):
@@ -710,7 +712,6 @@ class Result(DingoDataset):
 
 
 def check_equal_dict_of_arrays(a, b):
-
     if type(a) != type(b):
         return False
 


### PR DESCRIPTION
This adds the parameters that have delta-function priors when sampling. It is needed so that the sky rotation transform and importance sampling works when holding some parameters fixed.

Corner plotting is also updated with a new flag for whether to include these fixed parameters. Default is to not include them.

**This still needs to be tested.**