### PR TITLE
Fix #377: seed RNGs in tests to eliminate CI flakiness

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,15 @@
+import bilby.core.utils.random
+import numpy as np
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _seed_rngs():
+    """Seed numpy and bilby RNGs before every test.
+
+    Makes the full suite deterministic: each test starts from the same known
+    state, independent of test ordering. Avoids stochastic failures like the
+    ones tracked in issue #377.
+    """
+    np.random.seed(0)
+    bilby.core.utils.random.seed(0)

--- a/tests/gw/transforms/test_waveform_transforms.py
+++ b/tests/gw/transforms/test_waveform_transforms.py
@@ -220,11 +220,14 @@ def test_cropping_bounds_independence(cropping_setup):
     example_batch_single = dict(waveform=strain_in[0])
 
     for independent_detectors in [False, True]:
+        # cropping_probability=1.0: the probabilistic skip is covered by
+        # test_cropping_probability; here we only assert bounds independence,
+        # which is unambiguous when every sample is cropped.
         cropping_transform = CropMaskStrainRandom(
             domain,
             f_min_upper=32,
             f_max_lower=512,
-            cropping_probability=0.8,
+            cropping_probability=1.0,
             independent_detectors=independent_detectors,
             independent_lower_upper=False,
         )


### PR DESCRIPTION
## Summary
- Adds `tests/conftest.py` with an autouse fixture that seeds `np.random` and `bilby.core.utils.random` before every test, making the suite deterministic and order-independent.
- Sets `cropping_probability=1.0` in `test_cropping_bounds_independence`. The test asserts bounds independence along the detector/batch axes; with `p=0.8` on the single-sample non-batched path, there was a 20% chance nothing was cropped, which made the assertion flip. Probabilistic skip behavior is already covered by `test_cropping_probability`.

Closes #377

## Test plan
- [x] `pytest tests/` — 101 passed, 1 skipped, 0 failed (local)
- [x] `test_cropping_bounds_independence` run 10x in a loop — 10/10 pass (was ~20% flake rate)
- [x] `test_truncation_of_waveform`, `test_load_waveform_dataset` pass
- [ ] CI passes on all Python versions (3.10/3.11/3.12/3.13)

🤖 Generated with [Claude Code](https://claude.com/claude-code)