### PR TITLE
SVD dependency issue

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -13,6 +13,10 @@ on:
 jobs:
   pytest:
     runs-on: ubuntu-latest
+    env:
+      OPENBLAS_NUM_THREADS: 1
+      MKL_NUM_THREADS: 1
+      NUMEXPR_NUM_THREADS: 1
     steps:
       - name: Checkout code
         uses: actions/checkout@v3

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -13,10 +13,6 @@ on:
 jobs:
   pytest:
     runs-on: ubuntu-latest
-    env:
-      OPENBLAS_NUM_THREADS: 1
-      MKL_NUM_THREADS: 1
-      NUMEXPR_NUM_THREADS: 1
     steps:
       - name: Checkout code
         uses: actions/checkout@v3


### PR DESCRIPTION
Tests are currently failing due to the fact that `scikit-learn > 1.2` no longer supports complex datatypes when generating an SVD. This change changes the default SVD to use scipy instead. One may need to run `export OPENBLAS_NUM_THREADS=1 MKL_NUM_THREADS=1` before generating the SVD to avoid a segfault. 