### PR TITLE
Fix train_unconditional_density_estimator, dingo_pipe sampling

### DIFF
--- a/dingo/core/density/unconditional_density_estimation.py
+++ b/dingo/core/density/unconditional_density_estimation.py
@@ -71,8 +71,8 @@ def train_unconditional_density_estimator(
     samples_torch = torch.from_numpy((samples - mean) / std).float()
 
     # set up density estimation network
-    settings["model"]["input_dim"] = num_params
-    settings["model"]["context_dim"] = None
+    settings["model"]["posterior_kwargs"]["input_dim"] = num_params
+    settings["model"]["posterior_kwargs"]["context_dim"] = None
     # TODO: Allow for other types of density estimators (e.g., flow matching).
     model = NormalizingFlowPosteriorModel(
         metadata={"train_settings": settings, "base": copy.deepcopy(result.metadata)},

--- a/dingo/pipe/sampling.py
+++ b/dingo/pipe/sampling.py
@@ -156,7 +156,9 @@ class SamplingInput(Input):
         if len(self.detectors) == 1:
             model_settings = self._density_recovery_settings["nde_settings"]["model"]
             if model_settings["posterior_model_type"] == "normalizing_flow":
-                base_transform_kwargs = model_settings["base_transform_kwargs"]
+                base_transform_kwargs = model_settings["posterior_kwargs"][
+                    "base_transform_kwargs"
+                ]
                 if base_transform_kwargs["base_transform_type"] == "rq-coupling":
                     logger.info(
                         "Using autoregressive transform for density estimator since there is only one GNPE proxy "


### PR DESCRIPTION
Update specification of certain model settings (e.g., input_dim) to lie under posterior_kwargs in the model config. This is to reflect the new format expected by the new PosteriorModel classes.