### PR TITLE
LVK fixes for 0.9.8

### DIFF
--- a/dingo/asimov/asimov.py
+++ b/dingo/asimov/asimov.py
@@ -150,10 +150,10 @@ class Dingo(Pipeline):
         result_files = glob.glob(
             os.path.join(rundir, "result", f"*importance_sampling.hdf5")
         )
-    if len(result_files) == 0: 
-        raise ValueError("Importance sampling result file not found")
-    elif len(result_files) > 1: 
-        raise ValueError("multiple importance sampling result files found")
+        if len(result_files) == 0: 
+            raise ValueError("Importance sampling result file not found")
+        elif len(result_files) > 1: 
+            raise ValueError("Multiple importance sampling result files found")
 
         # pesummary can't presently read a result file containing MultibandedFrequencyDomain
         # This is a hotfix to create a copy of the result file with UniformFrequencyDomain

--- a/dingo/asimov/asimov.py
+++ b/dingo/asimov/asimov.py
@@ -18,6 +18,8 @@ from asimov.pipeline import (
     PESummaryPipeline,
 )
 
+from dingo.gw.result import Result
+
 
 class Dingo(Pipeline):
     """
@@ -149,6 +151,22 @@ class Dingo(Pipeline):
             os.path.join(rundir, "result", f"*importance_sampling.hdf5")
         )
         assert len(result_files) == 1
+
+        # pesummary can't presently read a result file containing MultibandedFrequencyDomain
+        # This is a hotfix to create a copy of the result file with UniformFrequencyDomain
+        result = Result(file_name=result_files[0])
+        settings = result.settings["dataset_settings"]["domain"]
+        if settings["type"] == "MultibandedFrequencyDomain":
+            result.settings["dataset_settings"]["domain"] = {
+                "type": "UniformFrequencyDomain",
+                "delta_f": settings["delta_f_initial"],
+                "f_min": settings["base_domain"]["f_min"],
+                "f_max": settings["base_domain"]["f_max"],
+            }
+            filename, ext = os.path.splitext(result_files[0])
+            result_files[0] = f"{filename}_pesummary{ext}"
+            result.to_file(result_files[0])
+
         return result_files
 
     def upload_assets(self):

--- a/dingo/asimov/asimov.py
+++ b/dingo/asimov/asimov.py
@@ -150,7 +150,10 @@ class Dingo(Pipeline):
         result_files = glob.glob(
             os.path.join(rundir, "result", f"*importance_sampling.hdf5")
         )
-        assert len(result_files) == 1
+    if len(result_files) == 0: 
+        raise ValueError("Importance sampling result file not found")
+    elif len(result_files) > 1: 
+        raise ValueError("multiple importance sampling result files found")
 
         # pesummary can't presently read a result file containing MultibandedFrequencyDomain
         # This is a hotfix to create a copy of the result file with UniformFrequencyDomain

--- a/dingo/asimov/asimov.py
+++ b/dingo/asimov/asimov.py
@@ -92,8 +92,6 @@ class Dingo(Pipeline):
         dryrun: bool
            If set to true the commands will not be run, but will be printed to standard output. Defaults to False.
 
-
-
         Raises
         ------
         PipelineException
@@ -110,13 +108,6 @@ class Dingo(Pipeline):
             ini = os.path.join(cwd, ini)
         else:
             ini = f"{self.production.name}.ini"
-
-        rundir = self.production.rundir
-
-        if "job label" in self.production.meta:
-            job_label = self.production.meta["job label"]
-        else:
-            job_label = self.production.name
 
         command = [
             os.path.join(config.get("pipelines", "environment"), "bin", "dingo_pipe"),
@@ -144,16 +135,21 @@ class Dingo(Pipeline):
                 time.sleep(10)
                 return PipelineLogger(message=out, production=self.production.name)
 
-    def samples(self):
+    def samples(self, absolute=False):
         """
         Collect the combined samples files for PESummary.
         """
 
-        results_dir = os.path.join(self.production.rundir, "result")
-        results_filenames = glob.glob(
-            os.path.join(results_dir, f"*importance_sampling.hdf5")
+        if absolute:
+            rundir = os.path.abspath(self.production.rundir)
+        else:
+            rundir = self.production.rundir
+        self.logger.info(f"Rundir for samples: {rundir}")
+        result_files = glob.glob(
+            os.path.join(rundir, "result", f"*importance_sampling.hdf5")
         )
-        return os.path.join(results_dir, results_filenames[0])
+        assert len(result_files) == 1
+        return result_files
 
     def upload_assets(self):
         """

--- a/dingo/asimov/dingo.ini
+++ b/dingo/asimov/dingo.ini
@@ -95,13 +95,16 @@ maximum-frequency={
 }
 {%- endif %}
 tukey-roll-off={{ likelihood['roll off time'] | default: 1.0 }}
+{% if data contains 'importance sampling updates' -%}
+importance-sampling-updates={{ data['importance sampling updates']}}
+{%- endif %}
 
 ################################################################################
 ##  Job submission arguments
 ################################################################################
 
 accounting = {{ scheduler["accounting group"] }}
-accounting-user = {{ scheduler["accounting user"] | default: None }}
+accounting_user = {{ config['condor']['user'] }}
 label={{ production.name }}
 local = False
 generation-pool={{ scheduler["generation pool"] | default: 'local' }}

--- a/dingo/asimov/dingo.ini
+++ b/dingo/asimov/dingo.ini
@@ -96,7 +96,7 @@ maximum-frequency={
 {%- endif %}
 tukey-roll-off={{ likelihood['roll off time'] | default: 1.0 }}
 {% if data contains 'importance sampling updates' -%}
-importance-sampling-updates={{ data['importance sampling updates']}}
+importance-sampling-updates={{ data['importance sampling updates'] }}
 {%- endif %}
 
 ################################################################################

--- a/dingo/asimov/dingo.ini
+++ b/dingo/asimov/dingo.ini
@@ -104,7 +104,7 @@ importance-sampling-updates={{ data['importance sampling updates']}}
 ################################################################################
 
 accounting = {{ scheduler["accounting group"] }}
-accounting_user = {{ config['condor']['user'] }}
+accounting-user = {{ config['condor']['user'] }}
 label={{ production.name }}
 local = False
 generation-pool={{ scheduler["generation pool"] | default: 'local' }}

--- a/dingo/core/utils/misc.py
+++ b/dingo/core/utils/misc.py
@@ -1,3 +1,4 @@
+import re
 from typing import Callable, Iterable
 
 import numpy as np
@@ -13,7 +14,7 @@ def get_version():
         return None
 
 
-def recursive_check_dicts_are_equal(dict_a, dict_b):
+def recursive_check_dicts_are_equal(dict_a, dict_b, rtol=1e-5):
     if dict_a.keys() != dict_b.keys():
         return False
     else:
@@ -21,8 +22,27 @@ def recursive_check_dicts_are_equal(dict_a, dict_b):
             v_b = dict_b[k]
             if type(v_a) != type(v_b):
                 return False
-            if type(v_a) == dict:
+            if isinstance(v_a, dict):
                 if not recursive_check_dicts_are_equal(v_a, v_b):
+                    return False
+            elif isinstance(v_a, str):
+                # Numbers in prior strings can vary due to float precision errors
+                # This happens when the importance_sampling jobs were run on different machines
+                # To counteract this, check numbers with allclose, then check the other chars
+                pattern = r"-?\d+\.\d+"
+                numbers_a = re.findall(pattern, v_a)
+                numbers_b = re.findall(pattern, v_b)
+                if len(numbers_a) != len(numbers_b):
+                    return False
+                if numbers_a:
+                    numbers_a = list(map(float, numbers_a))
+                    numbers_b = list(map(float, numbers_b))
+                    if not np.allclose(numbers_a, numbers_b, rtol=rtol):
+                        return False
+
+                remnant_a = re.sub(pattern, "", v_a)
+                remnant_b = re.sub(pattern, "", v_b)
+                if remnant_a != remnant_b:
                     return False
             elif not np.all(v_a == v_b):
                 return False


### PR DESCRIPTION
This PR implements four changes, one of which is necessary for DINGO to be used in (offline) production. In order of importance:

1. Correct the sample() function in asimov.py to be compatible with asimov >= 0.5 (this is absolutely necessary)
2. Modify the formatting of the file given to PESummary so it can run (also necessary but could technically be fixed on the PESummary side instead)
3. Change the asimov/dingo.ini file to allow for importance sampling updates, and to correctly pass the condor user (I would not make a new release for this, but since we need a release anyway, this will make things easier)
4. Change  recursive_check_dicts_are_equal to instead use np.allclose for floats. This one is not needed if we run everything on Hypatia, but is required to run IS jobs on the broader OSG. @stephengreen suggested that instead, a new function called recursive_check_dicts_are_allclose be created, which I plan to implement

