### PR TITLE
FEAT: add argument to specify calibration correction direction

### DIFF
--- a/dingo/gw/transforms/detector_transforms.py
+++ b/dingo/gw/transforms/detector_transforms.py
@@ -254,7 +254,7 @@ class ApplyCalibrationUncertainty(object):
     is not perfectly calibrated, the observed waveform is not identical to the true
     waveform $h(f)$. Rather, it is assumed to have corrections of the form
 
-    $$h_{obs}(f) = h(f) * (1 + \delta A(f)) * \exp(i \delta \phi(f)),$$
+    $$h_{obs}(f) = h(f) * (1 + \delta A(f)) * \exp(i \delta \phi(f)) = h(f) * \alpha(f),$$
 
     where $\delta A(f)$ and $\delta \phi(f)$ are frequency-dependent amplitude and
     phase errors. Under the calibration model, these are parametrized with cubic
@@ -275,6 +275,7 @@ class ApplyCalibrationUncertainty(object):
     calibration envelope, and applies them to generate $N$ observed waveforms $\{h^n_{
     obs}(f)\}$. This is intended to be used for marginalizing over the calibration
     uncertainty when evaluating the likelihood for importance sampling.
+
     """
 
     def __init__(
@@ -284,6 +285,7 @@ class ApplyCalibrationUncertainty(object):
         calibration_envelope,
         num_calibration_curves,
         num_calibration_nodes,
+        correction_type="data",
     ):
         r"""
         Parameters
@@ -306,6 +308,20 @@ class ApplyCalibrationUncertainty(object):
             Monte Carlo estimate of the marginalized likelihood integral.
         num_calibration_nodes : int
             Number of log-spaced frequency nodes $f_i$ to use in defining the spline.
+        correction_type : str = "data"
+            It was discovered in Oct. 2024 that the calibration envelopes specified by
+            the detchar group were not being used correctly by PE codes. According to
+            the detchar group, envelopes are over $\eta$ which is defined as:
+            
+            $$
+            h_{obs}(f) = \frac{1}{\eta} * h(f).
+            $$
+            
+            Of course, $\frac{1}{\eta} = \alpha$. Previously, the envelopes were
+            being used as if $\eta = \alpha$ which is wrong. Therefore, there is
+            now an additional option where one can specify correction_type = "data"
+            if the calibration envelopes are over $\eta$ and correction_type = "template"
+            if the calibration envelopes are over $\alpha$.
         """
 
         self.ifo_list = ifo_list
@@ -340,6 +356,7 @@ class ApplyCalibrationUncertainty(object):
                     self.data_domain.f_max,
                     num_calibration_nodes,
                     ifo.name,
+                    correction_type=correction_type,
                 )
 
         else:

--- a/dingo/pipe/importance_sampling.py
+++ b/dingo/pipe/importance_sampling.py
@@ -86,6 +86,7 @@ class ImportanceSamplingInput(Input):
         self.spline_calibration_nodes = args.spline_calibration_nodes
         self.spline_calibration_envelope_dict = args.spline_calibration_envelope_dict
         self.spline_calibration_curves = args.spline_calibration_curves
+        self.calibration_correction_type = args.calibration_correction_type
 
         # # Marginalization
         # self.distance_marginalization = args.distance_marginalization
@@ -117,6 +118,7 @@ class ImportanceSamplingInput(Input):
                 "calibration_envelope": self.spline_calibration_envelope_dict,
                 "num_calibration_nodes": self.spline_calibration_nodes,
                 "num_calibration_curves": self.spline_calibration_curves,
+                "correction_type": self.calibration_correction_type,
             }
         elif self.calibration_model == None:
             return None

--- a/dingo/pipe/parser.py
+++ b/dingo/pipe/parser.py
@@ -101,10 +101,11 @@ def create_parser(top_level=True):
     )
     calibration_parser.add(
         "--calibration-correction-type",
-        type=str,
+        type=nonestr,
         default="data",
-        help=("Number of calibration curves to use in marginalizing over calibration "
-              "uncertainty"),
+        help=("Type of calibration correction: can be either `data` or `template`."
+        " See https://bilby-dev.github.io/bilby/api/bilby.gw.detector.calibration.html "
+        "for more information.")
     )
     #
     # calibration_parser.add(

--- a/dingo/pipe/parser.py
+++ b/dingo/pipe/parser.py
@@ -99,6 +99,13 @@ def create_parser(top_level=True):
         help=("Number of calibration curves to use in marginalizing over calibration "
               "uncertainty"),
     )
+    calibration_parser.add(
+        "--calibration-correction-type",
+        type=str,
+        default="data",
+        help=("Number of calibration curves to use in marginalizing over calibration "
+              "uncertainty"),
+    )
     #
     # calibration_parser.add(
     #     "--spline-calibration-amplitude-uncertainty-dict",

--- a/dingo/pipe/parser.py
+++ b/dingo/pipe/parser.py
@@ -79,6 +79,15 @@ def create_parser(top_level=True):
     )
 
     calibration_parser.add(
+        "--calibration-correction-type",
+        type=nonestr,
+        default="data",
+        help=("Type of calibration correction: can be either `data` or `template`."
+        " See https://bilby-dev.github.io/bilby/api/bilby.gw.detector.calibration.html "
+        "for more information.")
+    )
+
+    calibration_parser.add(
         "--spline-calibration-envelope-dict",
         type=nonestr,
         default=None,
@@ -98,14 +107,6 @@ def create_parser(top_level=True):
         default=1000,
         help=("Number of calibration curves to use in marginalizing over calibration "
               "uncertainty"),
-    )
-    calibration_parser.add(
-        "--calibration-correction-type",
-        type=nonestr,
-        default="data",
-        help=("Type of calibration correction: can be either `data` or `template`."
-        " See https://bilby-dev.github.io/bilby/api/bilby.gw.detector.calibration.html "
-        "for more information.")
     )
     #
     # calibration_parser.add(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ classifiers = [
 dependencies = [
     "astropy",
     "bilby",
-    "bilby_pipe==1.4",
+    "bilby_pipe==1.4.2",
     "configargparse",
     "corner",
     "glasflow",


### PR DESCRIPTION
Following this bilby PR https://github.com/bilby-dev/bilby/pull/47 we can update the ApplyCalibrationUncertainty transform and dingo_pipe whether the calibration envelope is on $\eta$ or $\alpha = 1 / \eta$. Here $d = \alpha h + n$. 