### PR TITLE
Improvements to f_min / f_max updates for MultibandedFrequencyDomain

### DIFF
--- a/dingo/gw/domains/multibanded_frequency_domain.py
+++ b/dingo/gw/domains/multibanded_frequency_domain.py
@@ -270,6 +270,12 @@ class MultibandedFrequencyDomain(BaseFrequencyDomain):
         nodes_new[0] = self._f_base_lower[lower_bin]
         nodes_new[-1] = self._f_base_upper[upper_bin] + self.base_domain.delta_f
 
+        # Update base_domain f_min and f_max. These values might differ slightly from
+        # the final values for the multi-banded domain due to edge effects. Note that
+        # we do this update *after* all of our validation checks but *before* changing
+        # the state of the class.
+        self.base_domain.update({"f_min": f_min, "f_max": f_max})
+
         self._range_update_initial_length = len(self)
         self._range_update_idx_lower = lower_bin
         self._range_update_idx_upper = upper_bin
@@ -279,6 +285,9 @@ class MultibandedFrequencyDomain(BaseFrequencyDomain):
         assert self._range_update_idx_upper - self._range_update_idx_lower + 1 == len(
             self
         )
+
+        assert self.base_domain.f_min <= self.f_min
+        assert self.base_domain.f_max >= self.f_max
 
     def update_data(
         self, data: np.ndarray | torch.Tensor, axis: int = -1, **kwargs

--- a/dingo/gw/domains/multibanded_frequency_domain.py
+++ b/dingo/gw/domains/multibanded_frequency_domain.py
@@ -126,8 +126,10 @@ class MultibandedFrequencyDomain(BaseFrequencyDomain):
                 f"domain, {self.base_domain.domain_dict}"
             )
 
-        # Update base domain to required range.
-        self.base_domain.update({"f_min": self.f_min, "f_max": self.f_max})
+        # Note that f_max from the base domain can differ from that of the multi-banded
+        # domain. This occurs as a boundary effect, since a fixed number of bins in the
+        # base domain are averaged to obtain a bin in the multi-banded domain. When
+        # decimating, any extra bins in the base domain are dropped.
 
     def decimate(self, data: np.ndarray | torch.Tensor) -> np.ndarray | torch.Tensor:
         """

--- a/dingo/gw/domains/uniform_frequency_domain.py
+++ b/dingo/gw/domains/uniform_frequency_domain.py
@@ -79,25 +79,24 @@ class UniformFrequencyDomain(BaseFrequencyDomain):
     ):
         """
         Set a new range [f_min, f_max] for the domain. This is only allowed if the new
-        range is contained within the old one.
+        range is contained within the old one and if the new endpoints are pre-existing
+        sample points.
         """
         if f_min is not None and f_max is not None and f_min >= f_max:
             raise ValueError("f_min must not be larger than f_max.")
         if f_min is not None:
-            if self.f_min <= f_min <= self.f_max:
+            if self.f_min <= f_min <= self.f_max and f_min in self.sample_frequencies:
                 self.f_min = f_min
             else:
                 raise ValueError(
-                    f"f_min = {f_min} is not in expected range "
-                    f"[{self.f_min,self.f_max}]."
+                    f"New f_min = {f_min} is incompatible with domain {self.domain_dict}."
                 )
         if f_max is not None:
-            if self.f_min <= f_max <= self.f_max:
+            if f_max >= self.f_min and f_max in self.sample_frequencies:
                 self.f_max = f_max
             else:
                 raise ValueError(
-                    f"f_max = {f_max} is not in expected range "
-                    f"[{self.f_min, self.f_max}]."
+                    f"New f_max = {f_max} is incompatible with domain {self.domain_dict}."
                 )
 
     def update_data(self, data: np.ndarray, axis: int = -1, low_value: float = 0.0):

--- a/dingo/gw/domains/uniform_frequency_domain.py
+++ b/dingo/gw/domains/uniform_frequency_domain.py
@@ -76,28 +76,29 @@ class UniformFrequencyDomain(BaseFrequencyDomain):
 
     def _set_new_range(
         self, f_min: Optional[float] = None, f_max: Optional[float] = None
-    ):
+    ) -> None:
         """
-        Set a new range [f_min, f_max] for the domain. This is only allowed if the new
-        range is contained within the old one and if the new endpoints are pre-existing
-        sample points.
+        Set a new [f_min, f_max] range for the domain. Both endpoints must be in the
+        existing sample_frequencies, and f_min < f_max. Neither endpoint may lie
+        outside the current range.
         """
-        if f_min is not None and f_max is not None and f_min >= f_max:
-            raise ValueError("f_min must not be larger than f_max.")
-        if f_min is not None:
-            if self.f_min <= f_min <= self.f_max and f_min in self.sample_frequencies:
-                self.f_min = f_min
-            else:
-                raise ValueError(
-                    f"New f_min = {f_min} is incompatible with domain {self.domain_dict}."
-                )
-        if f_max is not None:
-            if f_max >= self.f_min and f_max in self.sample_frequencies:
-                self.f_max = f_max
-            else:
-                raise ValueError(
-                    f"New f_max = {f_max} is incompatible with domain {self.domain_dict}."
-                )
+        new_min = f_min if f_min is not None else self.f_min
+        new_max = f_max if f_max is not None else self.f_max
+
+        if new_min >= new_max:
+            raise ValueError("f_min must be strictly less than f_max.")
+
+        if not (self.f_min <= new_min and new_max <= self.f_max):
+            raise ValueError(
+                f"Requested range [{new_min}, {new_max}] lies outside "
+                f"original range [{self.f_min}, {self.f_max}]."
+            )
+
+        missing = [x for x in (new_min, new_max) if x not in self.sample_frequencies]
+        if missing:
+            raise ValueError(f"Endpoints {missing} not in existing sample_frequencies.")
+
+        self.f_min, self.f_max = new_min, new_max
 
     def update_data(self, data: np.ndarray, axis: int = -1, low_value: float = 0.0):
         """

--- a/tests/gw/test_mfd.py
+++ b/tests/gw/test_mfd.py
@@ -97,6 +97,10 @@ def test_mfd_set_new_range(mfd_params, mfd):
         domain._set_new_range(None, domain.f_min - 10)
     with pytest.raises(ValueError):
         domain._set_new_range(domain.f_min + 10, domain.f_min + 5)
+    with pytest.raises(ValueError):
+        domain._set_new_range(domain.f_min + 0.1, None)
+    with pytest.raises(ValueError):
+        domain._set_new_range(None, domain.f_max - 0.1)
     # test that setting new frequency range works as intended
     f_min_new, f_max_new = 40, 800
     domain._set_new_range(f_min_new, f_max_new)

--- a/tests/gw/test_mfd.py
+++ b/tests/gw/test_mfd.py
@@ -150,7 +150,7 @@ def test_mfd_set_new_range(mfd_params, mfd):
 def test_mfd_base_domain_consistency(mfd):
     assert np.all(mfd.sample_frequencies == mfd.decimate(mfd.base_domain()))
     assert mfd.f_min == mfd.base_domain.f_min
-    assert mfd.f_max == mfd.base_domain.f_max
+    assert mfd.f_max in mfd.base_domain.sample_frequencies
 
 
 def test_mfd_time_translation(mfd):

--- a/tests/gw/test_ufd.py
+++ b/tests/gw/test_ufd.py
@@ -98,6 +98,10 @@ def test_FD_set_new_range(uniform_FD_params):
         domain._set_new_range(None, p["f_min"] - 10)
     with pytest.raises(ValueError):
         domain._set_new_range(p["f_min"] + 10, p["f_min"] + 5)
+    with pytest.raises(ValueError):
+        domain._set_new_range(p["f_min"] + 0.1, None)
+    with pytest.raises(ValueError):
+        domain._set_new_range(None, p["f_max"] - 0.1)
     # test that setting new frequency range works as intended
     f_min_new, f_max_new = 40, 800
     n = int(f_max_new / p["delta_f"]) + 1


### PR DESCRIPTION
This is an improvement to #312.

With the previous update, the minimum and maximum frequencies of the base UniformFrequencyDomain are not updated at all. With this PR, we update them to the requested values. E.g., suppose we have
```yaml
domain:
  type: MultibandedFrequencyDomain
  nodes: [20.0, 33.0, 43.0, 59.0, 75.0, 107.0, 139.0, 203.0, 1099.0]
  delta_f_initial: 0.125
  base_domain:
    type: UniformFrequencyDomain
    f_min: 20.0
    f_max: 1099.0
    delta_f: 0.125
```
followed by
```yaml
  domain_update:
    f_max: 896
```
With this update, we will have `self.base_domain.f_max = 896` and `self.f_max = 890.875`. With the previous update, the base domain would have kept `f_max = 1099`.

Ultimately we want this change because it will ensure that dingo-pipe downloads data with `f_max = 896`, and that we are able to perform importance sampling in the UFD with this maximum frequency.

### Other changes

We now raise an error in the `UniformFrequencyDomain` if we try to update `f_min` or `f_max` to a value not on the existing frequency grid.

### Issues encountered

Some tests initially failed because the `set_new_range` methods were not careful about avoiding inconsistent states after partial updates. In particular, some validation checks were performed **after** modifying attributes of the class. I re-wrote `UniformFrequencyDomain._set_new_range` to fix this, however, we should be careful about such issues in the future.