### PR TITLE
fix bug introduced in cvmfs integration

### DIFF
--- a/dingo/pipe/sampling.py
+++ b/dingo/pipe/sampling.py
@@ -2,7 +2,7 @@
 """ Script to sample from a Dingo model. Based on bilby_pipe data analysis script. """
 import sys
 from pathlib import Path
-import os 
+import os
 
 from bilby_pipe.input import Input
 from bilby_pipe.utils import parse_args, logger, convert_string_to_dict
@@ -48,6 +48,9 @@ class SamplingInput(Input):
         if args.osg:
             self.model = os.path.basename(args.model)
             self.model_init = os.path.basename(args.model_init)
+        else:
+            self.model = args.model
+            self.model_init = args.model_init
         self.recover_log_prob = args.recover_log_prob
         self.device = args.device
         self.num_gnpe_iterations = args.num_gnpe_iterations


### PR DESCRIPTION
Bug:
`dingo_pipe` fails in CI with the following error:
``` File "/data/dingo/venv/lib/python3.12/site-packages/dingo/pipe/sampling.py", line 115, in _load_sampler
    filename=self.model, device=self.device, load_training_info=False
             ^^^^^^^^^^
AttributeError: 'SamplingInput' object has no attribute 'model'
```

Reason:
- An alternative path for `self.model` is required when running on OSG. This resulted in changes [when defining self.model](https://github.com/dingo-gw/dingo/blob/24685a911ade7d46ae6a8f25295597ec3306c363/dingo/pipe/sampling.py#L49)
- However, `self.model` and `self.model_init` are not defined if `args.osg is False`, leading to the CI failure.

This PR fixes this by including an `else` option.