### PR TITLE
Included error message for non-zero standard deviation

### DIFF
--- a/dingo/gw/gwutils.py
+++ b/dingo/gw/gwutils.py
@@ -111,7 +111,11 @@ def get_standardization_dict(
     # Check that overlap between intrinsic and extrinsic parameters is only
     # due to fiducial values (-> std 0)
     for k in std_intrinsic.keys() & std_extrinsic.keys():
-        assert std_intrinsic[k] == 0
+        if std_intrinsic[k] != 0:
+            raise ValueError(f'Expected intrinsic prior for {k} to be a fixed value in the waveform dataset, '
+                             f'since {k} is specified as an extrinsic prior in the train settings and will be sampled'
+                             f'during training. However, the standard deviation of {k} is non-zero: {std_intrinsic[k]}'
+                             f'Please re-generate the waveform dataset with a fixed value for {k}.')
 
     # Merge dicts, overwriting fiducial values for parameters (e.g.,
     # luminosity_distance) in intrinsic parameters by the extrinsic ones


### PR DESCRIPTION
When computing the standardization dict for the parameters, a sanity check is implemented [here](https://github.com/dingo-gw/dingo/blob/4e74e0d6ba0431e305dda787a16251ec61b0da10/dingo/gw/gwutils.py#L114) to make sure that intrinsic prior values have a zero standard deviation in the waveform dataset if they are also specified as an extrinsic prior value in the `train_settings` file.

This means that for example the luminosity distance (which is an extrinsic parameter) should be set to a constant value, e.g. `luminosity_distance: 100.0  # Mpc` in the `waveform_dataset_settings.yaml` and to the intended prior in the `extrinsic_prior` dict in the `train_settings.yaml` (e.g., `luminosity_distance: bilby.core.prior.Uniform(minimum=100.0, maximum=1000.0)`).

Since the sanity check is hard to understand for new `dingo` users, this PR provides a more concrete and detailed error message. This should also help in cases where people want to add a posterior parameter previously not included in `dingo`.

Hopefully, this will help solve issues such as https://github.com/dingo-gw/dingo/issues/282 
