### PR TITLE
fixed path issue in test_waveform_dataset.py

### DIFF
--- a/dingo/gw/dataset/generate_dataset.py
+++ b/dingo/gw/dataset/generate_dataset.py
@@ -1,26 +1,27 @@
+import argparse
 import copy
 import textwrap
-import yaml
-import argparse
 from multiprocessing import Pool
+from pathlib import Path
+from typing import Dict, Tuple
 
 import numpy as np
 import pandas as pd
-from typing import Tuple, Dict
+import yaml
+from bilby.gw.prior import BBHPriorDict
 from threadpoolctl import threadpool_limits
 from torchvision.transforms import Compose
-from bilby.gw.prior import BBHPriorDict
 
 from dingo.gw.dataset.waveform_dataset import WaveformDataset
-from dingo.gw.prior import build_prior_with_defaults
 from dingo.gw.domains import build_domain
+from dingo.gw.prior import build_prior_with_defaults
+from dingo.gw.SVD import ApplySVD, SVDBasis
 from dingo.gw.transforms import WhitenFixedASD
 from dingo.gw.waveform_generator import (
-    WaveformGenerator,
     NewInterfaceWaveformGenerator,
+    WaveformGenerator,
     generate_waveforms_parallel,
 )
-from dingo.gw.SVD import SVDBasis, ApplySVD
 
 
 def generate_parameters_and_polarizations(
@@ -274,15 +275,28 @@ def parse_args():
     return parser.parse_args()
 
 
-def main():
-    args = parse_args()
+def _generate_dataset_main(
+    settings_file: str, out_file: str, num_processes: int
+) -> None:
 
+    if not Path(settings_file).is_file():
+        raise FileNotFoundError(f"dataset generation, failed to find {settings_file}")
+    if not Path(out_file).parent.is_dir():
+        raise FileNotFoundError(
+            f"dataset generation: can not create {out_file}: "
+            f"{Path(out_file).parent} does not exist"
+        )
     # Load settings
-    with open(args.settings_file, "r") as f:
+    with open(settings_file, "r") as f:
         settings = yaml.safe_load(f)
 
-    dataset = generate_dataset(settings, args.num_processes)
-    dataset.to_file(args.out_file)
+    dataset = generate_dataset(settings, num_processes)
+    dataset.to_file(str(out_file))
+
+
+def main() -> None:
+    args = parse_args()
+    _generate_dataset_main(args.settings_file, args.out_file, args.num_processes)
 
 
 if __name__ == "__main__":

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,6 +60,10 @@ namespaces = false
 [tool.setuptools_scm]
 write_to = "dingo/_version.py"
 
+[tool.pytest.ini_options]
+markers = [
+    "slow: marks tests as slow",
+]
 
 [project.urls]
 homepage = "https://github.com/dingo-gw/dingo"

--- a/tests/gw/test_waveform_dataset.py
+++ b/tests/gw/test_waveform_dataset.py
@@ -58,7 +58,9 @@ def temp_dir() -> Generator[Path, None, None]:
     """
     Fixture to provide a temporary directory path using pathlib.Path.
 
-    :return: A pathlib.Path object pointing to the temporary directory.
+    Returns
+    -------
+    A pathlib.Path object pointing to the temporary directory.
     """
     with tempfile.TemporaryDirectory() as tmpdirname:
         yield Path(tmpdirname)
@@ -86,8 +88,9 @@ def generate_waveform_dataset_small(temp_dir: Path) -> Path:
     return path
 
 
-# @pytest.mark.slow
+@pytest.mark.slow
 def test_load_waveform_dataset(generate_waveform_dataset_small):
+
     wfd_path = generate_waveform_dataset_small
 
     path = f"{wfd_path}/waveform_dataset.hdf5"
@@ -127,7 +130,9 @@ def test_load_waveform_dataset(generate_waveform_dataset_small):
     # check that truncation works as intended when setting new range
     f_min_new = 20
     f_max_new = 100
-    wd2 = WaveformDataset(path, domain_update={"f_min": f_min_new, "f_max": f_max_new})
+    wd2 = WaveformDataset(
+        path, domain_update={"f_min": f_min_new, "f_max": f_max_new}
+    )
     assert len(wd2.domain) == len(wd2.domain())
     # check that new domain settings are correctly adapted
     assert wd2.domain.f_min == f_min_new
@@ -136,7 +141,9 @@ def test_load_waveform_dataset(generate_waveform_dataset_small):
     # check that truncation works as intended
     for pol in ["h_cross", "h_plus"]:
         # f_min_new to f_max_new check
-        a = el["waveform"][pol][int(f_min_new / delta_f) : int(f_max_new / delta_f) + 1]
+        a = el["waveform"][pol][
+            int(f_min_new / delta_f) : int(f_max_new / delta_f) + 1
+        ]
         b = wd2[0]["waveform"][pol][int(f_min_new / delta_f) :]
         scale_factor = np.max(np.abs(a))
         assert len(a) == f_max_new / delta_f + 1 - f_min_new / delta_f
@@ -144,8 +151,12 @@ def test_load_waveform_dataset(generate_waveform_dataset_small):
         assert not np.allclose(b / scale_factor, np.roll(a, 1) / scale_factor)
 
         # f_min to f_min_new check
-        a = el["waveform"][pol][int(f_min / delta_f) : int(f_min_new / delta_f)]
-        b = wd2[0]["waveform"][pol][int(f_min / delta_f) : int(f_min_new / delta_f)]
+        a = el["waveform"][pol][
+            int(f_min / delta_f) : int(f_min_new / delta_f)
+        ]
+        b = wd2[0]["waveform"][pol][
+            int(f_min / delta_f) : int(f_min_new / delta_f)
+        ]
         assert not np.allclose(b / scale_factor, a / scale_factor)
 
         # below f_min_new check

--- a/tests/gw/test_waveform_dataset.py
+++ b/tests/gw/test_waveform_dataset.py
@@ -1,12 +1,16 @@
 import os
+import tempfile
 import uuid
+from pathlib import Path
+from typing import Generator
 
 import numpy as np
 import pytest
 
-from dingo.gw.domains import Domain
-from dingo.gw.dataset.waveform_dataset import WaveformDataset
+from dingo.gw.dataset.generate_dataset import _generate_dataset_main
 from dingo.gw.dataset.generate_dataset_dag import create_args_string
+from dingo.gw.dataset.waveform_dataset import WaveformDataset
+from dingo.gw.domains import Domain
 
 SETTINGS_YAML_SMALL = """\
 # settings for domain of waveforms
@@ -50,67 +54,53 @@ compression:
 
 
 @pytest.fixture
-def generate_waveform_dataset_small(venv_dir='venv'):
+def temp_dir() -> Generator[Path, None, None]:
+    """
+    Fixture to provide a temporary directory path using pathlib.Path.
+
+    :return: A pathlib.Path object pointing to the temporary directory.
+    """
+    with tempfile.TemporaryDirectory() as tmpdirname:
+        yield Path(tmpdirname)
+
+
+@pytest.fixture
+def generate_waveform_dataset_small(temp_dir: Path) -> Path:
     """
     Create a small waveform dataset on-the-fly
     in a temporary directory.
-
-    venv_dir:
-        The name of the folder that contains the dingo
-        virtual environment relative to the 'dingo-devel' root.
     """
-    # Figure out the path to the 'dingo-devel' root directory
-    # s = os.getcwd()
-    # root = s.split('dingo-devel')[0]  # + 'dingo-devel'
-    # venv_path = os.path.join(root, venv_dir)
-    # generate_waveform_path = os.path.join(venv_path, 'bin/dingo_generate_waveforms')
 
     # Create temp directory and settings file
-    path = os.path.join('./tmp_test', str(uuid.uuid4()))
-    os.makedirs(path, exist_ok=True)
-    with open(os.path.join(path, 'settings.yaml'), 'w') as fp:
+    path = temp_dir / "tmp_test" / str(uuid.uuid4())
+    path.mkdir(parents=True)
+    settings_path = path / "settings.yaml"
+    out_file = path / "waveform_dataset.hdf5"
+    num_processes = 4
+
+    with open(settings_path, "w") as fp:
         fp.writelines(SETTINGS_YAML_SMALL)
 
-    # Mock up command line arguments for script
-    args_in = {'settings_file': os.path.join(path, 'settings.yaml'),
-               'out_file': os.path.join(path, 'waveform_dataset.hdf5'),
-               'num_processes': '4'}
-    args_string = create_args_string(args_in)
-    res = os.system('dingo_generate_dataset ' + args_string)
-    if not os.WIFEXITED(res):
-        raise RuntimeError(f'dingo_generate_waveforms returned a '
-                           f'nonzero exit code: {res}')
-
-    # args = parse_args(args_in)
-    # out_script = './waveform_generation_script.sh'
-    # if os.path.exists(out_script):
-    #     os.remove(out_script)
-    # generate_workflow(args)
-    #
-    # # Now execute the generated workflow
-    # os.chmod(out_script, stat.S_IREAD | stat.S_IWRITE | stat.S_IXUSR)
-    # res = os.system(f'{out_script} > ./waveform_generation_script.log 2>&1')
-    # if not os.WIFEXITED(res):
-    #     raise RuntimeError(f'waveform_generation_script.sh returned a '
-    #                        f'nonzero exit code: {res}')
+    _generate_dataset_main(str(settings_path), str(out_file), num_processes)
 
     return path
 
-@pytest.mark.slow
+
+# @pytest.mark.slow
 def test_load_waveform_dataset(generate_waveform_dataset_small):
     wfd_path = generate_waveform_dataset_small
 
-    path = f'{wfd_path}/waveform_dataset.hdf5'
-    wd = WaveformDataset(file_name=path, precision='single')
+    path = f"{wfd_path}/waveform_dataset.hdf5"
+    wd = WaveformDataset(file_name=path, precision="single")
 
     assert len(wd) > 0
     el = wd[0]
     assert isinstance(el, dict)
-    assert set(el.keys()) == {'parameters', 'waveform'}
-    assert isinstance(el['parameters'], dict)
-    assert isinstance(el['waveform'], dict)
-    assert isinstance(el['waveform']['h_plus'], np.ndarray)
-    assert isinstance(el['waveform']['h_cross'], np.ndarray)
+    assert set(el.keys()) == {"parameters", "waveform"}
+    assert isinstance(el["parameters"], dict)
+    assert isinstance(el["waveform"], dict)
+    assert isinstance(el["waveform"]["h_plus"], np.ndarray)
+    assert isinstance(el["waveform"]["h_cross"], np.ndarray)
 
     # Check the associated domain
     assert len(wd.domain) > 0
@@ -118,11 +108,14 @@ def test_load_waveform_dataset(generate_waveform_dataset_small):
     assert isinstance(wd.domain.domain_dict, dict)
 
     # Check the associated data settings
-    data_settings_keys = {'domain', 'waveform_generator',
-                          'intrinsic_prior', 'num_samples',
-                          'compression'}
+    data_settings_keys = {
+        "domain",
+        "waveform_generator",
+        "intrinsic_prior",
+        "num_samples",
+        "compression",
+    }
     assert set(wd.settings.keys()) == data_settings_keys
-
 
     """Check truncation of wd. Ideally, this should be an individual test, 
     but since the setup takes so long it is added here."""
@@ -134,28 +127,28 @@ def test_load_waveform_dataset(generate_waveform_dataset_small):
     # check that truncation works as intended when setting new range
     f_min_new = 20
     f_max_new = 100
-    wd2 = WaveformDataset(path, domain_update={'f_min': f_min_new, 'f_max': f_max_new})
+    wd2 = WaveformDataset(path, domain_update={"f_min": f_min_new, "f_max": f_max_new})
     assert len(wd2.domain) == len(wd2.domain())
     # check that new domain settings are correctly adapted
     assert wd2.domain.f_min == f_min_new
     assert wd2.domain.f_max == f_max_new
     assert wd2.domain._delta_f == wd.domain._delta_f
     # check that truncation works as intended
-    for pol in ['h_cross', 'h_plus']:
+    for pol in ["h_cross", "h_plus"]:
         # f_min_new to f_max_new check
-        a = el['waveform'][pol][int(f_min_new/delta_f):int(f_max_new/delta_f)+1]
-        b = wd2[0]['waveform'][pol][int(f_min_new/delta_f):]
+        a = el["waveform"][pol][int(f_min_new / delta_f) : int(f_max_new / delta_f) + 1]
+        b = wd2[0]["waveform"][pol][int(f_min_new / delta_f) :]
         scale_factor = np.max(np.abs(a))
         assert len(a) == f_max_new / delta_f + 1 - f_min_new / delta_f
         assert np.allclose(b / scale_factor, a / scale_factor)
         assert not np.allclose(b / scale_factor, np.roll(a, 1) / scale_factor)
 
         # f_min to f_min_new check
-        a = el['waveform'][pol][int(f_min / delta_f):int(f_min_new / delta_f)]
-        b = wd2[0]['waveform'][pol][int(f_min / delta_f):int(f_min_new / delta_f)]
+        a = el["waveform"][pol][int(f_min / delta_f) : int(f_min_new / delta_f)]
+        b = wd2[0]["waveform"][pol][int(f_min / delta_f) : int(f_min_new / delta_f)]
         assert not np.allclose(b / scale_factor, a / scale_factor)
 
         # below f_min_new check
-        assert np.all(wd2[0]['waveform'][pol][:int(f_min_new)] == 0.0)
+        assert np.all(wd2[0]["waveform"][pol][: int(f_min_new)] == 0.0)
     assert len(wd2.domain) == f_max_new / delta_f + 1
     assert len(wd2.domain) == len(wd2.domain())


### PR DESCRIPTION
## about

- test_waveform_dataset was failing because it could not find the path to the settings file

## fix

- refactor the test to use the tempfile package

## other

- refactored a bit the test to call a function rather than the `dingo_generate_dataset` executable
- black was called automatically on my IDE ... - - ; (we should find an agreement on formatting ?)

## warning

- The test still does not pass, it now crashes with a SegmentationFault (at this line: https://github.com/dingo-gw/dingo/blob/main/dingo/gw/SVD.py#L51)
- Other tests do not pass (unrelated to this PR)

## note

Because of the black reformatting, it can be hard to see the significant changes. I added comment on these changes. Everything else is just formatting.