### PR TITLE
Remove getenv=True.

### DIFF
--- a/dingo/gw/dataset/generate_dataset_dag.py
+++ b/dingo/gw/dataset/generate_dataset_dag.py
@@ -147,7 +147,7 @@ def create_dag(args, settings):
         "error": args.error,
         "output": args.output,
         "log": args.log,
-        "getenv": True,
+        "getenv": False,
     }
     kwargs_high_memory = kwargs.copy()
     if args.request_memory_high is not None:

--- a/dingo/gw/noise/generate_dataset_dag.py
+++ b/dingo/gw/noise/generate_dataset_dag.py
@@ -81,7 +81,7 @@ def create_dag(data_dir, settings_file, time_segments, out_name):
         "error": os.path.join(condor_dir, "error"),
         "output": os.path.join(condor_dir, "output"),
         "log": os.path.join(condor_dir, "logging"),
-        "getenv": True,
+        "getenv": False,
     }
     # scripts are installed in the env's bin directory
     env_path = os.path.join(settings["condor"]["env_path"], "bin")

--- a/dingo/gw/training/train_pipeline_condor.py
+++ b/dingo/gw/training/train_pipeline_condor.py
@@ -28,7 +28,7 @@ def create_submission_file(
     """
     lines = []
     # getenv required for GPU training because wandb needs $HOME to be defined
-    lines.append(f"getenv = True\n")
+    lines.append(f"getenv = HOME\n")
     lines.append(f'executable = {condor_settings["executable"]}\n')
     lines.append(f'request_cpus = {condor_settings["num_cpus"]}\n')
     lines.append(f'request_memory = {condor_settings["memory_cpus"]}\n')


### PR DESCRIPTION
Since yesterday, setting `getenv=True` in an htcondor job on CIT will automatically fail the job. This PR is an attempt to fix this by explicitely setting getenv to `HOME` when needed of `False` otherwise.