### PR TITLE
Allow resuming condor training without train_settings.yaml

### DIFF
--- a/dingo/gw/training/train_pipeline.py
+++ b/dingo/gw/training/train_pipeline.py
@@ -218,7 +218,7 @@ def prepare_training_resume(
             import wandb
 
             wandb.init(
-                resume="must",
+                resume="allow",
                 dir=train_dir,
                 **local_settings["wandb"],
             )

--- a/dingo/gw/training/train_pipeline_condor.py
+++ b/dingo/gw/training/train_pipeline_condor.py
@@ -79,13 +79,6 @@ def train_condor():
     )
     args = parser.parse_args()
 
-    # For condor settings, first try looking for a local settings file. Otherwise,
-    # defer to train_settings.yaml.
-    # if isfile(join(args.train_dir, 'local_settings.yaml')):
-    #     with open(join(args.train_dir, 'local_settings.yaml')) as f:
-    #         condor_settings = yaml.safe_load(f)['condor']
-    # else:
-
     if not args.start_submission:
 
         #
@@ -159,12 +152,20 @@ def train_condor():
         if args.checkpoint != "model_latest.pt":
             condor_arguments += f" --checkpoint {args.checkpoint}"
 
+        if isfile(join(args.train_dir, "local_settings.yaml")):
+            with open(join(args.train_dir, "local_settings.yaml"), "r") as f:
+                local_settings = yaml.safe_load(f)
+        else:
+            local_settings = {}
+
     if args.exit_command:
         condor_arguments += f" --exit_command '{args.exit_command}'"
 
     submission_file = "submission_file.sub"
-    with open(join(args.train_dir, "train_settings.yaml"), "r") as f:
-        condor_settings = yaml.safe_load(f)["local"]["condor"]
+    condor_settings = local_settings.get("condor")
+    if condor_settings is None:
+        with open(join(args.train_dir, "train_settings.yaml"), "r") as f:
+            condor_settings = yaml.safe_load(f)["local"]["condor"]
     condor_settings["arguments"] = condor_arguments
     condor_settings["executable"] = join(
         os.path.dirname(sys.executable), "dingo_train_condor"


### PR DESCRIPTION
## Problem
**Setting and expected behavior:**
I wanted to fine-tune DINGO models by appending a new training stage and continuing training in a different folder to separate the two runs clearly. After appending the stage, I expected that I would only need the modified model checkpoint and the `local_settings.yaml` file to start the fine-tuning training since the model metadata should contain all information that would in principle be part of the `train_settings.yaml` file.

**Actual behavior:**
However, when I tried to start the training jobs with condor, the code required `train_settings.yaml` to be present even though all necessary settings are already available in `local_settings.yaml` and the checkpoint. 
Additionally, I didn't copy over the `wandb` folder which resulted in another failure since wandb's `resume="must"` mode requires the local run state to exist.

## Fixes

- `train_pipeline_condor.py`: Read condor settings from `local_settings.yaml` when available; only fall back to `train_settings.yaml` if `local_settings.yaml` does not exist (i.e. on first submission).
- `train_pipeline.py`: Switch wandb `resume="must"` to `resume="allow"`, which resumes if local state is present and otherwise re-initializes from the server.

🤖 Generated with [Claude Code](https://claude.com/claude-code)