### PR TITLE
using torch loading with fallback

### DIFF
--- a/compatibility/remove_domain_window_factor.py
+++ b/compatibility/remove_domain_window_factor.py
@@ -2,10 +2,12 @@ import argparse
 import ast
 import textwrap
 from pathlib import Path
+
 import h5py
 import torch
 
 from dingo.core.utils.backward_compatibility import torch_load_with_fallback
+
 
 def main():
 
@@ -35,7 +37,7 @@ def main():
                 print("Dataset is already in correct format.")
 
     elif path.suffix == ".pt":
-        d = torch_load_with_fallback(args.checkpoint)
+        d, _ = torch_load_with_fallback(args.checkpoint)
 
         try:
             del d["metadata"]["dataset_settings"]["domain"]["window_factor"]

--- a/compatibility/remove_domain_window_factor.py
+++ b/compatibility/remove_domain_window_factor.py
@@ -5,6 +5,7 @@ from pathlib import Path
 import h5py
 import torch
 
+from dingo.core.utils.backward_compatibility import torch_load_with_fallback
 
 def main():
 
@@ -34,10 +35,7 @@ def main():
                 print("Dataset is already in correct format.")
 
     elif path.suffix == ".pt":
-        if torch.cuda.is_available():
-            d = torch.load(path)
-        else:
-            d = torch.load(path, map_location=torch.device("cpu"))
+        d = torch_load_with_fallback(args.checkpoint)
 
         try:
             del d["metadata"]["dataset_settings"]["domain"]["window_factor"]

--- a/compatibility/update_model_input_dims.py
+++ b/compatibility/update_model_input_dims.py
@@ -1,7 +1,9 @@
-import torch
 import argparse
-from dingo.gw.result import Result
+
+import torch
+
 from dingo.core.utils.backward_compatibility import torch_load_with_fallback
+from dingo.gw.result import Result
 
 """
 2. March 2023: Previously, we stored the input_dim of the embedding net as a tuple, 
@@ -53,7 +55,7 @@ def main():
 
     if args.checkpoint is not None:
         print(f"Updating model {args.checkpoint}.")
-        d = torch_load_with_fallback(args.checkpoint)
+        d, _ = torch_load_with_fallback(args.checkpoint)
 
         d["model_kwargs"]["embedding_net_kwargs"]["input_dims"] = list(
             d["model_kwargs"]["embedding_net_kwargs"]["input_dims"]

--- a/compatibility/update_model_input_dims.py
+++ b/compatibility/update_model_input_dims.py
@@ -1,6 +1,7 @@
 import torch
 import argparse
 from dingo.gw.result import Result
+from dingo.core.utils.backward_compatibility import torch_load_with_fallback
 
 """
 2. March 2023: Previously, we stored the input_dim of the embedding net as a tuple, 
@@ -52,13 +53,7 @@ def main():
 
     if args.checkpoint is not None:
         print(f"Updating model {args.checkpoint}.")
-        # Typically training is done on the GPU, so the model could be saved on a GPU
-        # device. Since this routine may be run on a CPU machine, allow for a remap of the
-        # torch tensors.
-        if torch.cuda.is_available():
-            d = torch.load(args.checkpoint)
-        else:
-            d = torch.load(args.checkpoint, map_location=torch.device("cpu"))
+        d = torch_load_with_fallback(args.checkpoint)
 
         d["model_kwargs"]["embedding_net_kwargs"]["input_dims"] = list(
             d["model_kwargs"]["embedding_net_kwargs"]["input_dims"]

--- a/compatibility/update_model_metadata.py
+++ b/compatibility/update_model_metadata.py
@@ -1,6 +1,6 @@
 import torch
 import argparse
-
+from dingo.core.utils.backward_compatibility import torch_load_with_fallback
 
 def parse_args():
 
@@ -14,13 +14,7 @@ def parse_args():
 def main():
     args = parse_args()
 
-    # Typically training is done on the GPU, so the model could be saved on a GPU
-    # device. Since this routine may be run on a CPU machine, allow for a remap of the
-    # torch tensors.
-    if torch.cuda.is_available():
-        d = torch.load(args.checkpoint)
-    else:
-        d = torch.load(args.checkpoint, map_location=torch.device('cpu'))
+    d = torch_load_with_fallback(args.checkpoint)
 
     # Figure out type of value
     try:

--- a/compatibility/update_model_metadata.py
+++ b/compatibility/update_model_metadata.py
@@ -1,20 +1,23 @@
-import torch
 import argparse
+
+import torch
+
 from dingo.core.utils.backward_compatibility import torch_load_with_fallback
+
 
 def parse_args():
 
     parser = argparse.ArgumentParser()
-    parser.add_argument('--checkpoint', type=str, required=True)
-    parser.add_argument('--key', type=str, required=True, nargs='+')
-    parser.add_argument('--value', type=str, required=True)
+    parser.add_argument("--checkpoint", type=str, required=True)
+    parser.add_argument("--key", type=str, required=True, nargs="+")
+    parser.add_argument("--value", type=str, required=True)
     return parser.parse_args()
 
 
 def main():
     args = parse_args()
 
-    d = torch_load_with_fallback(args.checkpoint)
+    d, _ = torch_load_with_fallback(args.checkpoint)
 
     # Figure out type of value
     try:
@@ -25,7 +28,7 @@ def main():
         except ValueError:
             value = args.value
 
-    settings = d['metadata']
+    settings = d["metadata"]
     for i in args.key[:-1]:
         settings = settings[i]
     settings[args.key[-1]] = value

--- a/compatibility/update_saved_model_for_train_stages.py
+++ b/compatibility/update_saved_model_for_train_stages.py
@@ -1,81 +1,89 @@
+import argparse
+import ast
 import os
 
-import torch
-import argparse
-import yaml
 import h5py
-import ast
+import torch
+import yaml
 
 from dingo.core.utils.backward_compatibility import torch_load_with_fallback
+
 
 def parse_args():
 
     parser = argparse.ArgumentParser()
-    parser.add_argument('--checkpoint', type=str, required=True)
-    parser.add_argument('--settings_file', type=str, required=True)
-    parser.add_argument('--out_file', type=str, required=True)
-    parser.add_argument('--train_dir', type=str, required=True)
+    parser.add_argument("--checkpoint", type=str, required=True)
+    parser.add_argument("--settings_file", type=str, required=True)
+    parser.add_argument("--out_file", type=str, required=True)
+    parser.add_argument("--train_dir", type=str, required=True)
     return parser.parse_args()
 
 
 def main():
     args = parse_args()
 
-    with open(args.settings_file, 'r') as f:
+    with open(args.settings_file, "r") as f:
         train_settings = yaml.safe_load(f)
 
-    d = torch_load_with_fallback(args.checkpoint)
+    d, _ = torch_load_with_fallback(args.checkpoint)
 
     data = {
-        'waveform_dataset_path': train_settings['waveform_dataset_path'],
-        'train_fraction': train_settings['train_settings']['train_fraction'],
-        'conditioning': train_settings['data_conditioning'],
+        "waveform_dataset_path": train_settings["waveform_dataset_path"],
+        "train_fraction": train_settings["train_settings"]["train_fraction"],
+        "conditioning": train_settings["data_conditioning"],
     }
-    data.update(train_settings['transform_settings'])
+    data.update(train_settings["transform_settings"])
 
-    model = d['model_kwargs']
-    model['type'] = 'nsf+embedding'
-    model['embedding_net_kwargs']['svd'] = {
-        'size': model['embedding_net_kwargs']['n_rb'],
-    },
-    del model['embedding_net_kwargs']['n_rb']
-    del model['embedding_net_kwargs']['V_rb_list']
+    model = d["model_kwargs"]
+    model["type"] = "nsf+embedding"
+    model["embedding_net_kwargs"]["svd"] = (
+        {
+            "size": model["embedding_net_kwargs"]["n_rb"],
+        },
+    )
+    del model["embedding_net_kwargs"]["n_rb"]
+    del model["embedding_net_kwargs"]["V_rb_list"]
 
-    training = {'stage_0': {
-        'epochs': train_settings['train_settings']['runtime_limits']['max_epochs_total'],
-        'asd_dataset_path': train_settings['asd_dataset_path'],
-        'freeze_rb_layer': train_settings['train_settings']['freeze_rb_layer'],
-        'optimizer': train_settings['train_settings']['optimizer_kwargs'],
-        'scheduler': train_settings['train_settings']['scheduler_kwargs'],
-        'batch_size': train_settings['train_settings']['batch_size'],
-    }
+    training = {
+        "stage_0": {
+            "epochs": train_settings["train_settings"]["runtime_limits"][
+                "max_epochs_total"
+            ],
+            "asd_dataset_path": train_settings["asd_dataset_path"],
+            "freeze_rb_layer": train_settings["train_settings"]["freeze_rb_layer"],
+            "optimizer": train_settings["train_settings"]["optimizer_kwargs"],
+            "scheduler": train_settings["train_settings"]["scheduler_kwargs"],
+            "batch_size": train_settings["train_settings"]["batch_size"],
+        }
     }
 
     local = {
-        'device': train_settings['train_settings']['device'],
-        'num_workers': train_settings['train_settings']['num_workers'],
-        'runtime_limits': train_settings['train_settings']['runtime_limits'],
-        'checkpoint_epochs': train_settings['train_settings']['checkpoint_epochs'],
-        'condor': train_settings['condor_settings'],
+        "device": train_settings["train_settings"]["device"],
+        "num_workers": train_settings["train_settings"]["num_workers"],
+        "runtime_limits": train_settings["train_settings"]["runtime_limits"],
+        "checkpoint_epochs": train_settings["train_settings"]["checkpoint_epochs"],
+        "condor": train_settings["condor_settings"],
     }
-    del local['runtime_limits']['max_epochs_total']
+    del local["runtime_limits"]["max_epochs_total"]
 
-    d['metadata'] = {'train_settings': {
-        'data': data,
-        'model': model,
-        'training': training,
-    }}
+    d["metadata"] = {
+        "train_settings": {
+            "data": data,
+            "model": model,
+            "training": training,
+        }
+    }
 
     # Save (for posterity) the waveform dataset settings
-    f = h5py.File(d['metadata']['train_settings']['data']['waveform_dataset_path'], 'r')
-    settings = ast.literal_eval(f.attrs['settings'])
-    d['metadata']['dataset_settings'] = settings
+    f = h5py.File(d["metadata"]["train_settings"]["data"]["waveform_dataset_path"], "r")
+    settings = ast.literal_eval(f.attrs["settings"])
+    d["metadata"]["dataset_settings"] = settings
     f.close()
 
     torch.save(d, args.out_file)
 
     # Save local settings
-    with open(os.path.join(args.train_dir, 'local_settings.yaml'), 'w') as f:
+    with open(os.path.join(args.train_dir, "local_settings.yaml"), "w") as f:
         yaml.dump(local, f, default_flow_style=False, sort_keys=False)
 
 

--- a/compatibility/update_saved_model_for_train_stages.py
+++ b/compatibility/update_saved_model_for_train_stages.py
@@ -6,6 +6,7 @@ import yaml
 import h5py
 import ast
 
+from dingo.core.utils.backward_compatibility import torch_load_with_fallback
 
 def parse_args():
 
@@ -23,13 +24,7 @@ def main():
     with open(args.settings_file, 'r') as f:
         train_settings = yaml.safe_load(f)
 
-    # Typically training is done on the GPU, so the model could be saved on a GPU
-    # device. Since this routine may be run on a CPU machine, allow for a remap of the
-    # torch tensors.
-    if torch.cuda.is_available():
-        d = torch.load(args.checkpoint)
-    else:
-        d = torch.load(args.checkpoint, map_location=torch.device('cpu'))
+    d = torch_load_with_fallback(args.checkpoint)
 
     data = {
         'waveform_dataset_path': train_settings['waveform_dataset_path'],

--- a/compatibility/update_saved_model_new_gnpe.py
+++ b/compatibility/update_saved_model_new_gnpe.py
@@ -1,6 +1,6 @@
-import torch
 import argparse
 
+import torch
 import yaml
 
 from dingo.core.utils.backward_compatibility import torch_load_with_fallback
@@ -17,7 +17,7 @@ def parse_args():
 def main():
     args = parse_args()
 
-    d = torch_load_with_fallback(args.checkpoint)
+    d, _ = torch_load_with_fallback(args.checkpoint)
 
     data_settings = d["metadata"]["train_settings"]["data"]
 

--- a/compatibility/update_saved_model_new_gnpe.py
+++ b/compatibility/update_saved_model_new_gnpe.py
@@ -3,6 +3,8 @@ import argparse
 
 import yaml
 
+from dingo.core.utils.backward_compatibility import torch_load_with_fallback
+
 
 def parse_args():
 
@@ -15,13 +17,7 @@ def parse_args():
 def main():
     args = parse_args()
 
-    # Typically training is done on the GPU, so the model could be saved on a GPU
-    # device. Since this routine may be run on a CPU machine, allow for a remap of the
-    # torch tensors.
-    if torch.cuda.is_available():
-        d = torch.load(args.checkpoint)
-    else:
-        d = torch.load(args.checkpoint, map_location=torch.device("cpu"))
+    d = torch_load_with_fallback(args.checkpoint)
 
     data_settings = d["metadata"]["train_settings"]["data"]
 

--- a/compatibility/update_saved_model_new_truncation.py
+++ b/compatibility/update_saved_model_new_truncation.py
@@ -1,6 +1,7 @@
 import torch
 import argparse
 
+from dingo.core.utils.backward_compatibility import torch_load_with_fallback
 
 def parse_args():
 
@@ -13,13 +14,7 @@ def parse_args():
 def main():
     args = parse_args()
 
-    # Typically training is done on the GPU, so the model could be saved on a GPU
-    # device. Since this routine may be run on a CPU machine, allow for a remap of the
-    # torch tensors.
-    if torch.cuda.is_available():
-        d = torch.load(args.checkpoint)
-    else:
-        d = torch.load(args.checkpoint, map_location=torch.device('cpu'))
+    d = torch_load_with_fallback(args.checkpoint)
 
     data_settings = d['metadata']['train_settings']['data']
     f_min, f_max = data_settings['conditioning']['frequency_range']

--- a/compatibility/update_saved_model_new_truncation.py
+++ b/compatibility/update_saved_model_new_truncation.py
@@ -1,26 +1,28 @@
-import torch
 import argparse
 
+import torch
+
 from dingo.core.utils.backward_compatibility import torch_load_with_fallback
+
 
 def parse_args():
 
     parser = argparse.ArgumentParser()
-    parser.add_argument('--checkpoint', type=str, required=True)
-    parser.add_argument('--out_file', type=str, required=True)
+    parser.add_argument("--checkpoint", type=str, required=True)
+    parser.add_argument("--out_file", type=str, required=True)
     return parser.parse_args()
 
 
 def main():
     args = parse_args()
 
-    d = torch_load_with_fallback(args.checkpoint)
+    d, _ = torch_load_with_fallback(args.checkpoint)
 
-    data_settings = d['metadata']['train_settings']['data']
-    f_min, f_max = data_settings['conditioning']['frequency_range']
-    del data_settings['conditioning']['frequency_range']
+    data_settings = d["metadata"]["train_settings"]["data"]
+    f_min, f_max = data_settings["conditioning"]["frequency_range"]
+    del data_settings["conditioning"]["frequency_range"]
 
-    data_settings['domain_update'] = {'f_min': f_min, 'f_max': f_max}
+    data_settings["domain_update"] = {"f_min": f_min, "f_max": f_max}
 
     torch.save(d, args.out_file)
 

--- a/dingo/core/posterior_models/base_model.py
+++ b/dingo/core/posterior_models/base_model.py
@@ -18,7 +18,7 @@ import dingo.core.utils.trainutils
 import json
 from collections import OrderedDict
 from typing import Optional
-from dingo.core.utils.backward_compatibility import update_model_config
+from dingo.core.utils.backward_compatibility import update_model_config, torch_load_with_fallback
 from dingo.core.utils.misc import get_version
 
 from dingo.core.utils.trainutils import EarlyStopping
@@ -318,7 +318,7 @@ class BasePosteriorModel(ABC):
         # machine may have moved the model from 'cuda' to 'cpu'.
         ext = os.path.splitext(model_filename)[-1]
         if ext == ".pt":
-            d = torch.load(model_filename, map_location=device)
+            d = torch_load_with_fallback(model_filename, preferred_map_location=device)
         elif ext == ".hdf5":
             d = self._load_model_from_hdf5(model_filename)
         else:

--- a/dingo/core/posterior_models/base_model.py
+++ b/dingo/core/posterior_models/base_model.py
@@ -84,7 +84,9 @@ class BasePosteriorModel(ABC):
         # build model
         if model_filename is not None:
             self.load_model(
-                model_filename, load_training_info=load_training_info, device=device
+                model_filename,
+                load_training_info=load_training_info,
+                device=device,
             )
         else:
             self.initialize_network()
@@ -120,7 +122,9 @@ class BasePosteriorModel(ABC):
         pass
 
     @abstractmethod
-    def sample_and_log_prob(self, *context: torch.Tensor, num_samples: int = 1):
+    def sample_and_log_prob(
+        self, *context: torch.Tensor, num_samples: int = 1
+    ):
         """
         Sample parameters theta from the posterior model,
 
@@ -193,7 +197,9 @@ class BasePosteriorModel(ABC):
         Put model to device, and set self.device accordingly.
         """
         if device not in ("cpu", "cuda"):
-            raise ValueError(f"Device should be either cpu or cuda, got {device}.")
+            raise ValueError(
+                f"Device should be either cpu or cuda, got {device}."
+            )
         self.device = torch.device(device)
         # Commented below so that code runs on first cuda device in the case of multiple.
         # if device == 'cuda' and torch.cuda.device_count() > 1:
@@ -255,9 +261,13 @@ class BasePosteriorModel(ABC):
             model_dict["optimizer_kwargs"] = self.optimizer_kwargs
             model_dict["scheduler_kwargs"] = self.scheduler_kwargs
             if self.optimizer is not None:
-                model_dict["optimizer_state_dict"] = self.optimizer.state_dict()
+                model_dict["optimizer_state_dict"] = (
+                    self.optimizer.state_dict()
+                )
             if self.scheduler is not None:
-                model_dict["scheduler_state_dict"] = self.scheduler.state_dict()
+                model_dict["scheduler_state_dict"] = (
+                    self.scheduler.state_dict()
+                )
 
         torch.save(model_dict, model_filename)
 
@@ -292,7 +302,9 @@ class BasePosteriorModel(ABC):
             # Load model weights
             model_state_dict = OrderedDict()
             for k, v in fp["model_weights"].items():
-                model_state_dict[k] = torch.from_numpy(np.array(v, dtype=np.float32))
+                model_state_dict[k] = torch.from_numpy(
+                    np.array(v, dtype=np.float32)
+                )
             d["model_state_dict"] = model_state_dict
 
         return d
@@ -321,9 +333,7 @@ class BasePosteriorModel(ABC):
         # machine may have moved the model from 'cuda' to 'cpu'.
         ext = os.path.splitext(model_filename)[-1]
         if ext == ".pt":
-            d, _ = torch_load_with_fallback(
-                model_filename, preferred_map_location=device
-            )
+            d = torch.load(model_filename, map_location=device)
         elif ext == ".hdf5":
             d = self._load_model_from_hdf5(model_filename)
         else:
@@ -435,8 +445,12 @@ class BasePosteriorModel(ABC):
                 utils.perform_scheduler_step(self.scheduler, test_loss)
 
                 # write history and save model
-                utils.write_history(train_dir, self.epoch, train_loss, test_loss, lr)
-                utils.save_model(self, train_dir, checkpoint_epochs=checkpoint_epochs)
+                utils.write_history(
+                    train_dir, self.epoch, train_loss, test_loss, lr
+                )
+                utils.save_model(
+                    self, train_dir, checkpoint_epochs=checkpoint_epochs
+                )
                 if use_wandb:
                     try:
                         import wandb
@@ -454,7 +468,9 @@ class BasePosteriorModel(ABC):
                             }
                         )
                     except ImportError:
-                        print("wandb not installed. Skipping logging to wandb.")
+                        print(
+                            "wandb not installed. Skipping logging to wandb."
+                        )
 
                 if early_stopping is not None:
                     # Whether to use train or test loss
@@ -466,7 +482,8 @@ class BasePosteriorModel(ABC):
                     is_best_model = early_stopping(early_stopping_loss)
                     if is_best_model:
                         self.save_model(
-                            join(train_dir, "best_model.pt"), save_training_info=False
+                            join(train_dir, "best_model.pt"),
+                            save_training_info=False,
                         )
                     if early_stopping.early_stop:
                         print("Early stopping")

--- a/dingo/core/posterior_models/base_model.py
+++ b/dingo/core/posterior_models/base_model.py
@@ -20,7 +20,6 @@ from torch.utils.data import Dataset
 import dingo.core.utils as utils
 import dingo.core.utils.trainutils
 from dingo.core.utils.backward_compatibility import (
-    torch_load_with_fallback,
     update_model_config,
 )
 from dingo.core.utils.misc import get_version

--- a/dingo/core/posterior_models/base_model.py
+++ b/dingo/core/posterior_models/base_model.py
@@ -3,24 +3,27 @@ This module contains the abstract base class for representing posterior models,
 as well as functions for training and testing across an epoch.
 """
 
-from abc import abstractmethod, ABC
-import os
-from os.path import join
-import h5py
-
-import torch
-import dingo.core.utils as utils
-from torch.utils.data import Dataset
-import time
-import numpy as np
-from threadpoolctl import threadpool_limits
-import dingo.core.utils.trainutils
 import json
+import os
+import time
+from abc import ABC, abstractmethod
 from collections import OrderedDict
+from os.path import join
 from typing import Optional
-from dingo.core.utils.backward_compatibility import update_model_config, torch_load_with_fallback
-from dingo.core.utils.misc import get_version
 
+import h5py
+import numpy as np
+import torch
+from threadpoolctl import threadpool_limits
+from torch.utils.data import Dataset
+
+import dingo.core.utils as utils
+import dingo.core.utils.trainutils
+from dingo.core.utils.backward_compatibility import (
+    torch_load_with_fallback,
+    update_model_config,
+)
+from dingo.core.utils.misc import get_version
 from dingo.core.utils.trainutils import EarlyStopping
 
 
@@ -318,7 +321,9 @@ class BasePosteriorModel(ABC):
         # machine may have moved the model from 'cuda' to 'cpu'.
         ext = os.path.splitext(model_filename)[-1]
         if ext == ".pt":
-            d = torch_load_with_fallback(model_filename, preferred_map_location=device)
+            d, _ = torch_load_with_fallback(
+                model_filename, preferred_map_location=device
+            )
         elif ext == ".hdf5":
             d = self._load_model_from_hdf5(model_filename)
         else:

--- a/dingo/core/posterior_models/build_model.py
+++ b/dingo/core/posterior_models/build_model.py
@@ -3,8 +3,8 @@ import torch
 from dingo.core.posterior_models.normalizing_flow import NormalizingFlowPosteriorModel
 from dingo.core.posterior_models.flow_matching import FlowMatchingPosteriorModel
 from dingo.core.posterior_models.score_matching import ScoreDiffusionPosteriorModel
-from dingo.core.utils.backward_compatibility import update_model_config
-
+from dingo.core.utils.backward_compatibility import update_model_config, torch_load_with_fallback
+    
 
 def build_model_from_kwargs(filename: str = None, settings: dict = None, **kwargs):
     """
@@ -38,7 +38,7 @@ def build_model_from_kwargs(filename: str = None, settings: dict = None, **kwarg
     }
 
     if filename is not None:
-        d = torch.load(filename, map_location="meta")
+        d = torch_load_with_fallback(filename, preferred_map_location="meta")
         update_model_config(d["metadata"]["train_settings"]["model"])  # Backward compat
         posterior_model_type = d["metadata"]["train_settings"]["model"][
             "posterior_model_type"

--- a/dingo/core/posterior_models/build_model.py
+++ b/dingo/core/posterior_models/build_model.py
@@ -1,10 +1,13 @@
 import torch
 
-from dingo.core.posterior_models.normalizing_flow import NormalizingFlowPosteriorModel
 from dingo.core.posterior_models.flow_matching import FlowMatchingPosteriorModel
+from dingo.core.posterior_models.normalizing_flow import NormalizingFlowPosteriorModel
 from dingo.core.posterior_models.score_matching import ScoreDiffusionPosteriorModel
-from dingo.core.utils.backward_compatibility import update_model_config, torch_load_with_fallback
-    
+from dingo.core.utils.backward_compatibility import (
+    torch_load_with_fallback,
+    update_model_config,
+)
+
 
 def build_model_from_kwargs(filename: str = None, settings: dict = None, **kwargs):
     """
@@ -38,7 +41,7 @@ def build_model_from_kwargs(filename: str = None, settings: dict = None, **kwarg
     }
 
     if filename is not None:
-        d = torch_load_with_fallback(filename, preferred_map_location="meta")
+        d, _ = torch_load_with_fallback(filename, preferred_map_location="meta")
         update_model_config(d["metadata"]["train_settings"]["model"])  # Backward compat
         posterior_model_type = d["metadata"]["train_settings"]["model"][
             "posterior_model_type"

--- a/dingo/core/utils/backward_compatibility.py
+++ b/dingo/core/utils/backward_compatibility.py
@@ -1,3 +1,73 @@
+import torch
+from typing import List
+
+
+def torch_available_devices() -> List[str]:
+    """
+    Returns a list of all available PyTorch devices,
+    ordered: meta, cuda, mps, hip, cpu
+    
+    Returns
+    -------
+    List of available device identifiers
+    """
+    devices = ["meta"]
+    
+    # cuda
+    if torch.cuda.is_available():
+        devices.extend("cuda")
+    
+    # mps
+    try:
+        if torch.backends.mps.is_available():
+            devices.append('mps')
+    except AttributeError:
+        pass      
+
+    # hip
+    try:
+        if hasattr(torch, 'hip') and torch.hip.is_available():
+            devices.append('hip')
+    except AttributeError:
+        pass  
+    
+    # cpu
+    devices.append('cpu')
+    
+    return devices
+
+
+def torch_load_with_fallback(filename: str, preferred_map_location: str="cuda"):
+    """
+    Loads a PyTorch file with fallback behavior:
+    1. Tries preferred_map_location (default: cuda)
+    2. Falls back to CUDA/MPS/HIP if available
+    3. Finally falls back to CPU
+
+    Returns
+    -------
+    Loaded model
+    """
+
+    try:
+        return torch.load(filename, map_location=preferred_map_location)
+    except RuntimeError:
+        pass
+    
+    devices = torch_available_devices()
+    
+    for location in [d for d in devices if d!=preferred_map_location]:
+        try:
+            return torch.load(filename, map_location=location)
+        except RuntimeError:
+            pass
+
+    raise RuntimeError(
+        f"failed to load model {filename} on any device, "
+        "tried: {', '.join(devices)}"
+    )
+
+
 def update_model_config(model_settings: dict):
     """
     Update the model settings to ensure backwards compatibility with networks

--- a/dingo/core/utils/backward_compatibility.py
+++ b/dingo/core/utils/backward_compatibility.py
@@ -1,6 +1,9 @@
 from typing import Dict, List, Literal, Tuple
+import logging
 
 import torch
+
+_logger = logging.getLogger(__name__)
 
 Device = Literal["meta", "cuda", "mps", "hip", "cpu"]
 
@@ -8,13 +11,13 @@ Device = Literal["meta", "cuda", "mps", "hip", "cpu"]
 def torch_available_devices() -> List[Device]:
     """
     Returns a list of all available PyTorch devices,
-    ordered: meta, cuda, mps, hip, cpu
+    ordered: cuda, mps, hip, cpu, meta
 
     Returns
     -------
     List of available device identifiers
     """
-    devices: List[Device] = ["meta"]
+    devices: List[Device] = []
 
     # cuda
     if torch.cuda.is_available():
@@ -37,12 +40,15 @@ def torch_available_devices() -> List[Device]:
     # cpu
     devices.append("cpu")
 
+    # meta
+    devices.append("meta")
+
     return devices
 
 
 def torch_load_with_fallback(
     filename: str, preferred_map_location: Device = "cuda"
-) -> Tuple[Dict, Device]:
+) -> Tuple[Dict, torch.device]:
     """
     Loads a PyTorch file with fallback behavior:
     1. Tries preferred_map_location (default: cuda)
@@ -51,14 +57,16 @@ def torch_load_with_fallback(
 
     Returns
     -------
-    Loaded model
+    Loaded model and torch device on which it has been loaded
     """
 
     try:
-        return (
+        r = (
             torch.load(filename, map_location=preferred_map_location),
-            preferred_map_location,
+            torch.device(preferred_map_location),
         )
+        _logger.debug(f"loaded model {filename} to {preferred_map_location}")
+        return r
     except RuntimeError:
         pass
 
@@ -66,12 +74,20 @@ def torch_load_with_fallback(
 
     for location in [d for d in devices if d != preferred_map_location]:
         try:
-            return torch.load(filename, map_location=location), location
+            r = torch.load(filename, map_location=location), torch.device(
+                location
+            )
+            _logger.debug(
+                f"loaded model {filename} to fallback device {location} "
+                f"(preferred device was {preferred_map_location})"
+            )
+            return r
         except RuntimeError:
             pass
 
     raise RuntimeError(
-        f"failed to load model {filename} on any device, " "tried: {', '.join(devices)}"
+        f"failed to load model {filename} on any device, "
+        "tried: {', '.join(devices)}"
     )
 
 
@@ -90,5 +106,7 @@ def update_model_config(model_settings: dict):
         del model_settings["type"]
         model_settings["posterior_kwargs"] = model_settings["nsf_kwargs"]
         del model_settings["nsf_kwargs"]
-        model_settings["embedding_kwargs"] = model_settings["embedding_net_kwargs"]
+        model_settings["embedding_kwargs"] = model_settings[
+            "embedding_net_kwargs"
+        ]
         del model_settings["embedding_net_kwargs"]

--- a/dingo/core/utils/backward_compatibility.py
+++ b/dingo/core/utils/backward_compatibility.py
@@ -1,43 +1,48 @@
+from typing import Dict, List, Literal, Tuple
+
 import torch
-from typing import List
+
+Device = Literal["meta", "cuda", "mps", "hip", "cpu"]
 
 
-def torch_available_devices() -> List[str]:
+def torch_available_devices() -> List[Device]:
     """
     Returns a list of all available PyTorch devices,
     ordered: meta, cuda, mps, hip, cpu
-    
+
     Returns
     -------
     List of available device identifiers
     """
-    devices = ["meta"]
-    
+    devices: List[Device] = ["meta"]
+
     # cuda
     if torch.cuda.is_available():
-        devices.extend("cuda")
-    
+        devices.append("cuda")
+
     # mps
     try:
         if torch.backends.mps.is_available():
-            devices.append('mps')
+            devices.append("mps")
     except AttributeError:
-        pass      
+        pass
 
     # hip
     try:
-        if hasattr(torch, 'hip') and torch.hip.is_available():
-            devices.append('hip')
+        if hasattr(torch, "hip") and torch.hip.is_available():
+            devices.append("hip")
     except AttributeError:
-        pass  
-    
+        pass
+
     # cpu
-    devices.append('cpu')
-    
+    devices.append("cpu")
+
     return devices
 
 
-def torch_load_with_fallback(filename: str, preferred_map_location: str="cuda"):
+def torch_load_with_fallback(
+    filename: str, preferred_map_location: Device = "cuda"
+) -> Tuple[Dict, Device]:
     """
     Loads a PyTorch file with fallback behavior:
     1. Tries preferred_map_location (default: cuda)
@@ -50,21 +55,23 @@ def torch_load_with_fallback(filename: str, preferred_map_location: str="cuda"):
     """
 
     try:
-        return torch.load(filename, map_location=preferred_map_location)
+        return (
+            torch.load(filename, map_location=preferred_map_location),
+            preferred_map_location,
+        )
     except RuntimeError:
         pass
-    
+
     devices = torch_available_devices()
-    
-    for location in [d for d in devices if d!=preferred_map_location]:
+
+    for location in [d for d in devices if d != preferred_map_location]:
         try:
-            return torch.load(filename, map_location=location)
+            return torch.load(filename, map_location=location), location
         except RuntimeError:
             pass
 
     raise RuntimeError(
-        f"failed to load model {filename} on any device, "
-        "tried: {', '.join(devices)}"
+        f"failed to load model {filename} on any device, " "tried: {', '.join(devices)}"
     )
 
 

--- a/dingo/core/utils/backward_compatibility.py
+++ b/dingo/core/utils/backward_compatibility.py
@@ -53,7 +53,7 @@ def torch_load_with_fallback(
     Loads a PyTorch file with fallback behavior:
     1. Tries preferred_map_location (default: cuda)
     2. Falls back to CUDA/MPS/HIP if available
-    3. Finally falls back to CPU
+    3. Finally falls back to CPU, and if that fails, meta.
 
     Returns
     -------

--- a/dingo/gw/ls_cli.py
+++ b/dingo/gw/ls_cli.py
@@ -1,18 +1,18 @@
 import argparse
+import json
 from pathlib import Path
+from pprint import pprint
 
 import h5py
 import torch
 import yaml
-import json
-from pprint import pprint
 
+from dingo.core.backward_compatibility import torch_load_with_fallback
 from dingo.core.dataset import DingoDataset
-from dingo.gw.SVD import SVDBasis
 from dingo.core.result import Result
 from dingo.gw.dataset import WaveformDataset
 from dingo.gw.noise.asd_dataset import ASDDataset
-from dingo.core.backward_compatibility import torch_load_with_fallback
+from dingo.gw.SVD import SVDBasis
 
 
 def ls():
@@ -23,7 +23,7 @@ def ls():
     path = Path(args.file_name)
     if path.suffix == ".pt":
         print("Extracting information about torch model.\n")
-        d = torch_load_with_fallback(path)
+        d, _ = torch_load_with_fallback(path)
         print(f"Version: {d.get('version')}\n")
         print(f"Model epoch: {d['epoch']}\n")
         print("Model metadata:")
@@ -133,9 +133,9 @@ def ls():
                 print(f"Model epoch: {f.attrs['epoch']}")
                 print("Model metadata:")
 
-                for d in ['model_kwargs', 'metadata']:
-                    json_data = json.loads(f['serialized_dicts'][d][()])
-                    print(f"\n{d}:\n" + "-"*(len(d)+1))
+                for d in ["model_kwargs", "metadata"]:
+                    json_data = json.loads(f["serialized_dicts"][d][()])
+                    print(f"\n{d}:\n" + "-" * (len(d) + 1))
                     pprint(json_data)
 
         else:

--- a/dingo/gw/ls_cli.py
+++ b/dingo/gw/ls_cli.py
@@ -23,7 +23,7 @@ def ls():
     path = Path(args.file_name)
     if path.suffix == ".pt":
         print("Extracting information about torch model.\n")
-        d, _ = torch_load_with_fallback(path)
+        d, _ = torch_load_with_fallback(path, preferred_map_location="meta")
         print(f"Version: {d.get('version')}\n")
         print(f"Model epoch: {d['epoch']}\n")
         print("Model metadata:")

--- a/dingo/gw/ls_cli.py
+++ b/dingo/gw/ls_cli.py
@@ -7,9 +7,9 @@ import h5py
 import torch
 import yaml
 
-from dingo.core.backward_compatibility import torch_load_with_fallback
 from dingo.core.dataset import DingoDataset
 from dingo.core.result import Result
+from dingo.core.utils.backward_compatibility import torch_load_with_fallback
 from dingo.gw.dataset import WaveformDataset
 from dingo.gw.noise.asd_dataset import ASDDataset
 from dingo.gw.SVD import SVDBasis

--- a/dingo/gw/ls_cli.py
+++ b/dingo/gw/ls_cli.py
@@ -12,6 +12,7 @@ from dingo.gw.SVD import SVDBasis
 from dingo.core.result import Result
 from dingo.gw.dataset import WaveformDataset
 from dingo.gw.noise.asd_dataset import ASDDataset
+from dingo.core.backward_compatibility import torch_load_with_fallback
 
 
 def ls():
@@ -22,7 +23,7 @@ def ls():
     path = Path(args.file_name)
     if path.suffix == ".pt":
         print("Extracting information about torch model.\n")
-        d = torch.load(path, map_location="meta")
+        d = torch_load_with_fallback(path)
         print(f"Version: {d.get('version')}\n")
         print(f"Model epoch: {d['epoch']}\n")
         print("Model metadata:")

--- a/dingo/gw/training/utils.py
+++ b/dingo/gw/training/utils.py
@@ -3,6 +3,7 @@ import torch
 import argparse
 import yaml
 
+from dingo.core.utils.backward_compatibility import torch_load_with_fallback
 
 def append_stage():
 
@@ -13,13 +14,8 @@ def append_stage():
     parser.add_argument("--replace", type=int)
     args = parser.parse_args()
 
-    # Typically training is done on the GPU, so the model could be saved on a GPU
-    # device. Since this routine may be run on a CPU machine, allow for a remap of the
-    # torch tensors.
-    if torch.cuda.is_available():
-        d = torch.load(args.checkpoint)
-    else:
-        d = torch.load(args.checkpoint, map_location=torch.device("cpu"))
+    # trying to load on CUDA, MPS, HIP or CPU
+    d = torch_load_with_fallback(args.checkpoint)
 
     stages = [
         v

--- a/dingo/gw/training/utils.py
+++ b/dingo/gw/training/utils.py
@@ -1,9 +1,11 @@
+import argparse
+
 import numpy as np
 import torch
-import argparse
 import yaml
 
 from dingo.core.utils.backward_compatibility import torch_load_with_fallback
+
 
 def append_stage():
 
@@ -15,7 +17,7 @@ def append_stage():
     args = parser.parse_args()
 
     # trying to load on CUDA, MPS, HIP or CPU
-    d = torch_load_with_fallback(args.checkpoint)
+    d, _ = torch_load_with_fallback(args.checkpoint)
 
     stages = [
         v
@@ -30,8 +32,10 @@ def append_stage():
 
     if args.replace is not None:
         if args.replace < 0 or args.replace >= num_stages:
-            raise ValueError(f"Invalid argument replace={args.replace}. Valid values "
-                             f"are {list(range(num_stages))}.")
+            raise ValueError(
+                f"Invalid argument replace={args.replace}. Valid values "
+                f"are {list(range(num_stages))}."
+            )
         current_epoch = d["epoch"]
         stage_epoch = np.sum([s["epochs"] for s in stages[: args.replace]])
         if current_epoch > stage_epoch:

--- a/tests/core/test_utils.py
+++ b/tests/core/test_utils.py
@@ -43,8 +43,10 @@ def test_load_torch_with_fallback(model_path) -> None:
     raise an error and map at least correctly to cpu
     """
     devices = get_args(Device)
-    model, device = torch_load_with_fallback(model_path, preferred_map_location="cpu")
-    assert device == "cpu"
+    model, device = torch_load_with_fallback(
+        model_path, preferred_map_location="cpu"
+    )
+    assert device == torch.device("cpu")
     for device in devices:
         # just checking no error is raised.
         # Not checking if it is mapped to the proper device, as we do not

--- a/tests/core/test_utils.py
+++ b/tests/core/test_utils.py
@@ -1,0 +1,52 @@
+from pathlib import Path
+from typing import get_args
+
+import pytest
+import torch
+
+from dingo.core.utils.backward_compatibility import (
+    Device,
+    torch_available_devices,
+    torch_load_with_fallback,
+)
+
+
+class TestModel(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.linear = torch.nn.Linear(5, 3)
+
+
+@pytest.fixture
+def model_path(tmp_path) -> str:
+    model = TestModel()
+    model.linear.weight.data.fill_(1.0)
+    model.linear.bias.data.fill_(2.0)
+    model_path = tmp_path / "test_model.pt"
+    torch.save(model.state_dict(), model_path)
+    return str(model_path)
+
+
+def test_torch_available_device() -> None:
+    """
+    checks torch_available_devices do not
+    raise an error and lists at least cpu
+    """
+    devices = torch_available_devices()
+    assert len(devices) != 0
+    assert "cpu" in devices
+
+
+def test_load_torch_with_fallback(model_path) -> None:
+    """
+    checks torch_load_with_fallback do not
+    raise an error and map at least correctly to cpu
+    """
+    devices = get_args(Device)
+    model, device = torch_load_with_fallback(model_path, preferred_map_location="cpu")
+    assert device == "cpu"
+    for device in devices:
+        # just checking no error is raised.
+        # Not checking if it is mapped to the proper device, as we do not
+        # want to assume which device is available on the test machine.
+        torch_load_with_fallback(model_path, preferred_map_location=device)


### PR DESCRIPTION
## About

The toy npe demo could not run using older version of python and cuda (e.g. python3.9 / cuda 11.3), because of poor support of the "meta" device. This pull request introduces the function 'torch_load_with_fallback' which fallback to other devices when the preferred device is not available/supported. This function attempts to fallback to cuda/mps/hip/cpu 

The code has been updated to use `torch_load_with_fallback` everywhere, not only to solve the compatibility with older version, but also for more flexibility in general.

## How we know it works

- pytest passing (cpu / older cuda)
- toy npe demo passing (cpu/older cuda)

Not tested for mps/hip.

## To consider

- Some modules in the sub-package `compatibility` where independent to the dingo package. Using `torch_load_with_fallback` them made them dependent to it. This should be reverted if not a good thing.



