### PR TITLE
Fix bugs related to early stopping and wandb

### DIFF
--- a/dingo/core/posterior_models/base_model.py
+++ b/dingo/core/posterior_models/base_model.py
@@ -2,6 +2,7 @@
 This module contains the abstract base class for representing posterior models,
 as well as functions for training and testing across an epoch.
 """
+
 from abc import abstractmethod, ABC
 import os
 from os.path import join
@@ -451,7 +452,13 @@ class BasePosteriorModel(ABC):
                         print("wandb not installed. Skipping logging to wandb.")
 
                 if early_stopping is not None:
-                    is_best_model = early_stopping(test_loss)
+                    # Whether to use train or test loss
+                    early_stopping_loss = (
+                        test_loss
+                        if early_stopping.metric == "validation"
+                        else train_loss
+                    )
+                    is_best_model = early_stopping(early_stopping_loss)
                     if is_best_model:
                         self.save_model(
                             join(train_dir, "best_model.pt"), save_training_info=False

--- a/dingo/core/utils/trainutils.py
+++ b/dingo/core/utils/trainutils.py
@@ -32,7 +32,13 @@ class EarlyStopping:
     early stopping occurs.
     """
 
-    def __init__(self, patience: int = 5, verbose: bool = False, delta: float = 0.0, metric: Literal["training", "validation"]="validation"):
+    def __init__(
+        self,
+        patience: int = 5,
+        verbose: bool = False,
+        delta: float = 0.0,
+        metric: Literal["training", "validation"] = "validation",
+    ):
         """
         Parameters
         ----------
@@ -42,6 +48,8 @@ class EarlyStopping:
             Whether to print counter increments.
         delta: float = 0.0
             Amount by which loss must decrease in patience epochs.
+        metric: Literal["training", "validation"]
+            Whether to use the training loss to determine early stopping ("training") or the test loss ("validation")
         """
         self.patience = patience
         self.verbose = verbose
@@ -51,7 +59,9 @@ class EarlyStopping:
         self.val_loss_min = np.Inf
         self.delta = delta
         if metric not in ["training", "validation"]:
-            raise ValueError("Early Stopping metric must be 'training' or 'validation'.")
+            raise ValueError(
+                "Early Stopping metric must be 'training' or 'validation'."
+            )
         self.metric = metric
 
     def __call__(self, val_loss: float):

--- a/dingo/gw/training/train_pipeline_condor.py
+++ b/dingo/gw/training/train_pipeline_condor.py
@@ -19,6 +19,8 @@ def create_submission_file(train_dir, condor_settings, filename="submission_file
     :return:
     """
     lines = []
+    # getenv required for GPU training because wandb needs $HOME to be defined
+    lines.append(f"getenv = True\n")
     lines.append(f'executable = {condor_settings["executable"]}\n')
     lines.append(f'request_cpus = {condor_settings["num_cpus"]}\n')
     lines.append(f'request_memory = {condor_settings["memory_cpus"]}\n')
@@ -27,7 +29,7 @@ def create_submission_file(train_dir, condor_settings, filename="submission_file
         f"requirements = TARGET.CUDAGlobalMemoryMb > "
         f'{condor_settings["memory_gpus"]}\n\n'
     )
-    lines.append(f'arguments = \"{condor_settings["arguments"]}\"\n')
+    lines.append(f'arguments = "{condor_settings["arguments"]}"\n')
     lines.append(f'error = {join(train_dir, "info.err")}\n')
     lines.append(f'output = {join(train_dir, "info.out")}\n')
     lines.append(f'log = {join(train_dir, "info.log")}\n')
@@ -127,7 +129,9 @@ def train_condor():
         #
 
         if complete:
-            print(f"Training complete, job will not be resubmitted. Executing exit command: {args.exit_command}.")
+            print(
+                f"Training complete, job will not be resubmitted. Executing exit command: {args.exit_command}."
+            )
             if args.exit_command:
                 os.system(args.exit_command)
             sys.exit()


### PR DESCRIPTION
This PR fixes two small bugs:
1. The argument `metric` of `EarlyStopping` does not have an effect at the moment since it is not used in the code after [initialization](https://github.com/dingo-gw/dingo-development/blob/204e43359d74fa817cf17a657c54bc52e20e5451/dingo/core/utils/trainutils.py#L55). Since it is mentioned in the example train settings files [(for example here)](https://github.com/dingo-gw/dingo/blob/11c8269aa8a76fcd51aad430822d8c8edc91d1e3/examples/fmpe_model/train_settings.yaml#L96), this might give a wrong impression to users.
A simple check for `early_stopping.metric` [here](https://github.com/dingo-gw/dingo/commit/ca79cbde9e59187f18a29db223dc411a2ef117b8#diff-e4df0a069e94766d19de6ff0aa66ff79d349e278b7a519d696e7c4c715df308bR455) which determines whether the training or test loss is used to check for early stopping resolves this issue.
2. `wandb` can crash the training on an htcondor cluster, because `$HOME` is often not automatically defined in a submitted job. This is detrimental because the `.netrc` file (which specifies the `wandb` user credentials) is located there. Without the user credentials, `wandb` can't log correctly and it crashes the job.
This is solved by adding the line `getenv = True` to the submission file.