### PR TITLE
Fix: raise FileNotFoundError for missing custom checkpoints

### DIFF
--- a/dingo/gw/training/train_pipeline.py
+++ b/dingo/gw/training/train_pipeline.py
@@ -32,7 +32,10 @@ from dingo.core.posterior_models import BasePosteriorModel
 
 
 def copy_files_to_local(
-    file_path: str, local_dir: Optional[str], leave_keys_on_disk: bool, is_condor: bool = False,
+    file_path: str,
+    local_dir: Optional[str],
+    leave_keys_on_disk: bool,
+    is_condor: bool = False,
 ) -> str:
     """
     Copy files to local node if local_dir is provided to minimize network traffic during training.
@@ -465,6 +468,8 @@ def train_local():
         pm, wfd = prepare_training_new(train_settings, args.train_dir, local_settings)
 
     else:
+        if not os.path.isfile(args.checkpoint):
+            raise FileNotFoundError(f"Checkpoint not found: {args.checkpoint}")
         print("Resuming training run.")
         with open(os.path.join(args.train_dir, "local_settings.yaml"), "r") as f:
             local_settings = yaml.safe_load(f)

--- a/dingo/gw/training/train_pipeline_condor.py
+++ b/dingo/gw/training/train_pipeline_condor.py
@@ -93,6 +93,10 @@ def train_condor():
         #
 
         if not isfile(join(args.train_dir, args.checkpoint)):
+            if args.checkpoint != "model_latest.pt":
+                raise FileNotFoundError(
+                    f"Checkpoint not found: {join(args.train_dir, args.checkpoint)}"
+                )
             print("Beginning new training run.")
             with open(join(args.train_dir, "train_settings.yaml"), "r") as f:
                 train_settings = yaml.safe_load(f)


### PR DESCRIPTION
## Problem

When a user provides a custom `--checkpoint` path that does not exist:

- **`dingo_train`**: crashes with an unhelpful traceback buried inside PyTorch's model loading code (`build_model_from_kwargs`), making it hard to identify the root cause.
- **`dingo_train_condor`**: silently falls through to the \"beginning new training run\" branch and starts training from scratch, ignoring the user's intent entirely.

The default `model_latest.pt` checkpoint in `dingo_train_condor` is intentionally allowed to be absent (that signals the first run), so that case must be preserved.

## Fix

Add an explicit `FileNotFoundError` with a clear message in both commands before any model loading is attempted:

- **`dingo_train`** (`train_pipeline.py`): check `os.path.isfile(args.checkpoint)` before calling `prepare_training_resume`.
- **`dingo_train_condor`** (`train_pipeline_condor.py`): inside the `not isfile(...)` branch, raise if the checkpoint is not the default `model_latest.pt`.

Both commands now produce the same error message format:
```
FileNotFoundError: Checkpoint not found: <path>
```