### PR TITLE
forcing scipy to 1.13.1

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -34,7 +34,7 @@ jobs:
           pytest --junit-xml=pytest-report.xml tests/
 
       - name: Upload Pytest Report
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: pytest-report.xml
           path: pytest-report.xml

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,7 @@ dependencies = [
     "pyyaml",
     "requests",
     "scikit-learn",
-    "scipy",
+    "scipy==1.13.1",
     "threadpoolctl",
     "torch",
     "torchdiffeq",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,7 @@ dependencies = [
     "pyyaml",
     "requests",
     "scikit-learn",
-    "scipy<=1.13.1",
+    "scipy==1.13.1",
     "threadpoolctl",
     "torch",
     "torchdiffeq",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,7 @@ dependencies = [
     "pyyaml",
     "requests",
     "scikit-learn",
-    "scipy==1.13.1",
+    "scipy<=1.13.1",
     "threadpoolctl",
     "torch",
     "torchdiffeq",


### PR DESCRIPTION
Newer versions of scipy (e.g. 1.14.1) result in test_waveform_dataset.py crashing (segmentation fault).

The crash happens at this line:

https://github.com/dingo-gw/dingo/blob/main/dingo/gw/SVD.py#L51

(when sklearn.utils.extmath.randomized_svd is called).

This pull request set pyproject.toml to install scipy 1.13.1.
