### PR TITLE
leave waveforms on disk in dingo_ls for waveform datasets

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -18,7 +18,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Set up Python 3.10
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v5
         with:
           python-version: '3.10'
           cache: 'pip'

--- a/dingo/gw/ls_cli.py
+++ b/dingo/gw/ls_cli.py
@@ -87,7 +87,9 @@ def ls():
             svd.print_validation_summary()
 
         elif dataset_type == "waveform_dataset":
-            waveform_dataset = WaveformDataset(file_name=args.file_name)
+            waveform_dataset = WaveformDataset(
+                file_name=args.file_name, leave_waveforms_on_disk=True
+            )
             print(f"Dingo version: {waveform_dataset.version}")
             print("\nWaveform dataset\n" + "================\n")
 


### PR DESCRIPTION
I ran into memory issues when trying to extract the metadata (e.g., SVD compression statistics) from a large waveform dataset with `dingo_ls`.

Explanation of the bug:
* `dingo_ls` loads the full waveform dataset into memory. This can lead to memory issues when running this command on cluster login nodes with limited memory.

Solution:
* add key `leave_waveforms_on_disk=True` to prevent waveform dataset from loading the waveforms into memory.

I tested it on our cluster and it works now.