### PR TITLE
ENH: Add triangular interferometer

### DIFF
--- a/dingo/gw/inference/gw_samplers.py
+++ b/dingo/gw/inference/gw_samplers.py
@@ -316,7 +316,7 @@ class GWSampler(GWSamplerMixin, Sampler):
             # transform data, since this transform is used by the GNPE sampler as
             # well.
             RepackageStrainsAndASDS(
-                ifos=self.detectors,
+                ifos=[ifo.name for ifo in InterferometerList(self.detectors)],
                 first_index=self.domain.min_idx,
             ),
             ToTorch(device=self.model.device),

--- a/dingo/gw/injection.py
+++ b/dingo/gw/injection.py
@@ -71,7 +71,12 @@ class GWSignal(object):
             self.waveform_generator = WaveformGenerator(domain=wfg_domain, **wfg_kwargs)
 
         self.t_ref = t_ref
-        self.ifo_list = InterferometerList(ifo_list)
+        if len(ifo_list) == 3 and all(d.startswith('ET') for d in ifo_list):
+            self.ifo_list = InterferometerList(['ET'])
+        elif all(d.startswith('ET') for d in ifo_list[:3]) and len(ifo_list) > 3:
+            self.ifo_list = InterferometerList(['ET'] + ifo_list[3:])
+        else:
+            self.ifo_list = InterferometerList(ifo_list)
 
         # When we set self.whiten, the projection transforms are automatically prepared.
         self._calibration_envelope = None

--- a/dingo/gw/injection.py
+++ b/dingo/gw/injection.py
@@ -71,12 +71,7 @@ class GWSignal(object):
             self.waveform_generator = WaveformGenerator(domain=wfg_domain, **wfg_kwargs)
 
         self.t_ref = t_ref
-        if len(ifo_list) == 3 and all(d.startswith('ET') for d in ifo_list):
-            self.ifo_list = InterferometerList(['ET'])
-        elif all(d.startswith('ET') for d in ifo_list[:3]) and len(ifo_list) > 3:
-            self.ifo_list = InterferometerList(['ET'] + ifo_list[3:])
-        else:
-            self.ifo_list = InterferometerList(ifo_list)
+        self.ifo_list = InterferometerList(ifo_list)
 
         # When we set self.whiten, the projection transforms are automatically prepared.
         self._calibration_envelope = None

--- a/dingo/gw/training/train_builders.py
+++ b/dingo/gw/training/train_builders.py
@@ -104,7 +104,12 @@ def set_train_transforms(wfd, data_settings, asd_dataset_path, omit_transforms=N
 
     ref_time = data_settings["ref_time"]
     # Build detector objects
-    ifo_list = InterferometerList(data_settings["detectors"])
+    if len(data_settings["detectors"]) == 3 and all(d.startswith('ET') for d in data_settings["detectors"]):
+        ifo_list = InterferometerList(['ET'])
+    elif all(d.startswith('ET') for d in data_settings["detectors"][:3]) and len(data_settings["detectors"]) > 3:
+        ifo_list = InterferometerList(['ET'] + data_settings["detectors"][3:])
+    else:
+        ifo_list = InterferometerList(data_settings["detectors"])
 
     # Build transforms.
     transforms = [

--- a/dingo/gw/training/train_builders.py
+++ b/dingo/gw/training/train_builders.py
@@ -86,12 +86,16 @@ def set_train_transforms(wfd, data_settings, asd_dataset_path, omit_transforms=N
     if omit_transforms is not None:
         print("Omitting \n\t" + "\n\t".join([t.__name__ for t in omit_transforms]))
 
+    # Build detector objects
+    ifo_list = InterferometerList(data_settings["detectors"])
+    ifo_names = [ifo.name for ifo in ifo_list]
+    
     # By passing the wfd domain when instantiating the noise dataset, this ensures the
     # domains will match. In particular, it truncates the ASD dataset beyond the new
     # f_max, and sets it to 1 below f_min.
     asd_dataset = ASDDataset(
         asd_dataset_path,
-        ifos=data_settings["detectors"],
+        ifos=ifo_names,
         precision="single",
         domain_update=wfd.domain.domain_dict,
     )
@@ -103,13 +107,6 @@ def set_train_transforms(wfd, data_settings, asd_dataset_path, omit_transforms=N
         data_settings["inference_parameters"] = default_inference_parameters
 
     ref_time = data_settings["ref_time"]
-    # Build detector objects
-    if len(data_settings["detectors"]) == 3 and all(d.startswith('ET') for d in data_settings["detectors"]):
-        ifo_list = InterferometerList(['ET'])
-    elif all(d.startswith('ET') for d in data_settings["detectors"][:3]) and len(data_settings["detectors"]) > 3:
-        ifo_list = InterferometerList(['ET'] + data_settings["detectors"][3:])
-    else:
-        ifo_list = InterferometerList(data_settings["detectors"])
 
     # Build transforms.
     transforms = [
@@ -175,7 +172,7 @@ def set_train_transforms(wfd, data_settings, asd_dataset_path, omit_transforms=N
         )
     )
     transforms.append(
-        RepackageStrainsAndASDS(data_settings["detectors"], first_index=domain.min_idx)
+        RepackageStrainsAndASDS(ifo_names, first_index=domain.min_idx)
     )
     if "random_strain_cropping" in data_settings:
         transforms.append(
@@ -336,7 +333,7 @@ def build_svd_for_embedding_network(
     print(f"Truncating SVD matrices below index {wfd.domain.min_idx}.")
     print("...V matrix shapes:")
     V_rb_list = []
-    for ifo in data_settings["detectors"]:
+    for ifo in ifo_names:
         V = basis_dict[ifo].V
         assert np.allclose(V[: wfd.domain.min_idx], 0)
         V = V[wfd.domain.min_idx :]

--- a/dingo/gw/training/train_builders.py
+++ b/dingo/gw/training/train_builders.py
@@ -333,7 +333,7 @@ def build_svd_for_embedding_network(
     print(f"Truncating SVD matrices below index {wfd.domain.min_idx}.")
     print("...V matrix shapes:")
     V_rb_list = []
-    for ifo in ifo_names:
+    for ifo in ifos:
         V = basis_dict[ifo].V
         assert np.allclose(V[: wfd.domain.min_idx], 0)
         V = V[wfd.domain.min_idx :]

--- a/dingo/pipe/main.py
+++ b/dingo/pipe/main.py
@@ -180,8 +180,8 @@ def fill_in_arguments_from_model(args, perform_arg_checks=True):
                 asd_key = ifo_name # normal detector, e.g. 'H1'
             else:
                 asd_key = [ifo.name for ifo in InterferometerList([ifo_name])][0]  # 'ET'-> 'ET1' and fixing 'ET1'
-            psd_path = asd_dataset.save_psd(args.outdir, ifo_name, rng=rng)
-            psd_dict[ifo_name] = str(psd_path)
+            psd_path = asd_dataset.save_psd(args.outdir, asd_key, rng=rng)
+            psd_dict[ifo_name] = str(psd_path) # keyed by 'ET'
         args.asd_dataset = None
         args.psd_dict = str(psd_dict)
 

--- a/dingo/pipe/main.py
+++ b/dingo/pipe/main.py
@@ -176,6 +176,10 @@ def fill_in_arguments_from_model(args, perform_arg_checks=True):
         psd_dict = {}
         rng = np.random.default_rng(args.generation_seed)
         for ifo_name in args.detectors:
+            if ifo_name in asd_dataset.asds:
+                asd_key = ifo_name # normal detector, e.g. 'H1'
+            else:
+                asd_key = [ifo.name for ifo in InterferometerList([ifo_name])][0]  # 'ET'-> 'ET1' and fixing 'ET1'
             psd_path = asd_dataset.save_psd(args.outdir, ifo_name, rng=rng)
             psd_dict[ifo_name] = str(psd_path)
         args.asd_dataset = None

--- a/dingo/pipe/main.py
+++ b/dingo/pipe/main.py
@@ -179,6 +179,13 @@ def fill_in_arguments_from_model(args, perform_arg_checks=True):
             if ifo_name in asd_dataset.asds:
                 asd_key = ifo_name # normal detector, e.g. 'H1'
             else:
+                # Triangular detector ('ET'): the ASD dataset is keyed by arm name
+                # (ET1/ET2/ET3), but bilby_pipe only accepts 'ET' as a psd_dict key,
+                # so we save the first arm's PSD and use it for all three arms.
+                # Note: different PSDs per-arm are NOT supported. This matches
+                # bilby's current ET definition (all arms share one sensitivity curve);
+                # supporting this would require bilby/bilby_pipe to treat ET1/ET2/ET3
+                # as separate detectors.
                 asd_key = [ifo.name for ifo in InterferometerList([ifo_name])][0]  # 'ET'-> 'ET1' and fixing 'ET1'
             psd_path = asd_dataset.save_psd(args.outdir, asd_key, rng=rng)
             psd_dict[ifo_name] = str(psd_path) # keyed by 'ET'


### PR DESCRIPTION
Hi,

I am opening this pull request to enable Dingo to work automatically with a triangular interferometer configuration, such as the Einstein Telescope (ET).

I am aware that the current implementation is not particularly elegant. In its present form, creating a [new interferometer object in Bilby](https://github.com/bilby-dev/bilby/tree/main/bilby/gw/detector/detectors) also requires modifying the sections of code shown below, which is not ideal. The main issue is that Dingo currently expects `data_settings["detectors"]` to contain the full list of interferometers, and this list is directly passed to `InterferometerList`. However, doing so results in an error from Bilby, since the interferometer `'ET-1'` does not exist.  

This happens because when `InterferometerList` is called with a triangular configuration (i.e., just `'ET'`), it automatically generates all the individual interferometers defined in `data_settings["detectors"]`.

I would appreciate any suggestions for a cleaner or more flexible solution.

Thanks a lot in advance, 
Kind regards,  
Filippo
