### PR TITLE
Fix bug in recursive_hdf5_load

### DIFF
--- a/dingo/core/dataset.py
+++ b/dingo/core/dataset.py
@@ -53,10 +53,11 @@ def recursive_hdf5_load(
                     d[k] = v[...]
                 elif isinstance(idx, list) and len(idx) > 1:
                     # Load batch of indices: hdf5 load requires index list to be sorted
-                    sorted_idx = np.sort(idx)
-                    reverse_sorting = np.argsort(idx)
-                    sorted_data = v[sorted_idx]
-                    d[k] = sorted_data[reverse_sorting]
+                    sorting = np.argsort(idx)
+                    sorted_idx = np.array(idx)[sorting]
+                    reverse_sorting = np.zeros_like(sorting)
+                    reverse_sorting[sorting] = np.arange(len(sorting))
+                    d[k] = v[sorted_idx][reverse_sorting]
                 else:
                     # Load specific idx
                     d[k] = v[idx]

--- a/tests/gw/test_waveform_dataset.py
+++ b/tests/gw/test_waveform_dataset.py
@@ -203,7 +203,7 @@ def test_load_waveform_dataset_with_leave_polarizations_on_disk(
     assert isinstance(el["waveform"]["h_cross"], np.ndarray)
 
     """Check that using a list of indices also works."""
-    ind_list = [0, 1, 2]
+    ind_list = [0, 1, 2, 3, 4, 5]
     el_list = wfd.__getitems__(ind_list)
     assert isinstance(el_list, list)
     assert len(el_list) == len(ind_list)
@@ -216,20 +216,16 @@ def test_load_waveform_dataset_with_leave_polarizations_on_disk(
     """Check that using a randomly ordered list of indices provides the expected ordering."""
     ind_list_rand = np.random.permutation(ind_list).tolist()
     el_list_rand = wfd.__getitems__(ind_list_rand)
-    assert np.all(
-        [
-            el_list_rand[ind_list_rand[i]]["waveform"]["h_plus"]
-            == el_list[i]["waveform"]["h_plus"]
-            for i in range(len(ind_list))
-        ]
+    np.testing.assert_equal([el_list[i] for i in ind_list_rand], el_list_rand)
+
+    """Check that waveforms and parameters are loaded from disk equivalently to loading the full dataset."""
+    wfd_full = WaveformDataset(
+        file_name=path,
+        precision="single",
+        leave_waveforms_on_disk=False,
     )
-    assert np.all(
-        [
-            el_list_rand[ind_list_rand[i]]["waveform"]["h_cross"]
-            == el_list[i]["waveform"]["h_cross"]
-            for i in range(len(ind_list))
-        ]
-    )
+    el_list_full = wfd_full.__getitems__(ind_list)
+    np.testing.assert_equal(el_list, el_list_full)
 
 
 @pytest.fixture


### PR DESCRIPTION
When loading dataset elements batch-wise from disk, the ordering was not maintained properly. This effectively randomized the waveforms with respect to parameters.

This PR fixes the ordering.