### PR TITLE
Set maximum Python version to 3.12.6

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ authors = [
 description = "Deep inference for gravitational-wave observations"
 license = {text = "MIT"}
 readme = "README.md"
-requires-python = ">=3.10,<3.12.6"
+requires-python = ">=3.10,<=3.12.6"
 dynamic = ["version"]
 
 classifiers = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ authors = [
 description = "Deep inference for gravitational-wave observations"
 license = {text = "MIT"}
 readme = "README.md"
-requires-python = ">=3.10"
+requires-python = ">=3.10,<3.12.6"
 dynamic = ["version"]
 
 classifiers = [


### PR DESCRIPTION
Python==3.12.7 introduced a change to argparse, breaking the usage of mutually exclusive groups in bilby_pipe (and by extension, dingo_pipe):
* https://git.ligo.org/lscsoft/bilby_pipe/-/issues/310