### PR TITLE
Update pipe for compatibility with bilby_pipe == 1.7.0.

### DIFF
--- a/dingo/pipe/data_generation.py
+++ b/dingo/pipe/data_generation.py
@@ -47,6 +47,9 @@ class DataGenerationInput(BilbyDataGenerationInput):
         self.ini = args.ini
         self.transfer_files = args.transfer_files
 
+        # Global settings
+        # self.cosmology = args.cosmology
+
         # Run index arguments
         self.idx = args.idx
         self.generation_seed = args.generation_seed
@@ -113,6 +116,9 @@ class DataGenerationInput(BilbyDataGenerationInput):
         self.waveform_generator_class = (
             "bilby.gw.waveform_generator.LALCBCWaveformGenerator"
         )
+        # self.waveform_generator_class_ctor_args = (
+        #     args.waveform_generator_constructor_dict
+        # )
         self.waveform_approximant = args.waveform_approximant
         self.catch_waveform_errors = args.catch_waveform_errors
         # TODO: These are set to parser defaults. Fix to set from model.
@@ -168,6 +174,7 @@ class DataGenerationInput(BilbyDataGenerationInput):
         #
         # # Calibration
         # self.calibration_model = args.calibration_model
+        # self.calibration_correction_type = args.calibration_correction_type
         # self.spline_calibration_envelope_dict = args.spline_calibration_envelope_dict
         # self.spline_calibration_amplitude_uncertainty_dict = (
         #     args.spline_calibration_amplitude_uncertainty_dict
@@ -429,10 +436,15 @@ class DataGenerationInput(BilbyDataGenerationInput):
             # Dingo and Bilby have different geocent_time conventions.
             settings["injection_parameters"]["geocent_time"] -= self.trigger_time
             settings["optimal_SNR"] = {
-                k: v["optimal_SNR"].item() if hasattr(v['optimal_SNR'], 'item') else v['optimal_SNR'] for k, v in self.interferometers.meta_data.items()
+                k: v["optimal_SNR"].item()
+                if hasattr(v["optimal_SNR"], "item")
+                else v["optimal_SNR"]
+                for k, v in self.interferometers.meta_data.items()
             }
             settings["matched_filter_SNR"] = {
-                k: v["matched_filter_SNR"].item() if hasattr(v['matched_filter_SNR'], 'item') else v['matched_filter_SNR']
+                k: v["matched_filter_SNR"].item()
+                if hasattr(v["matched_filter_SNR"], "item")
+                else v["matched_filter_SNR"]
                 for k, v in self.interferometers.meta_data.items()
             }
 

--- a/dingo/pipe/importance_sampling.py
+++ b/dingo/pipe/importance_sampling.py
@@ -53,7 +53,7 @@ class ImportanceSamplingInput(Input):
         self.prior_dict_updates = args.prior_dict_updates
 
         # Choices for running
-        # self.detectors = args.detectors
+        self.detectors = args.detectors
 
         # self.sampler = args.sampler
         # self.sampler_kwargs = args.sampler_kwargs

--- a/dingo/pipe/main.py
+++ b/dingo/pipe/main.py
@@ -131,7 +131,9 @@ def fill_in_arguments_from_model(args, perform_arg_checks=True):
             if args_v != v:
                 # this is for when the minimum-frequency is a float
                 # but args_v is a dict
-                if isinstance(args_v, dict) and all(val == v for val in args_v.values()):
+                if isinstance(args_v, dict) and all(
+                    val == v for val in args_v.values()
+                ):
                     continue
 
                 if isinstance(args_v, list):
@@ -223,6 +225,8 @@ class MainInput(BilbyMainInput):
         self.scitoken_issuer = args.scitoken_issuer
         self.container = args.container
 
+        # self.cosmology = args.cosmology
+
         self.outdir = args.outdir
         self.label = args.label
         self.log_directory = args.log_directory
@@ -310,6 +314,9 @@ class MainInput(BilbyMainInput):
         # self.injection_waveform_approximant = args.injection_waveform_approximant
         # self.injection_frequency_domain_source_model = (
         #     args.injection_frequency_domain_source_model
+        # )
+        # self.injection_waveform_generator_class_ctor_args = (
+        #     args.injection_waveform_generator_constructor_dict
         # )
         self.generation_seed = args.generation_seed
         if self.importance_sampling_updates and self.gaussian_noise:

--- a/dingo/pipe/parser.py
+++ b/dingo/pipe/parser.py
@@ -36,7 +36,7 @@ class StoreBoolean(argparse.Action):
             setattr(namespace, self.dest, False)
 
 
-def create_parser(top_level=True):
+def create_parser(top_level=True, usage=None):
     """Creates the BilbyArgParser for dingo_pipe
 
     Parameters
@@ -52,10 +52,11 @@ def create_parser(top_level=True):
 
     """
     parser = BilbyArgParser(
-        usage="Perform inference with dingo based on a .ini file.",
+        usage="%(prog)s ini [options]",
+        description=usage,
         ignore_unknown_config_file_keys=False,
         allow_abbrev=False,
-        formatter_class=configargparse.ArgumentDefaultsHelpFormatter,
+        formatter_class=configargparse.ArgumentDefaultsRawHelpFormatter,
     )
     parser.add("ini", type=str, is_config_file=True, help="Configuration ini file")
     parser.add("-v", "--verbose", action="store_true", help="Verbose output")
@@ -292,8 +293,18 @@ def create_parser(top_level=True):
     )
     data_gen_pars.add(
         "--data-find-url",
-        default="https://datafind.ligo.org",
-        help="URL to use for datafind, default is https://datafind.ligo.org to query CVMFS",
+        type=nonestr,
+        default=None,
+        help=(
+            "URL to use for datafind. This happens during the initial attempt "
+            "to locate frames by :code:`bilby_pipe` or by "
+            ":code:`bilby_pipe_generation`. In both cases, the order of "
+            "preference is: 1) the value of this argument, 2) the value of "
+            "the environment variable GWDATAFIND_SERVER, 3) the value "
+            "of the global default in bilby_pipe.utils.DEFAULT_GWDATAFIND_SERVER. "
+            "This value will override the value of GWDATAFIND_SERVER if it is set"
+            "in :code:`getenv` or :code:`environment-variables`."
+        ),
     )
     data_gen_pars.add(
         "--data-find-urltype",
@@ -522,6 +533,17 @@ def create_parser(top_level=True):
             "A dictionary of arbitrary additional waveform-arguments to pass "
             "to the bilby waveform generator's waveform arguments for the "
             "injection only"
+        ),
+    )
+    injection_parser.add(
+        "--injection-waveform-generator-constructor-dict",
+        default=None,
+        type=nonestr,
+        help=(
+            "A dictionary of arbitrary arguments to pass"
+            " to the bilby waveform generator class constructor for the injection"
+            " only. The class will be the same as the one specified in"
+            " '--waveform-generator'."
         ),
     )
     injection_parser.add(
@@ -1242,6 +1264,15 @@ def create_parser(top_level=True):
     #     help="The waveform generator class, should be a python path. This will "
     #     "not be able to use any arguments not passed to the default.",
     # )
+    # waveform_parser.add(
+    #     "--waveform-generator-constructor-dict",
+    #     default=None,
+    #     type=nonestr,
+    #     help=(
+    #         "A dictionary of arbitrary arguments to pass"
+    #         " to the bilby waveform generator class constructor."
+    #     ),
+    # )
     waveform_parser.add(
         "--reference-frequency",
         default=None,
@@ -1295,14 +1326,14 @@ def create_parser(top_level=True):
         ),
     )
     # waveform_parser.add(
-        # "--waveform-arguments-dict",
-        # default=None,
-        # type=nonestr,
-        # help=(
-            # "A dictionary of arbitrary additional waveform-arguments to pass"
-            # "  to the bilby waveform generator's `waveform_arguments`. Only used "
-            # "for injections"
-        # ),
+    # "--waveform-arguments-dict",
+    # default=None,
+    # type=nonestr,
+    # help=(
+    # "A dictionary of arbitrary additional waveform-arguments to pass"
+    # "  to the bilby waveform generator's `waveform_arguments`. Only used "
+    # "for injections"
+    # ),
     # )
     # waveform_parser.add(
     #     "--mode-array",
@@ -1352,6 +1383,23 @@ def create_parser(top_level=True):
     #         "the generation function is bilby.gw.conversion.generate_all_bns_parameters. "
     #         "If you specify your own function, you may wish to use the I/O of those functions as templates"
     #         "If given as 'noconvert' (case insensitive), no generation is used'"
+    #     ),
+    # )
+
+    # # Constants arguments
+    # global_settings_parser = parser.add_argument_group(
+    #     title="Global settings",
+    #     description="Settings for global configuration",
+    # )
+    # global_settings_parser.add(
+    #     "--cosmology",
+    #     default="Planck15",
+    #     type=str,
+    #     help=(
+    #         "The name of the cosmology to use. "
+    #         "Defaults to Planck15, see "
+    #         ":external:py:func:`bilby.gw.cosmology.get_available_cosmologies` "
+    #         "for a list of the available cosmologies."
     #     ),
     # )
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ classifiers = [
 dependencies = [
     "astropy",
     "bilby",
-    "bilby_pipe==1.4.2",
+    "bilby_pipe",
     "configargparse",
     "corner",
     "glasflow",


### PR DESCRIPTION
Updates dingo-pipe for compatibility with latest bilby_pipe (1.7.0).

### Changes

I looked at the bilby_pipe diff and copied various changes. In cases where we do not use the updated code, I commented it. It was necessary to made some small additional changes to ensure that the code runs (e.g., making `self.detectors` available in for ImportanceSamplingInput).

I also removed the pin to `bilby_pipe == 1.4.2`.

### Testing

I tested one analysis of an event and performed one injection. @nihargupte-ph You may wish to perform additional tests.

### To-do

@nihargupte-ph I saw that the lines you added to `MergeNode` in #307 now exist in a similar form in `bilby_pipe`, https://git.ligo.org/lscsoft/bilby_pipe/-/blob/master/bilby_pipe/job_creation/nodes/merge_node.py#L17-34. 

With the latest `bilby_pipe`, the code now executes **both** bits of code, since our `MergeNode.__init__()` calls its `super().__init__()`.  What is the appropriate behavior?

* If you want to use only our code, then we should not call the superclass init function, but then we need to copy the rest of the init function into ours.
* If you're happy to use only their code, then remove the lines from ours.
* If you're happy for both to run leave as is.
* If it's possible to use theirs by modifying some variables, then remove the lines from ours but modify the variables appropriately.

Happy to advise if you explain what this does.