### PR TITLE
Fix fmpe bug related to the cache

### DIFF
--- a/dingo/core/nn/cfnets.py
+++ b/dingo/core/nn/cfnets.py
@@ -120,7 +120,7 @@ class ContinuousFlow(nn.Module):
 
         # embed context (self.context_embedding_net might just be identity)
         if not self.use_cache:
-            context_embedding = self.context_embedding_net(*self._cached_context)
+            context_embedding = self.context_embedding_net(*context)
 
         else:
             self._update_cached_context(*context)


### PR DESCRIPTION
Fix for this issue: https://github.com/dingo-gw/dingo/issues/277

I verified that training is now running successfully with a toy example.