### PR TITLE
Update event_dingo.yaml

### DIFF
--- a/examples/asimov/event_dingo.yaml
+++ b/examples/asimov/event_dingo.yaml
@@ -8,11 +8,11 @@ data:
     H1: H1_HOFT_C02
     L1: L1_HOFT_C02
   segment length: 8
-event time: 1126259462.391 
-psd length: 128
-interferometers:
-- H1
-- L1
+  event time: 1126259462.391 
+  psd length: 128
+  interferometers:
+  - H1
+  - L1
 quality:
   minimum frequency:
     H1: 20


### PR DESCRIPTION
Fixed typo with tabing in event_data.yaml so that "event time" "psd length" and "interferometers" are under the data settings