### PR TITLE
Fix TypeError when model_init is None in data_generation and sampling

### DIFF
--- a/dingo/pipe/data_generation.py
+++ b/dingo/pipe/data_generation.py
@@ -31,7 +31,9 @@ logger.name = "dingo_pipe"
 class DataGenerationInput(BilbyDataGenerationInput):
     def __init__(self, args, unknown_args, create_data=True):
         self.model = resolve_filename_with_transfer_fallback(args.model) or args.model
-        self.model_init = resolve_filename_with_transfer_fallback(args.model_init) or args.model_init
+        self.model_init = args.model_init and (
+            resolve_filename_with_transfer_fallback(args.model_init) or args.model_init
+        )
 
         Input.__init__(self, args, unknown_args)
         # Generic initialisation
@@ -438,15 +440,19 @@ class DataGenerationInput(BilbyDataGenerationInput):
             # Dingo and Bilby have different geocent_time conventions.
             settings["injection_parameters"]["geocent_time"] -= self.trigger_time
             settings["optimal_SNR"] = {
-                k: v["optimal_SNR"].item()
-                if hasattr(v["optimal_SNR"], "item")
-                else v["optimal_SNR"]
+                k: (
+                    v["optimal_SNR"].item()
+                    if hasattr(v["optimal_SNR"], "item")
+                    else v["optimal_SNR"]
+                )
                 for k, v in self.interferometers.meta_data.items()
             }
             settings["matched_filter_SNR"] = {
-                k: v["matched_filter_SNR"].item()
-                if hasattr(v["matched_filter_SNR"], "item")
-                else v["matched_filter_SNR"]
+                k: (
+                    v["matched_filter_SNR"].item()
+                    if hasattr(v["matched_filter_SNR"], "item")
+                    else v["matched_filter_SNR"]
+                )
                 for k, v in self.interferometers.meta_data.items()
             }
 

--- a/dingo/pipe/sampling.py
+++ b/dingo/pipe/sampling.py
@@ -1,11 +1,16 @@
 #!/usr/bin/env python
-""" Script to sample from a Dingo model. Based on bilby_pipe data analysis script. """
+"""Script to sample from a Dingo model. Based on bilby_pipe data analysis script."""
 import sys
 from pathlib import Path
 import os
 
 from bilby_pipe.input import Input
-from bilby_pipe.utils import parse_args, logger, convert_string_to_dict, resolve_filename_with_transfer_fallback
+from bilby_pipe.utils import (
+    parse_args,
+    logger,
+    convert_string_to_dict,
+    resolve_filename_with_transfer_fallback,
+)
 
 from dingo.core.posterior_models.build_model import build_model_from_kwargs
 from dingo.gw.data.event_dataset import EventDataset
@@ -44,7 +49,9 @@ class SamplingInput(Input):
         self.detectors = args.detectors
 
         self.model = resolve_filename_with_transfer_fallback(args.model) or args.model
-        self.model_init = resolve_filename_with_transfer_fallback(args.model_init) or args.model_init
+        self.model_init = args.model_init and (
+            resolve_filename_with_transfer_fallback(args.model_init) or args.model_init
+        )
         self.recover_log_prob = args.recover_log_prob
         self.device = args.device
         self.num_gnpe_iterations = args.num_gnpe_iterations


### PR DESCRIPTION
## Problem

Calling `resolve_filename_with_transfer_fallback(args.model_init)` with `args.model_init=None` raises a `TypeError`:

```
File "dingo/pipe/data_generation.py", line 34, in __init__
    self.model_init = resolve_filename_with_transfer_fallback(args.model_init) or args.model_init
File "bilby_pipe/utils.py", line 900, in resolve_filename_with_transfer_fallback
    if os.path.isfile(filename):
TypeError: stat: path should be string, bytes, os.PathLike or integer, not NoneType
```

`--model-init` is an optional argument (only required for GNPE models) that defaults to `None`. The bug was introduced in #372, which added `resolve_filename_with_transfer_fallback` calls for `model_init` without guarding against the case where `model_init` is not set.

## Fix

Guard the call with `args.model_init and (...)` so that `None` short-circuits before `resolve_filename_with_transfer_fallback` is reached. The same fix is applied symmetrically in both `data_generation.py` and `sampling.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)