### PR TITLE
Update plot corner (additional changes)

### DIFF
--- a/dingo/core/result.py
+++ b/dingo/core/result.py
@@ -588,9 +588,8 @@ class Result(DingoDataset):
         self,
         parameters: list = None,
         filename: str = "corner.pdf",
-        legend_font_size: int = 50,
         truths: dict = None,
-        truth_color: str = None,
+        **kwargs,
     ):
         """
         Generate a corner plot of the samples.
@@ -602,12 +601,16 @@ class Result(DingoDataset):
             (Default: None)
         filename : str
             Where to save samples.
-        legend_font_size: int
-            Font size of the legend.
         truths : dict
             Dictionary of truth values to include.
-        truth_color: str
+
+        Other Parameters
+        ----------------
+        truth_color : str
             Color of the truth values.
+        legend_font_size: int
+            Font size of the legend.
+
         """
         theta = self._cleaned_samples()
         # delta_log_prob_target is not interesting so never plot it.
@@ -630,18 +633,16 @@ class Result(DingoDataset):
                 weights=[None, weights.to_numpy()],
                 labels=["Dingo", "Dingo-IS"],
                 filename=filename,
-                legend_font_size=legend_font_size,
                 truths=truths,
-                truth_color=truth_color,
+                **kwargs,
             )
         else:
             plot_corner_multi(
                 theta,
                 labels=["Dingo"],
                 filename=filename,
-                legend_font_size=legend_font_size,
                 truths=truths,
-                truth_color=truth_color,
+                **kwargs
             )
 
     def plot_log_probs(self, filename="log_probs.png"):

--- a/dingo/core/result.py
+++ b/dingo/core/result.py
@@ -621,8 +621,8 @@ class Result(DingoDataset):
         # User option to plot specific parameters.
         if parameters:
             theta = theta[parameters]
-            if truths is not None:
-                kwargs["truths"] = [truths.get(k) for k in theta.columns]
+        if truths is not None:
+            kwargs["truths"] = [truths.get(k) for k in theta.columns]
 
         if weights is not None:
             plot_corner_multi(

--- a/dingo/core/result.py
+++ b/dingo/core/result.py
@@ -588,6 +588,7 @@ class Result(DingoDataset):
         self,
         parameters: list = None,
         filename: str = "corner.pdf",
+        truths: dict = None,
         **kwargs,
     ):
         """
@@ -600,11 +601,11 @@ class Result(DingoDataset):
             (Default: None)
         filename : str
             Where to save samples.
+        truths : dict
+            Dictionary of truth values to include.
 
         Other Parameters
         ----------------
-        truths : dict
-            Dictionary of truth values to include.
         legend_font_size: int
             Font size of the legend.
 
@@ -620,8 +621,8 @@ class Result(DingoDataset):
         # User option to plot specific parameters.
         if parameters:
             theta = theta[parameters]
-            if "truths" in kwargs.keys():
-                kwargs["truths"] = [kwargs["truths"].get(k) for k in theta.columns]
+            if truths is not None:
+                kwargs["truths"] = [truths.get(k) for k in theta.columns]
 
         if weights is not None:
             plot_corner_multi(

--- a/dingo/core/result.py
+++ b/dingo/core/result.py
@@ -588,7 +588,6 @@ class Result(DingoDataset):
         self,
         parameters: list = None,
         filename: str = "corner.pdf",
-        truths: dict = None,
         **kwargs,
     ):
         """
@@ -601,13 +600,11 @@ class Result(DingoDataset):
             (Default: None)
         filename : str
             Where to save samples.
-        truths : dict
-            Dictionary of truth values to include.
 
         Other Parameters
         ----------------
-        truth_color : str
-            Color of the truth values.
+        truths : dict
+            Dictionary of truth values to include.
         legend_font_size: int
             Font size of the legend.
 
@@ -623,9 +620,8 @@ class Result(DingoDataset):
         # User option to plot specific parameters.
         if parameters:
             theta = theta[parameters]
-
-        if truths:
-            truths = [truths.get(k) for k in theta.columns]
+            if "truths" in kwargs.keys():
+                kwargs["truths"] = [kwargs["truths"].get(k) for k in theta.columns]
 
         if weights is not None:
             plot_corner_multi(
@@ -633,7 +629,6 @@ class Result(DingoDataset):
                 weights=[None, weights.to_numpy()],
                 labels=["Dingo", "Dingo-IS"],
                 filename=filename,
-                truths=truths,
                 **kwargs,
             )
         else:
@@ -641,7 +636,6 @@ class Result(DingoDataset):
                 theta,
                 labels=["Dingo"],
                 filename=filename,
-                truths=truths,
                 **kwargs
             )
 

--- a/dingo/core/result.py
+++ b/dingo/core/result.py
@@ -597,7 +597,6 @@ class Result(DingoDataset):
         parameters: list = None,
         filename: str = "corner.pdf",
         truths: dict = None,
-        include_fixed_parameters: bool = False,
         **kwargs,
     ):
         """
@@ -612,9 +611,6 @@ class Result(DingoDataset):
             Where to save samples.
         truths : dict
             Dictionary of truth values to include.
-        include_fixed_parameters : bool
-            Whether to plot parameters that have delta-function priors. (Default: False)
-
 
         Other Parameters
         ----------------
@@ -625,9 +621,8 @@ class Result(DingoDataset):
         theta = self._cleaned_samples()
         # delta_log_prob_target is not interesting so never plot it.
         theta = theta.drop(columns="delta_log_prob_target", errors="ignore")
-
-        if not include_fixed_parameters:
-            theta = theta.drop(columns=self.fixed_parameter_keys, errors="ignore")
+        # corner cannot handle fixed parameters
+        theta = theta.drop(columns=self.fixed_parameter_keys, errors="ignore")
 
         if "weights" in theta:
             weights = theta["weights"]

--- a/dingo/core/result.py
+++ b/dingo/core/result.py
@@ -584,7 +584,14 @@ class Result(DingoDataset):
 
         return self.samples.replace(-np.inf, np.nan).dropna(axis=0)
 
-    def plot_corner(self, parameters=None, filename="corner.pdf"):
+    def plot_corner(
+        self,
+        parameters: list = None,
+        filename: str = "corner.pdf",
+        legend_font_size: int = 50,
+        truths: dict = None,
+        truth_color: str = None,
+    ):
         """
         Generate a corner plot of the samples.
 
@@ -595,27 +602,46 @@ class Result(DingoDataset):
             (Default: None)
         filename : str
             Where to save samples.
+        legend_font_size: int
+            Font size of the legend.
+        truths : dict
+            Dictionary of truth values to include.
+        truth_color: str
+            Color of the truth values.
         """
         theta = self._cleaned_samples()
         # delta_log_prob_target is not interesting so never plot it.
         theta = theta.drop(columns="delta_log_prob_target", errors="ignore")
 
+        if "weights" in theta:
+            weights = theta["weights"]
+        else:
+            weights = None
         # User option to plot specific parameters.
         if parameters:
             theta = theta[parameters]
 
-        if "weights" in theta:
+        if truths:
+            truths = [truths.get(k) for k in theta.columns]
+
+        if weights is not None:
             plot_corner_multi(
                 [theta, theta],
-                weights=[None, theta["weights"].to_numpy()],
+                weights=[None, weights.to_numpy()],
                 labels=["Dingo", "Dingo-IS"],
                 filename=filename,
+                legend_font_size=legend_font_size,
+                truths=truths,
+                truth_color=truth_color,
             )
         else:
             plot_corner_multi(
                 theta,
-                labels="Dingo",
+                labels=["Dingo"],
                 filename=filename,
+                legend_font_size=legend_font_size,
+                truths=truths,
+                truth_color=truth_color,
             )
 
     def plot_log_probs(self, filename="log_probs.png"):

--- a/dingo/core/utils/plotting.py
+++ b/dingo/core/utils/plotting.py
@@ -31,8 +31,8 @@ def plot_corner_multi(
 
     Other Parameters
     ----------------
-    truth_color : str
-        Color of the truth values. Defaults to black. 
+    truths : list
+        Contains truth values for posterior in same order as samples.
     legend_font_size: int
         Font size used in legend. Defaults to 50.
     Also contains additional parameters forwarded to corner.corner.
@@ -48,8 +48,6 @@ def plot_corner_multi(
         "levels": [0.5, 0.9],
         "bins": 30,
     }
-    if "truths" in kwargs and kwargs["truths"] is not None and "truth_color" not in kwargs:
-        corner_params["truth_color"] = "black"
     corner_params.update(kwargs)
 
     serif_old = mpl.rcParams["font.family"]
@@ -96,18 +94,6 @@ def plot_corner_multi(
     else:
         space = 1 / (4 * len(common_parameters))
         fig.subplots_adjust(wspace=space, hspace=space)
-
-    if "truths" in corner_params and corner_params["truths"] is not None:
-        handles.append(
-            plt.Line2D(
-                [],
-                [],
-                color=corner_params["truth_color"],
-                label="Truth",
-                linewidth=5,
-                markersize=20,
-            )
-        )
 
     fig.legend(
         handles=handles,

--- a/dingo/core/utils/plotting.py
+++ b/dingo/core/utils/plotting.py
@@ -8,7 +8,12 @@ import pandas as pd
 
 
 def plot_corner_multi(
-    samples, weights=None, labels=None, filename="corner.pdf", **kwargs
+    samples,
+    weights=None,
+    labels=None,
+    filename: str = "corner.pdf",
+    legend_font_size: int = 50,
+    **kwargs,
 ):
     """
     Generate a corner plot for multiple posteriors.
@@ -24,6 +29,8 @@ def plot_corner_multi(
         Labels for the posteriors.
     filename : str
         Where to save samples.
+    legend_font_size: int
+        Font size used in legend. Defaults to 50.
     **kwargs :
         Forwarded to corner.corner.
     """
@@ -38,6 +45,8 @@ def plot_corner_multi(
         "levels": [0.5, 0.9],
         "bins": 30,
     }
+    if "truths" in kwargs and "truth_color" not in kwargs:
+        corner_params["truth_color"] = "black"
     corner_params.update(kwargs)
 
     serif_old = mpl.rcParams["font.family"]
@@ -72,7 +81,7 @@ def plot_corner_multi(
             color=color,
             no_fill_contours=True,
             fig=fig,
-            **corner_params
+            **corner_params,
         )
         handles.append(
             plt.Line2D([], [], color=color, label=l, linewidth=5, markersize=20)
@@ -85,10 +94,22 @@ def plot_corner_multi(
         space = 1 / (4 * len(common_parameters))
         fig.subplots_adjust(wspace=space, hspace=space)
 
+    if "truths" in corner_params:
+        handles.append(
+            plt.Line2D(
+                [],
+                [],
+                color=corner_params["truth_color"],
+                label="Truth",
+                linewidth=5,
+                markersize=20,
+            )
+        )
+
     fig.legend(
         handles=handles,
         loc="upper right",
-        fontsize=50,
+        fontsize=legend_font_size,
         labelcolor="linecolor",
     )
 

--- a/dingo/core/utils/plotting.py
+++ b/dingo/core/utils/plotting.py
@@ -12,7 +12,6 @@ def plot_corner_multi(
     weights=None,
     labels=None,
     filename: str = "corner.pdf",
-    legend_font_size: int = 50,
     **kwargs,
 ):
     """
@@ -29,10 +28,14 @@ def plot_corner_multi(
         Labels for the posteriors.
     filename : str
         Where to save samples.
+
+    Other Parameters
+    ----------------
+    truth_color : str
+        Color of the truth values. Defaults to black. 
     legend_font_size: int
         Font size used in legend. Defaults to 50.
-    **kwargs :
-        Forwarded to corner.corner.
+    Also contains additional parameters forwarded to corner.corner.
     """
     # Define plot properties
     cmap = "Dark2"
@@ -109,7 +112,7 @@ def plot_corner_multi(
     fig.legend(
         handles=handles,
         loc="upper right",
-        fontsize=legend_font_size,
+        fontsize=kwargs.get("legend_font_size", 50),
         labelcolor="linecolor",
     )
 

--- a/dingo/core/utils/plotting.py
+++ b/dingo/core/utils/plotting.py
@@ -45,7 +45,7 @@ def plot_corner_multi(
         "levels": [0.5, 0.9],
         "bins": 30,
     }
-    if "truths" in kwargs and "truth_color" not in kwargs:
+    if "truths" in kwargs and kwargs["truths"] is not None and "truth_color" not in kwargs:
         corner_params["truth_color"] = "black"
     corner_params.update(kwargs)
 
@@ -94,7 +94,7 @@ def plot_corner_multi(
         space = 1 / (4 * len(common_parameters))
         fig.subplots_adjust(wspace=space, hspace=space)
 
-    if "truths" in corner_params:
+    if "truths" in corner_params and corner_params["truths"] is not None:
         handles.append(
             plt.Line2D(
                 [],

--- a/dingo/core/utils/plotting.py
+++ b/dingo/core/utils/plotting.py
@@ -31,8 +31,6 @@ def plot_corner_multi(
 
     Other Parameters
     ----------------
-    truths : list
-        Contains truth values for posterior in same order as samples.
     legend_font_size: int
         Font size used in legend. Defaults to 50.
     Also contains additional parameters forwarded to corner.corner.


### PR DESCRIPTION
Upon discussion with Stephen, I changed how the truth values and truth color are passed to `result.plot_corner()` and `plot_corner_multi()`.

The reasoning behind this is the following:
- `truth_color` is included in the `**kwargs` and the description is removed since it is exactly a `corner` kwarg and does not get modified.
- `truths` is passed as a kwarg to `plot_corner_multi()`. There, `truths` needs to be a list with the values in exactly the same order as the values within `samples`. However, this order is specified within `result.plot_corner()` by the order of the `parameter` list. Therefore, we need to pass the truth values as a dictionary to `result.plot_corner()` and extract the order of parameters by replicating the order of `theta.columns`. The resulting list is added to kwargs and passed on to `plot_corner_multi()`.

I am not entirely sure whether this is the best way of handling the problem since it might be confusing why `truth_color` is handled as a kwarg in `result.plot_corner()` while `truths` is an explicit argument.

We can discuss this within this PR.