### PR TITLE
Window factor fix

### DIFF
--- a/dingo/core/posterior_models/build_model.py
+++ b/dingo/core/posterior_models/build_model.py
@@ -7,6 +7,7 @@ from dingo.core.posterior_models.score_matching import ScoreDiffusionPosteriorMo
 from dingo.core.utils.backward_compatibility import (
     torch_load_with_fallback,
     update_model_config,
+    check_window_factor_fix
 )
 
 
@@ -45,6 +46,7 @@ def build_model_from_kwargs(
 
     if filename is not None:
         d, _ = torch_load_with_fallback(filename, preferred_map_location="meta")
+        check_window_factor_fix(d)
         update_model_config(d["metadata"]["train_settings"]["model"])  # Backward compat
         posterior_model_type = d["metadata"]["train_settings"]["model"][
             "posterior_model_type"

--- a/dingo/gw/domains/base_frequency_domain.py
+++ b/dingo/gw/domains/base_frequency_domain.py
@@ -92,16 +92,6 @@ class BaseFrequencyDomain(Domain, ABC):
         pass
 
     @property
-    @abstractmethod
-    def window_factor(self) -> float:
-        pass
-
-    @window_factor.setter
-    @abstractmethod
-    def window_factor(self, value: float):
-        pass
-
-    @property
     def delta_f(self) -> float | np.ndarray:
         return self._delta_f
 
@@ -206,25 +196,36 @@ class BaseFrequencyDomain(Domain, ABC):
         r"""
         Standard deviation per bin for white noise,
         $$
+        \sigma_{\mathrm{noise}} = \sqrt{\frac{1}{4 \delta f}}
+        $$
+
+        Historical note: 
+        Note we *no longer* use the noise std of the form 
+        $$
         \sigma_{\mathrm{noise}} = \sqrt{\frac{w}{4 \delta f}}
         $$
-        where $w$ is the window factor.
+        where $w$ is the window factor. For the full discussion, see 
+        https://git.ligo.org/pe/pe-group-coordination/-/issues/1#note_1465275. 
 
-        The window factor arises because of the way frequency domain data is
-        constructed from observed time domain data. Generally a window is applied to
-        the time domain data before taking the Fourier transform. This reduces the
-        power in the noise by $w^2$. However, the signal is assumed to be unaffected by
-        the window, which tapers near the edges of the domain. We keep track of this in
-        DINGO by generating noise with standard deviation as above.
+        The window factor generally arises because of the way frequency domain data is
+        constructed from observed time series. Typically, a window 
+        is applied to time series before taking the Fourier transform. Therefore,
+        for an arbitrary timeseries, applying a window to the time domain 
+        reduces the signal power by $w^2$. 
+        
+        However, with GWs we assume the signal is unaffected by the window (ie where 
+        the window is not one, the signal is assumed to be zero). Thus we should 
+        not divide by the window factor. Now the whitened data is not unit Gaussian 
+        near the boundaries of the domain. So technically, one has a non-stationary
+        noise process, but a reasonable approximation is to ignore this and simply
+        set the window factor to one.
 
         To scale noise such that it is consistent with a multivariate *unit* normal
-        distribution, you must divide whitened data by the noise_std. For the
+        distribution in the, you must divide whitened data by the noise_std. For the
         UniformFrequencyDomain, noise_std is a number, as delta_f is constant across
         the domain. For the MultibandedFrequencyDomain, it is an array.
         """
-        if self.window_factor is None:
-            raise ValueError("Window factor needs to be set for noise_std.")
-        return np.sqrt(self.window_factor) / np.sqrt(4.0 * self.delta_f)
+        return 1 / np.sqrt(4.0 * self.delta_f)
 
     def check_data_compatibility(self, data: np.ndarray) -> bool:
         """

--- a/dingo/gw/domains/base_frequency_domain.py
+++ b/dingo/gw/domains/base_frequency_domain.py
@@ -214,8 +214,8 @@ class BaseFrequencyDomain(Domain, ABC):
         reduces the signal power by $w^2$. 
         
         However, with GWs we assume the signal is unaffected by the window (ie where 
-        the window is not one, the signal is assumed to be zero). Thus we should 
-        not divide by the window factor. Now the whitened data is not unit Gaussian 
+        the window is not one, the signal is assumed to be zero). Thus there is 
+        no *signal* power loss from the window. Now the whitened data is not unit Gaussian 
         near the boundaries of the domain. So technically, one has a non-stationary
         noise process, but a reasonable approximation is to ignore this and simply
         set the window factor to one.

--- a/dingo/gw/domains/uniform_frequency_domain.py
+++ b/dingo/gw/domains/uniform_frequency_domain.py
@@ -66,8 +66,6 @@ class UniformFrequencyDomain(BaseFrequencyDomain):
         for k, v in new_settings.items():
             if k not in ["f_min", "f_max", "delta_f", "window_factor"]:
                 raise KeyError(f"Invalid key for domain update: {k}.")
-            if k == "window_factor" and v != self._window_factor:
-                raise ValueError("Cannot update window_factor.")
             if k == "delta_f" and v != self._delta_f:
                 raise ValueError("Cannot update delta_f.")
         self._set_new_range(
@@ -207,15 +205,6 @@ class UniformFrequencyDomain(BaseFrequencyDomain):
         return round(self._f_max / self._delta_f)
 
     @property
-    def window_factor(self) -> float:
-        return self._window_factor
-
-    @window_factor.setter
-    def window_factor(self, value: float):
-        """Set self._window_factor."""
-        self._window_factor = float(value)
-
-    @property
     def f_max(self) -> float:
         """The maximum frequency [Hz] is typically set to half the sampling
         rate."""
@@ -263,5 +252,4 @@ class UniformFrequencyDomain(BaseFrequencyDomain):
             "f_min": self.f_min,
             "f_max": self.f_max,
             "delta_f": self.delta_f,
-            "window_factor": self.window_factor,
         }

--- a/dingo/gw/download_strain_data.py
+++ b/dingo/gw/download_strain_data.py
@@ -5,7 +5,6 @@ from gwpy.timeseries import TimeSeries
 from dingo.gw.domains import UniformFrequencyDomain
 from dingo.gw.gwutils import (
     get_window,
-    get_window_factor,
 )
 
 
@@ -188,7 +187,6 @@ def download_event_data_in_FD(
         f_min=0,
         f_max=f_s / 2,
         delta_f=1 / time_segment,
-        window_factor=get_window_factor(window),
     )
 
     return data, domain

--- a/dingo/gw/gwutils.py
+++ b/dingo/gw/gwutils.py
@@ -23,14 +23,6 @@ def get_window(window_kwargs):
         raise NotImplementedError(f"Unknown window type {type}.")
 
 
-def get_window_factor(window):
-    """Compute window factor. If window is not provided as array or tensor but as
-    window_kwargs, first build the window."""
-    if type(window) == dict:
-        window = get_window(window)
-    return np.sum(window**2) / len(window)
-
-
 def get_extrinsic_prior_dict(extrinsic_prior):
     """Build dict for extrinsic prior by starting with
     default_extrinsic_dict, and overwriting every element for which

--- a/dingo/gw/inference/gw_samplers.py
+++ b/dingo/gw/inference/gw_samplers.py
@@ -12,7 +12,7 @@ from dingo.core.samplers import Sampler, GNPESampler
 from dingo.core.transforms import GetItem, RenameKey
 from dingo.gw.domains import MultibandedFrequencyDomain
 from dingo.gw.domains import build_domain
-from dingo.gw.gwutils import get_window_factor, get_extrinsic_prior_dict
+from dingo.gw.gwutils import get_extrinsic_prior_dict
 from dingo.gw.prior import build_prior_with_defaults
 from dingo.gw.result import Result
 from dingo.gw.transforms import (
@@ -51,8 +51,7 @@ class GWSamplerMixin(object):
 
     def _build_domain(self):
         """
-        Construct the domain object based on model metadata. Includes the window factor
-        needed for whitening data.
+        Construct the domain object based on model metadata.
 
         Called by __init__() immediately after _build_prior().
         """
@@ -64,7 +63,6 @@ class GWSamplerMixin(object):
         if "domain_update" in data_settings:
             self.domain.update(data_settings["domain_update"])
 
-        self.domain.window_factor = get_window_factor(data_settings["window"])
 
     def _correct_reference_time(
         self, samples: Union[dict, pd.DataFrame], inverse: bool = False

--- a/dingo/gw/injection.py
+++ b/dingo/gw/injection.py
@@ -304,15 +304,6 @@ class GWSignal(object):
             if asd.domain.domain_dict != self.data_domain.domain_dict:
                 print("Updating ASDDataset domain to match data domain.")
                 domain_dict = self.data_domain.domain_dict
-                if "window_factor" in domain_dict:
-                    print("Dropping window factor for update.")
-                    del domain_dict["window_factor"]
-                if (
-                    "base_domain" in domain_dict
-                    and "window_factor" in domain_dict["base_domain"]
-                ):
-                    print("Dropping window factor for update.")
-                    del domain_dict["base_domain"]["window_factor"]
                 asd.update_domain(domain_dict)
         elif isinstance(asd, dict):
             if set(asd.keys()) != set(ifo_names):

--- a/dingo/gw/likelihood.py
+++ b/dingo/gw/likelihood.py
@@ -242,13 +242,11 @@ class StationaryGaussianGWLikelihood(GWSignal, Likelihood):
         Here, we work with data d and signals mu that are already whitened by
         1 / [sqrt(PSD) * domain.noise_std], where
 
-                  noise_std = np.sqrt(window_factor) / np.sqrt(4 * delta_f).
+                  noise_std = 1 / np.sqrt(4 * delta_f).
 
         With this preprocessing, the inner products thus simply become
 
                   <a, b> = sum(a.conj() * b).real.
-
-        ! Be careful with window factors here !
 
 
         Time marginalization:

--- a/dingo/gw/noise/asd_estimation.py
+++ b/dingo/gw/noise/asd_estimation.py
@@ -58,7 +58,6 @@ def download_and_estimate_psds(
             "f_min": f_min,
             "f_max": f_max,
             "delta_f": delta_f,
-            "window_factor": None,
         }
     )
 

--- a/dingo/gw/result.py
+++ b/dingo/gw/result.py
@@ -15,7 +15,7 @@ from dingo.core.result import Result as CoreResult
 from dingo.gw.conversion import change_spin_conversion_phase
 from dingo.gw.domains import MultibandedFrequencyDomain
 from dingo.gw.domains import build_domain
-from dingo.gw.gwutils import get_extrinsic_prior_dict, get_window_factor
+from dingo.gw.gwutils import get_extrinsic_prior_dict
 from dingo.gw.likelihood import StationaryGaussianGWLikelihood
 from dingo.gw.prior import build_prior_with_defaults
 
@@ -135,8 +135,7 @@ class Result(CoreResult):
 
     def _build_domain(self):
         """
-        Construct the domain object based on model metadata. Includes the window factor
-        needed for whitening data.
+        Construct the domain object based on model metadata
 
         Called by __init__() immediately after _build_prior().
         """
@@ -145,8 +144,6 @@ class Result(CoreResult):
         data_settings = self.base_metadata["train_settings"]["data"]
         if "domain_update" in data_settings:
             self.domain.update(data_settings["domain_update"])
-
-        self.domain.window_factor = get_window_factor(data_settings["window"])
 
     def _rebuild_domain(self, verbose=False):
         """Rebuild the domain based on settings updated for importance sampling.
@@ -170,7 +167,6 @@ class Result(CoreResult):
             window_settings.update(
                 (k, updates[k]) for k in set(window_settings).intersection(updates)
             )
-            updates["window_factor"] = float(get_window_factor(window_settings))
 
         if "T" in updates:
             updates["delta_f"] = 1.0 / updates["T"]

--- a/dingo/gw/training/train_builders.py
+++ b/dingo/gw/training/train_builders.py
@@ -95,16 +95,7 @@ def set_train_transforms(wfd, data_settings, asd_dataset_path, omit_transforms=N
         domain_update=wfd.domain.domain_dict,
     )
     assert wfd.domain == asd_dataset.domain
-
-    # Add window factor to domain, so that we can compute the noise variance.
-    # TODO: we want to set `domain = wfd.domain`. This does not work at the moment,
-    #  because this requires updating the window factor of the wfd.domain (instead of
-    #  just the local domain object). This causes trouble if the
-    #  set_train_transforms function is called multiple times, since the second time
-    #  the domain_update = wfd.domain.domain_dict contains a window factor, which will
-    #  cause an error in domain_update.
-    domain = build_domain(wfd.domain.domain_dict)
-    domain.window_factor = get_window_factor(data_settings["window"])
+    domain = wfd.domain
 
     extrinsic_prior_dict = get_extrinsic_prior_dict(data_settings["extrinsic_prior"])
     if data_settings["inference_parameters"] == "default":

--- a/dingo/gw/transforms/noise_transforms.py
+++ b/dingo/gw/transforms/noise_transforms.py
@@ -131,10 +131,10 @@ class WhitenAndScaleStrain(object):
     and scale it with 1/scale_factor.
 
     In uniform frequency domain the scale factor should be
-    np.sqrt(window_factor) / np.sqrt(4.0 * delta_f).
-    It has two purposes:
-        (*) the denominator accounts for frequency binning
-        (*) dividing by window factor accounts for windowing of strain data
+
+    1 / np.sqrt(4.0 * delta_f).
+
+    This accounts for for frequency binning if delta_f is not constant.
     """
 
     def __init__(self, scale_factor):

--- a/dingo/pipe/data_generation.py
+++ b/dingo/pipe/data_generation.py
@@ -424,23 +424,6 @@ class DataGenerationInput(BilbyDataGenerationInput):
         else:
             self._importance_sampling_updates = None
 
-    def _set_interferometers_from_gaussian_noise(self):
-        super()._set_interferometers_from_gaussian_noise()
-        # Scale the FD strain appropriately by the window factor (not done by default
-        # in Bilby / bilby_pipe). This is to ensure that the injection is consistent
-        # with TD data with a given PSD, making it consistent also with DINGO network
-        # training.
-        for ifo in self.interferometers:
-            # This is a hack to set the window factor. It ensures also that the SNRs
-            # are calculated correctly.
-            td_strain = ifo.time_domain_strain
-            # TODO: correct for window factor changes https://git.ligo.org/pe/pe-group-coordination/-/issues/1
-            ifo.strain_data.time_domain_window(roll_off=self.tukey_roll_off)
-            ifo.strain_data.frequency_domain_strain = (
-                ifo.strain_data.frequency_domain_strain
-                * np.sqrt(ifo.strain_data.window_factor)
-            )
-
     @property
     def prior_dict_updates(self):
         """The input prior_dict from the ini (if given)

--- a/dingo/pipe/main.py
+++ b/dingo/pipe/main.py
@@ -132,8 +132,6 @@ def fill_in_arguments_from_model(args, perform_arg_checks=True):
     if args.asd_dataset:
         asd_dataset = ASDDataset(file_name=args.asd_dataset)
         domain_dict = copy.deepcopy(domain.domain_dict)
-        if "window_factor" in domain_dict:
-            del domain_dict["window_factor"]
         asd_dataset.update_domain(domain_dict)
         psd_dict = {}
         rng = np.random.default_rng(args.generation_seed)

--- a/tests/gw/dataset/test_generate_dataset.py
+++ b/tests/gw/dataset/test_generate_dataset.py
@@ -1,0 +1,55 @@
+import bilby
+import numpy as np
+import pytest
+
+from dingo.gw.dataset.generate_dataset import generate_dataset
+
+
+@pytest.fixture
+def wfd_settings():
+    settings = {
+        "domain": {
+            "delta_f": 0.125,
+            "f_max": 1024,
+            "f_min": 20,
+            "type": "FrequencyDomain",
+        },
+        "intrinsic_prior": {
+            "mass_1": bilby.core.prior.Constraint(minimum=7.5, maximum=120.0),
+            "mass_2": bilby.core.prior.Constraint(minimum=7.5, maximum=120.0),
+            "chi_1": bilby.gw.prior.AlignedSpin(
+                name="chi_1", a_prior=bilby.core.prior.Uniform(minimum=0, maximum=0.99)
+            ),
+            "chi_2": bilby.gw.prior.AlignedSpin(
+                name="chi_2", a_prior=bilby.core.prior.Uniform(minimum=0, maximum=0.99)
+            ),
+            "chirp_mass": bilby.gw.prior.UniformInComponentsChirpMass(
+                minimum=12.5, maximum=150.0
+            ),
+            "geocent_time": 0.0,
+            "luminosity_distance": 100.0,
+            "mass_ratio": bilby.gw.prior.UniformInComponentsMassRatio(
+                minimum=0.125, maximum=1.0
+            ),
+            "phase": bilby.core.prior.Uniform(
+                minimum=0.0, maximum=2 * np.pi, boundary="periodic"
+            ),
+            "theta_jn": bilby.core.prior.Sine(minimum=0.0, maximum=np.pi),
+        },
+        "num_samples": 1000,
+        "waveform_generator": {
+            "approximant": "IMRPhenomD",
+            "f_ref": 10.0,
+            "spin_conversion_phase": 0,
+        },
+    }
+    return settings
+
+
+def test_wfd_size(wfd_settings):
+    """
+    Test that the size requested by the waveform generator settings is the same as the
+    size of the generated dataset. This should be the case even when there are failures.
+    """
+
+    assert 1==1

--- a/tests/gw/test_injection.py
+++ b/tests/gw/test_injection.py
@@ -21,7 +21,6 @@ def signal_setup_EOB():
             "f_min": 20,
             "f_max": 1024,
             "delta_f": 0.125,
-            "window_factor": 1.0,
         }
     )
     data_domain = build_domain(
@@ -30,7 +29,6 @@ def signal_setup_EOB():
             "f_min": 20.0,
             "f_max": 1024.0,
             "delta_f": 0.125,
-            "window_factor": 0.9374713897717841,
         }
     )
     ifo_list = ["H1", "L1"]

--- a/tests/gw/test_ufd.py
+++ b/tests/gw/test_ufd.py
@@ -2,7 +2,6 @@ import torch
 
 from dingo.gw.domains import UniformFrequencyDomain, TimeDomain
 from dingo.gw.domains import build_domain
-from dingo.gw.gwutils import get_window_factor
 import pytest
 import numpy as np
 
@@ -13,22 +12,6 @@ def uniform_FD_params():
     f_max = 4096.0
     delta_f = 1.0 / 4.0
     return {"f_min": f_min, "f_max": f_max, "delta_f": delta_f}
-
-
-@pytest.fixture
-def window_setup():
-    type = "tukey"
-    f_s = 4096
-    T = 8.0
-    roll_off = 0.4
-    window_kwargs = {
-        "type": type,
-        "f_s": f_s,
-        "T": T,
-        "roll_off": roll_off,
-    }
-    window_factor = get_window_factor(window_kwargs)
-    return window_kwargs, window_factor
 
 
 def test_uniform_FD(uniform_FD_params):
@@ -181,25 +164,3 @@ def test_FD_caching(uniform_FD_params):
     # result
     assert len(domain()) < len(domain_ref())
 
-
-def test_FD_window_factor(uniform_FD_params, window_setup):
-    p = uniform_FD_params
-    domain = UniformFrequencyDomain(**p)
-    _, window_factor = window_setup
-    assert window_factor == 0.9374713897717841
-    # check that window_factor is initially None
-    assert domain.window_factor is None
-    # set new window_factor
-    domain.window_factor = window_factor
-    assert domain._window_factor == domain.window_factor == window_factor
-    noise_std = domain.noise_std
-    assert noise_std == np.sqrt(domain.window_factor) / np.sqrt(4 * domain.delta_f)
-    window_factor = 1
-    # now set new window factor correctly via the setter and check that
-    # noise_std is updated as intended since the cache is cleared
-    domain.window_factor = window_factor
-    assert domain._window_factor == domain.window_factor == window_factor
-    assert domain.noise_std != noise_std
-    assert domain.noise_std == np.sqrt(domain.window_factor) / np.sqrt(
-        4 * domain.delta_f
-    )


### PR DESCRIPTION
Following the discussion here, https://git.ligo.org/pe/pe-group-coordination/-/issues/1#note_1469386 we need to change the way that we handle the window factor. The way to do this is to set all window factors to one. The cleanest way to do this in the code is to remove all occurrences of the window factor, which is what this PR does.

Additionally, this PR breaks backwards compatibility with old networks, which were trained with the incorrect PSD scaling. This logic is implemented with the following pseudocode: 

```
if dingo_version >= 0.8.6 & model_version < 0.8.6:
   downgrade DINGO to use the network 
elif dingo_version < 0.8.6 & model_version > 0.8.6: 
   upgrade DINGO to use the network 
```