### PR TITLE
Removed bid argument from examples yaml files

### DIFF
--- a/examples/gnpe_model/train_settings.yaml
+++ b/examples/gnpe_model/train_settings.yaml
@@ -104,7 +104,6 @@ local:
   checkpoint_epochs: 10
   # Local settings related to condor, remove if not used on cluster
   condor:
-    bid: 100
     num_cpus: 16
     memory_cpus: 128000
     num_gpus: 1

--- a/examples/gnpe_model/train_settings_init.yaml
+++ b/examples/gnpe_model/train_settings_init.yaml
@@ -90,7 +90,6 @@ local:
     max_epochs_per_run: 500
   checkpoint_epochs: 10
   condor:
-    bid: 100
     num_cpus: 16
     memory_cpus: 128000
     num_gpus: 1

--- a/examples/npe_model/train_settings.yaml
+++ b/examples/npe_model/train_settings.yaml
@@ -97,7 +97,6 @@ local:
   checkpoint_epochs: 50
   # Local settings related to condor, remove if not used on cluster
   condor:
-    bid: 100
     num_cpus: 16
     memory_cpus: 128000
     num_gpus: 1


### PR DESCRIPTION
The bid argument is only useful for the MPI-IS cluster so removing it from the examples. 