### PR TITLE
Throw error when trying to standardize fixed parameter

### DIFF
--- a/dingo/gw/transforms/parameter_transforms.py
+++ b/dingo/gw/transforms/parameter_transforms.py
@@ -110,6 +110,12 @@ class SelectStandardizeRepackageParameters(object):
                     else:
                         standardized = np.empty(len(v), dtype=np.float32)
                     for idx, par in enumerate(v):
+                        if self.std[par] == 0:
+                            raise ValueError(
+                                f"Parameter {par} with standard deviation zero is included in inference parameters. "
+                                f"This is not allowed. Please remove it from inference_parameters or create a new "
+                                f"dataset where std({par}) is not zero."
+                            )
                         standardized[..., idx] = (
                             full_parameters[par] - self.mean[par]
                         ) / self.std[par]


### PR DESCRIPTION
By accident, I encountered a failure case when training a model with a waveform dataset where one parameter is set to a fixed value (e.g. phase = 0).
If this fixed parameter is included in the list of inference parameters by accident, no error message is thrown, but the loss is NaN. The reason for this behavior is that the fixed phase parameter is divided by the std = 0 in the parameter standardization transform, resulting in NaNs.

To fix this, I included a check for `std !=0` in the standardization transform with a suitable error message.
This might not be the ideal place to throw this error. If there is a better place in the code, let me know.