### PR TITLE
Fix MultibandedFrequencyDomain f_max issue

### DIFF
--- a/dingo/gw/domains/multibanded_frequency_domain.py
+++ b/dingo/gw/domains/multibanded_frequency_domain.py
@@ -126,8 +126,10 @@ class MultibandedFrequencyDomain(BaseFrequencyDomain):
                 f"domain, {self.base_domain.domain_dict}"
             )
 
-        # Update base domain to required range.
-        self.base_domain.update({"f_min": self.f_min, "f_max": self.f_max})
+        # Note that f_max from the base domain can differ from that of the multi-banded
+        # domain. This occurs as a boundary effect, since a fixed number of bins in the
+        # base domain are averaged to obtain a bin in the multi-banded domain. When
+        # decimating, any extra bins in the base domain are dropped.
 
     def decimate(self, data: np.ndarray | torch.Tensor) -> np.ndarray | torch.Tensor:
         """

--- a/tests/gw/test_mfd.py
+++ b/tests/gw/test_mfd.py
@@ -150,7 +150,7 @@ def test_mfd_set_new_range(mfd_params, mfd):
 def test_mfd_base_domain_consistency(mfd):
     assert np.all(mfd.sample_frequencies == mfd.decimate(mfd.base_domain()))
     assert mfd.f_min == mfd.base_domain.f_min
-    assert mfd.f_max == mfd.base_domain.f_max
+    assert mfd.f_max in mfd.base_domain.sample_frequencies
 
 
 def test_mfd_time_translation(mfd):


### PR DESCRIPTION
## Issue

When initializing the `MultibandedFrequencyDomain`, the minimum and maximum frequencies of the underlying `UniformFrequencyDomain` were updated to match those of the MFD. Indeed, these can differ due to boundary effects. This led to a problem where data segments prepared by dingo-pipe inadvertently had a lower maximum frequency than expected, resulting in slight evidence mismatches vs Bilby.

## Fix

Remove the resetting of the UFD minimum and maximum frequencies and drop any extra bins when decimating data from UFD to MFD. In fact, no change is needed to the decimation method as it already does this.

## Review

@max-dax Check that you are happy with the updated `MultibandedFrequencyDomain` class.

@nihargupte-ph Check that you obtain consistent results with Bilby now.