### PR TITLE
Add options to enable antisymmetric modes in SEOBNRv5PHM

### DIFF
--- a/dingo/gw/waveform_generator/waveform_generator.py
+++ b/dingo/gw/waveform_generator/waveform_generator.py
@@ -949,6 +949,17 @@ class NewInterfaceWaveformGenerator(WaveformGenerator):
 
         self.mode_list = kwargs.get("mode_list", None)
 
+        allowed_extra_kwargs = {
+            "postadiabatic",
+            "postadiabatic_type",
+            "lmax_nyquist",
+            "enable_antisymmetric_modes",
+            "antisymmetric_modes_hm",
+        }
+        extra_wf_kwargs = {k: v for k, v in kwargs.items() if k in allowed_extra_kwargs}
+        extra_wf_kwargs["lmax_nyquist"] = kwargs.get("lmax_nyquist", 2)
+        self.extra_wf_kwargs = extra_wf_kwargs
+
     @property
     def domain(self):
         if self._use_base_domain:
@@ -1042,22 +1053,7 @@ class NewInterfaceWaveformGenerator(WaveformGenerator):
         }
 
         # SEOBNRv5 specific parameters
-        if "postadiabatic" in p:
-            params_gwsignal["postadiabatic"] = p["postadiabatic"]
-
-            if "postadiabatic_type" in p:
-                params_gwsignal["postadiabatic_type"] = p["postadiabatic_type"]
-
-        if "lmax_nyquist" in p:
-            params_gwsignal["lmax_nyquist"] = p["lmax_nyquist"]
-        else:
-            params_gwsignal["lmax_nyquist"] = 2
-
-        if "enable_antisymmetric_modes" in p:
-            params_gwsignal["enable_antisymmetric_modes"] = p["enable_antisymmetric_modes"]
-
-            if "antisymmetric_modes_hm" in p:
-                params_gwsignal["antisymmetric_modes_hm"] = p["antisymmetric_modes_hm"]
+        params_gwsignal.update(self.extra_wf_kwargs)
 
         if return_target_function:
             # This is a hack to make compatible with LAL version. Target functions for

--- a/dingo/gw/waveform_generator/waveform_generator.py
+++ b/dingo/gw/waveform_generator/waveform_generator.py
@@ -1053,6 +1053,12 @@ class NewInterfaceWaveformGenerator(WaveformGenerator):
         else:
             params_gwsignal["lmax_nyquist"] = 2
 
+        if "enable_antisymmetric_modes" in p:
+            params_gwsignal["enable_antisymmetric_modes"] = p["enable_antisymmetric_modes"]
+
+            if "antisymmetric_modes_hm" in p:
+                params_gwsignal["antisymmetric_modes_hm"] = p["antisymmetric_modes_hm"]
+
         if return_target_function:
             # This is a hack to make compatible with LAL version. Target functions for
             # new waveform generator are defined in generate_FD_waveform, etc.

--- a/tests/gw/waveform_generator/test_wfg.py
+++ b/tests/gw/waveform_generator/test_wfg.py
@@ -1,5 +1,5 @@
 from dingo.gw.domains import UniformFrequencyDomain
-from dingo.gw.waveform_generator.waveform_generator import WaveformGenerator
+from dingo.gw.waveform_generator.waveform_generator import WaveformGenerator, NewInterfaceWaveformGenerator
 from dingo.gw.transforms.parameter_transforms import StandardizeParameters
 import pytest
 import numpy as np
@@ -100,3 +100,29 @@ def test_standardize_parameters_on_distribution():
     tol = 0.01
     assert np.all(np.abs(np.mean(parameters_tr, axis=0)) < tol)
     assert np.all(np.abs(np.std(parameters_tr, axis=0)) - np.ones(3) < tol)
+
+
+def test_new_interface_extra_kwargs(uniform_fd_domain, precessing_spin_wf_parameters):
+    """ When extra kwargs are provided at construction, they should be copied 
+    through to the gwsignal parameter dictionary.
+    """
+    parameters, f_ref, _ = precessing_spin_wf_parameters
+
+    wfg = NewInterfaceWaveformGenerator(
+        approximant="SEOBNRv5PHM",
+        domain=uniform_fd_domain,
+        f_ref=f_ref,
+        lmax_nyquist=3,
+        postadiabatic=True,
+        postadiabatic_type="analytic",
+        enable_antisymmetric_modes=True,
+        antisymmetric_modes_hm=True,
+    )
+
+    params_gwsignal = wfg._convert_parameters({**parameters, "f_ref": f_ref})
+
+    assert params_gwsignal["lmax_nyquist"] == 3
+    assert params_gwsignal["postadiabatic"] is True
+    assert params_gwsignal["postadiabatic_type"] == "analytic"
+    assert params_gwsignal["enable_antisymmetric_modes"] is True
+    assert params_gwsignal["antisymmetric_modes_hm"] == True

--- a/tests/gw/waveform_generator/test_wfg.py
+++ b/tests/gw/waveform_generator/test_wfg.py
@@ -125,4 +125,4 @@ def test_new_interface_extra_kwargs(uniform_fd_domain, precessing_spin_wf_parame
     assert params_gwsignal["postadiabatic"] is True
     assert params_gwsignal["postadiabatic_type"] == "analytic"
     assert params_gwsignal["enable_antisymmetric_modes"] is True
-    assert params_gwsignal["antisymmetric_modes_hm"] == True
+    assert params_gwsignal["antisymmetric_modes_hm"] is True


### PR DESCRIPTION
Hello! I started taking a look at the DINGO code to better understand the logic, and I noticed that the option to use the updated SEOBNRv5PHM model including mode asymmetries was missing (see https://arxiv.org/abs/2506.19911). These options are not turned on by default and need to be passed explicitly. This version of the model is the one that will be used for Production PE in O4b.

After checking with Nihar, I also adjusted the logic for handling extra waveform arguments, so that they are passed directly as kwargs to the `waveform_generator`.