### PR TITLE
Refactor pipe/

### DIFF
--- a/dingo/gw/domains/uniform_frequency_domain.py
+++ b/dingo/gw/domains/uniform_frequency_domain.py
@@ -155,7 +155,7 @@ class UniformFrequencyDomain(BaseFrequencyDomain):
         elif data.shape[-1] != len(self):
             raise TypeError(
                 f"Data with {data.shape[-1]} frequency bins is "
-                f"incompatible with domain."
+                f"incompatible with domain with {len(self)} bins."
             )
 
         return f

--- a/dingo/pipe/data_generation.py
+++ b/dingo/pipe/data_generation.py
@@ -76,7 +76,7 @@ class DataGenerationInput(Input):
         )
 
         if create_data:
-            if self.dingo_injection:
+            if args.dingo_injection:
                 self.create_data_dingo_injection(args)
             else:
                 self.bilby_generation_input.create_data(args)
@@ -107,7 +107,7 @@ class DataGenerationInput(Input):
 
         # Create noise with bilby_pipe and inject with DINGO
         self.bilby_generation_input.create_data(args)
-        if self.injection:
+        if args.injection:
             self._inject_dingo_signal()
 
     def _inject_dingo_signal(self):

--- a/dingo/pipe/data_generation.py
+++ b/dingo/pipe/data_generation.py
@@ -1,80 +1,56 @@
 import os
 import sys
 
-import dingo.pipe.create_injections  # Needed for delta-function time priors.
-
-import bilby
 from bilby_pipe.input import Input
-from bilby_pipe.plotting_utils import plot_whitened_data
 from bilby_pipe.data_generation import DataGenerationInput as BilbyDataGenerationInput
-from bilby.core.prior import PriorDict
 from bilby_pipe.utils import (
     parse_args,
     logger,
     convert_string_to_dict,
-    convert_prior_string_input,
     resolve_filename_with_transfer_fallback,
-    BilbyPipeError,
 )
 import lalsimulation as LS
 import numpy as np
 
-from dingo.core.posterior_models.build_model import build_model_from_kwargs
 from dingo.gw.data.event_dataset import EventDataset
 from dingo.gw.domains import UniformFrequencyDomain, build_domain_from_model_metadata
 from dingo.gw.injection import Injection
 from dingo.pipe.parser import create_parser
+from dingo.core.utils.backward_compatibility import torch_load_with_fallback
 
 logger.name = "dingo_pipe"
 
 
-class DataGenerationInput(BilbyDataGenerationInput):
-    def __init__(self, args, unknown_args, create_data=True):
-        self.model = resolve_filename_with_transfer_fallback(args.model) or args.model
-        self.model_init = args.model_init and (
-            resolve_filename_with_transfer_fallback(args.model_init) or args.model_init
-        )
+class DataGenerationInput(Input):
 
-        Input.__init__(self, args, unknown_args)
-        # Generic initialisation
+    def __init__(self, args, unknown_args, create_data=True):
+        super().__init__(args, unknown_args)
         self.meta_data = dict(
             command_line_args=args.__dict__,
             unknown_command_line_args=unknown_args,
             injection_parameters=None,
-            # bilby_version=bilby.__version__,
-            # bilby_pipe_version=get_version_information(),
         )
-        self.injection_parameters = None
 
-        # Admin arguments
-        self.ini = args.ini
-        self.transfer_files = args.transfer_files
-
-        # Global settings
-        # self.cosmology = args.cosmology
-
-        # Run index arguments
-        self.idx = args.idx
-        self.generation_seed = args.generation_seed
+        self.model = resolve_filename_with_transfer_fallback(args.model) or args.model
+        self.model_init = args.model_init and (
+            resolve_filename_with_transfer_fallback(args.model_init) or args.model_init
+        )
         self.trigger_time = args.trigger_time
 
-        # Naming arguments
-        self.outdir = args.outdir
-        self.label = args.label
+        model, _ = torch_load_with_fallback(self.model, preferred_map_location="meta")
+        self.model_metadata = model["metadata"]
 
-        # Prior arguments
-        # self.reference_frame = args.reference_frame
-        # self.time_reference = "geocent" # DINGO mod used for saving data dump
-        # self.phase_marginalization = args.phase_marginalization
-        self.prior_dict = args.prior_dict
-        self.default_prior = "BBHPriorDict"
-        self.time_reference = "geocent"
-        self.prior_dict_updates = args.prior_dict_updates
+        # ###############################
+        # TODO: AUTOCOMPLETE FROM MODEL #
+        # ###############################
+        args.detectors = self.model_metadata["train_settings"]["data"]["detectors"]
+        self.domain = build_domain_from_model_metadata(self.model_metadata, base=True)
+        assert isinstance(self.domain, UniformFrequencyDomain)
+        args.duration = int(np.round(1 / self.domain.delta_f))
 
         # Whether to generate data for importance sampling. This must be done when
         # desired data settings differ from those used for network training. If this is
         # the case, save the new data to a different file name.
-
         self.importance_sampling = args.importance_sampling_generation
         self.importance_sampling_updates = args.importance_sampling_updates
         if self.importance_sampling:
@@ -85,129 +61,32 @@ class DataGenerationInput(BilbyDataGenerationInput):
                 self.importance_sampling_updates.pop("maximum_frequency")
             vars(args).update(self.importance_sampling_updates)
 
-        # Data arguments
-        self.ignore_gwpy_data_quality_check = args.ignore_gwpy_data_quality_check
-        self.detectors = args.detectors
-        self.channel_dict = args.channel_dict
-        self.fetch_open_data_kwargs = args.fetch_open_data_kwargs
-        self.data_dict = args.data_dict
-        self.data_format = args.data_format
-        self.allow_tape = args.allow_tape
-        self.tukey_roll_off = args.tukey_roll_off
-        self.gaussian_noise = args.gaussian_noise
-        self.zero_noise = args.zero_noise
-        self.resampling_method = args.resampling_method
-
-        if args.timeslide_dict is not None:
-            self.timeslide_dict = convert_string_to_dict(args.timeslide_dict)
-            logger.info(f"Read-in timeslide dict directly: {self.timeslide_dict}")
-        elif args.timeslide_file is not None:
-            self.gps_file = args.gps_file
-            self.timeslide_file = args.timeslide_file
-            self.timeslide_dict = self.get_timeslide_dict(self.idx)
-
-        # Data duration arguments
-        self.duration = args.duration
-        self.post_trigger_duration = args.post_trigger_duration
-
-        # Frequencies
-        self.sampling_frequency = args.sampling_frequency
-        self.minimum_frequency = args.minimum_frequency
-        self.maximum_frequency = args.maximum_frequency
-        self.reference_frequency = args.reference_frequency
-
-        # Waveform, source model and likelihood
-        self.waveform_generator_class = (
-            "bilby.gw.waveform_generator.LALCBCWaveformGenerator"
-        )
-        # self.waveform_generator_class_ctor_args = (
-        #     args.waveform_generator_constructor_dict
-        # )
-        self.waveform_approximant = args.waveform_approximant
-        self.catch_waveform_errors = args.catch_waveform_errors
-        # TODO: These are set to parser defaults. Fix to set from model.
-        self.pn_spin_order = -1
-        self.pn_tidal_order = -1
-        self.pn_phase_order = -1
-        self.pn_amplitude_order = 0
-        self.mode_array = None
-        # don't set self.waveform_arguments_dict, it will be updated later by injection_waveform_arguments
-        self.waveform_arguments_dict = None
-        self.injection_waveform_arguments = args.injection_waveform_arguments
-        self.numerical_relativity_file = args.numerical_relativity_file
-        self.dingo_injection = args.dingo_injection
-        self.injection_waveform_approximant = args.injection_waveform_approximant
-        if args.injection_waveform_approximant in [
-            "SEOBNRv5PHM",
-            "SEOBNRv5EHM",
-            "SEOBNRv5HM",
-        ]:
-            self.injection_frequency_domain_source_model = "gwsignal_binary_black_hole"
-            self.frequency_domain_source_model = "gwsignal_binary_black_hole"
-        else:
-            self.injection_frequency_domain_source_model = "lal_binary_black_hole"
-            self.frequency_domain_source_model = "lal_binary_black_hole"
-
-        # DINGO mod
         self.save_bilby_data_dump = args.save_bilby_data_dump
-        if self.save_bilby_data_dump:
-            self.time_reference = args.time_reference
-            self.deltaT = args.deltaT
 
-        # self.conversion_function = args.conversion_function
-        # self.generation_function = args.generation_function
-        # self.likelihood_type = args.likelihood_type
-        # self.extra_likelihood_kwargs = args.extra_likelihood_kwargs
-        self.enforce_signal_duration = args.enforce_signal_duration
-
-        # PSD
-        self.psd_maximum_duration = args.psd_maximum_duration
-        self.psd_dict = args.psd_dict
-        self.psd_length = args.psd_length
-        self.psd_fractional_overlap = args.psd_fractional_overlap
-        self.psd_start_time = args.psd_start_time
-        self.psd_method = args.psd_method
-
-        # # ROQ
-        # self.roq_folder = args.roq_folder
-        # self.roq_linear_matrix = args.roq_linear_matrix
-        # self.roq_quadratic_matrix = args.roq_quadratic_matrix
-        # self.roq_weights = args.roq_weights
-        # self.roq_weight_format = args.roq_weight_format
-        # self.roq_scale_factor = args.roq_scale_factor
-        #
-        # # Calibration
-        # self.calibration_model = args.calibration_model
-        # self.calibration_correction_type = args.calibration_correction_type
-        # self.spline_calibration_envelope_dict = args.spline_calibration_envelope_dict
-        # self.spline_calibration_amplitude_uncertainty_dict = (
-        #     args.spline_calibration_amplitude_uncertainty_dict
-        # )
-        # self.spline_calibration_phase_uncertainty_dict = (
-        #     args.spline_calibration_phase_uncertainty_dict
-        # )
-        # self.spline_calibration_nodes = args.spline_calibration_nodes
-        # self.calibration_prior_boundary = args.calibration_prior_boundary
-        #
-        # # Marginalization
-        # self.distance_marginalization = args.distance_marginalization
-        # self.distance_marginalization_lookup_table = (
-        #     args.distance_marginalization_lookup_table
-        # )
-        # self.phase_marginalization = args.phase_marginalization
-        # self.time_marginalization = args.time_marginalization
-        # self.jitter_time = args.jitter_time
-        #
-        # # Plotting
-        self.plot_data = args.plot_data
-        self.plot_spectrogram = args.plot_spectrogram
-        self.plot_injection = args.plot_injection
+        # Build the base domain from model metadata to ensure bilby generates
+        # data with the full available frequency range. This way it won't set zeros
+        # outside the range, and DINGO can mask it later as needed.
+        self.bilby_generation_input = BilbyDataGenerationInput(
+            args, unknown_args, create_data=False
+        )
+        self.bilby_generation_input.minimum_frequency = self.domain.f_min
+        self.bilby_generation_input.maximum_frequency = self.domain.f_max
+        self.bilby_generation_input.sampling_frequency = (
+            self.lowest_sampling_frequency_from_domain()
+        )
 
         if create_data:
             if self.dingo_injection:
                 self.create_data_dingo_injection(args)
             else:
-                self.create_data(args)
+                self.bilby_generation_input.create_data(args)
+
+    def __getattr__(self, name):
+        try:
+            return getattr(self.bilby_generation_input, name)
+        except AttributeError:
+            pass
+        return None
 
     def create_data_dingo_injection(self, args):
         """Adaptation of create_data to use Dingo signal models rather than Bilby.
@@ -218,70 +97,23 @@ class DataGenerationInput(BilbyDataGenerationInput):
         Second, calls _inject_dingo_signal to generate the Dingo signal waveform and
         add it to the noisy data within the interferometers.
         """
-        # Save values of relevant args.
-        injection = args.injection
-        injection_file = args.injection_file
-        injection_dict = args.injection_dict
+        self.injection = args.injection
+        self.injection_file = args.injection_file
+        self.injection_dict = args.injection_dict
 
         args.injection = False
         args.injection_file = None
         args.injection_dict = None
 
-        # Create noise.
-        self.create_data(args)
-
-        # Reset args.
-        args.injection = injection
-        args.injection_file = injection_file
-        args.injection_dict = injection_dict
-        self.injection = args.injection
-        self.injection_file = args.injection_file
-        self.injection_dict = args.injection_dict
-
+        # Create noise with bilby_pipe and inject with DINGO
+        self.bilby_generation_input.create_data(args)
         if self.injection:
-            self._inject_dingo_signal(args)
+            self._inject_dingo_signal()
 
-    @BilbyDataGenerationInput.interferometers.setter
-    def interferometers(self, interferometers):
-        # Monkey patch to avoid bilby_pipe zeroing data below
-        # self.minimum_frequency_dict and above self.maximum_frequency_dict. Remove
-        # this code if we are happy to let bilby_pipe do this. Possible issue is edge
-        # effects for multi-banded frequency domain, so instead we do the masking
-        # within Dingo.
-        for ifo in interferometers:
-            if isinstance(ifo, bilby.gw.detector.Interferometer) is False:
-                raise BilbyPipeError(f"ifo={ifo} is not a bilby Interferometer")
-            # if self.minimum_frequency is not None:
-            #     ifo.minimum_frequency = self.minimum_frequency_dict[ifo.name]
-            # if self.maximum_frequency is not None:
-            #     ifo.maximum_frequency = self.maximum_frequency_dict[ifo.name]
-            # if self.calibration_model is not None:
-            #     self.add_calibration_model_to_interferometers(ifo)
-
-        self._interferometers = interferometers
-        self.data_set = True
-        if self.plot_data:
-            interferometers.plot_data(outdir=self.data_directory, label=self.label)
-            plot_whitened_data(
-                interferometers=interferometers,
-                data_directory=self.data_directory,
-                label=self.label,
-            )
-
-    def _inject_dingo_signal(self, args):
+    def _inject_dingo_signal(self):
         """Generate a GW signal using the dingo.gw.injection class and add it to the
         interferometer strain data. Also compute SNRs and store them."""
-        try:
-            model = build_model_from_kwargs(
-                filename=args.model, device="meta", load_training_info=False
-            )
-        except RuntimeError:
-            # 'meta' is not supported by older version of python / torch
-            model = build_model_from_kwargs(
-                filename=args.model, device="cpu", load_training_info=False
-            )
-
-        injection = Injection.from_posterior_model_metadata(model.metadata)
+        injection = Injection.from_posterior_model_metadata(self.model_metadata)
         injection.use_base_domain = True  # Do not generate MFD signals.
         injection.t_ref = self.trigger_time
         injection._initialize_transform()
@@ -339,19 +171,6 @@ class DataGenerationInput(BilbyDataGenerationInput):
         This method will also save the PSDs as .txt files in the data directory
         for easy reading by pesummary and Bilby.
         """
-
-        try:
-            model = build_model_from_kwargs(
-                filename=self.model, device="meta", load_training_info=False
-            )
-        except RuntimeError:
-            # 'meta' is not supported by older version of python / torch
-            model = build_model_from_kwargs(
-                filename=self.model, device="cpu", load_training_info=False
-            )
-        domain = build_domain_from_model_metadata(model.metadata, base=True)
-        assert isinstance(domain, UniformFrequencyDomain)
-
         if self.save_bilby_data_dump:
             # this is needed because we want bilby to use the updated DINGO
             # prior
@@ -381,14 +200,14 @@ class DataGenerationInput(BilbyDataGenerationInput):
             )
 
             # These arrays extend up to self.sampling_frequency / 2. Truncate them to
-            # the model maximum frequency, and also set the ASD to 1.0 below model
-            # minimum frequency.
-            strain = domain.update_data(strain)
-            asd = domain.update_data(asd, low_value=1.0)
+            # the base domain maximum frequency, and set the ASD to 1.0 below base domain
+            # minimum frequency (which should already be the case from bilby generation).
+            strain = self.domain.update_data(strain)
+            asd = self.domain.update_data(asd, low_value=1.0)
 
             # Dingo expects data to have trigger time 0, so we apply a cyclic time shift
             # by the post-trigger duration.
-            strain = domain.time_translate_data(strain, self.post_trigger_duration)
+            strain = self.domain.time_translate_data(strain, self.post_trigger_duration)
 
             # Note that the ASD estimated by the Bilby Interferometer differs ever so
             # slightly from the ASDs we computed before using pycbc. In addition,
@@ -469,7 +288,7 @@ class DataGenerationInput(BilbyDataGenerationInput):
         for ifo in self.interferometers:
             np.savetxt(
                 os.path.join(self.data_directory, f"{ifo.name}_psd.txt"),
-                np.vstack([domain(), data["asds"][ifo.name] ** 2]).T,
+                np.vstack([self.domain(), data["asds"][ifo.name] ** 2]).T,
             )
 
     @property
@@ -491,39 +310,12 @@ class DataGenerationInput(BilbyDataGenerationInput):
         else:
             self._importance_sampling_updates = None
 
-    @property
-    def prior_dict_updates(self):
-        """The input prior_dict from the ini (if given)
-
-        Note, this is not the bilby prior (see self.priors for that), this is
-        a key-val dictionary where the val's are strings which are converting
-        into bilby priors in `_get_prior
-        """
-        return self._prior_dict_updates
-
-    @prior_dict_updates.setter
-    def prior_dict_updates(self, prior_dict_updates):
-        if isinstance(prior_dict_updates, dict):
-            prior_dict_updates = prior_dict_updates
-        elif isinstance(prior_dict_updates, str):
-            prior_dict_updates = convert_prior_string_input(prior_dict_updates)
-        elif prior_dict_updates is None:
-            self._prior_dict_updates = None
-            return
-        else:
-            raise BilbyPipeError(
-                f"prior_dict_updates={prior_dict_updates} not " f"understood"
-            )
-
-        self._prior_dict_updates = {
-            self._convert_prior_dict_key(key): val
-            for key, val in prior_dict_updates.items()
-        }
-
-    def _get_priors(self, add_time=True):
-        priors = super()._get_priors(add_time=add_time)
-        priors.update(PriorDict(self.prior_dict_updates))
-        return priors
+    def lowest_sampling_frequency_from_domain(self):
+        """Set the sampling frequency as the lowest power of two greater than
+        self.domain.f_max that, when divided by two, is greater or equal to
+        self.domain.f_max."""
+        target = 2 * self.domain.f_max
+        return 2 ** np.ceil(np.log2(target))
 
 
 def create_generation_parser():

--- a/dingo/pipe/parser.py
+++ b/dingo/pipe/parser.py
@@ -1,17 +1,12 @@
-#
-#  Modified version of bilby_pipe parser.
-#
-
-import argparse
+"""Modified version of bilby_pipe parser."""
 
 import configargparse
-from packaging import version
 
-import bilby_pipe
 from bilby_pipe.bilbyargparser import BilbyArgParser
+from bilby_pipe.parser import StoreBoolean
+from bilby_pipe.parser import create_parser as create_bilby_pipe_parser
 from bilby_pipe.utils import (
     ENVIRONMENT_DEFAULTS,
-    get_version_information,
     logger,
     nonefloat,
     noneint,
@@ -19,27 +14,6 @@ from bilby_pipe.utils import (
 )
 
 logger.name = "dingo_pipe"
-
-# bilby_pipe v1.8.0 changed mutually exclusive group handling
-_BILBY_PIPE_V1_8 = version.parse(bilby_pipe.__version__) >= version.parse("1.8.0")
-
-
-class StoreBoolean(argparse.Action):
-    """argparse class for robust handling of booleans with configargparse
-
-    When using configargparse, if the argument is setup with
-    action="store_true", but the default is set to True, then there is no way,
-    in the config file to switch the parameter off. To resolve this, this class
-    handles the boolean properly.
-
-    """
-
-    def __call__(self, parser, namespace, value, option_string=None):
-        value = str(value).lower()
-        if value in ["true"]:
-            setattr(namespace, self.dest, True)
-        else:
-            setattr(namespace, self.dest, False)
 
 
 def create_parser(top_level=True, usage=None):
@@ -57,144 +31,36 @@ def create_parser(top_level=True, usage=None):
         Argument parser
 
     """
-    parser = BilbyArgParser(
-        usage="%(prog)s ini [options]",
-        description=usage,
-        ignore_unknown_config_file_keys=False,
-        allow_abbrev=False,
-        formatter_class=configargparse.ArgumentDefaultsRawHelpFormatter,
-    )
-    # bilby_pipe v1.8.0+ uses exclusive_keys dict instead of add_mutually_exclusive_group()
-    if _BILBY_PIPE_V1_8:
-        parser.exclusive_keys = {
+    bilby_pipe_parser = create_bilby_pipe_parser(top_level=top_level, usage=usage)
+
+    bilby_pipe_parser.exclusive_keys.update(
+        {
             "Detector arguments": ["--psd-dict", "--asd-dataset"],
             "Injection arguments": ["--injection-file", "--injection-dict"],
             "Prior arguments": ["--prior-file", "--prior-dict"],
         }
-    parser.add("ini", type=str, is_config_file=True, help="Configuration ini file")
-    parser.add("-v", "--verbose", action="store_true", help="Verbose output")
-    # parser.add(
-    #     "--version",
-    #     action="version",
-    #     version=f"%(prog)s={get_version_information()}\nbilby={bilby.__version__}",
-    # )
-
-    calibration_parser = parser.add_argument_group(
-        "Calibration arguments",
-        description="Settings for handling calibration uncertainty during importance "
-        "sampling. Calibration uncertainty can either be marginalized over (averaging "
-        "likelihoods over multiple calibration draws) or sampled (treating calibration "
-        "parameters as part of the posterior). These modes are mutually exclusive.",
-    )
-    calibration_parser.add(
-        "--calibration-model",
-        type=nonestr,
-        default=None,
-        choices=["CubicSpline", None],
-        help="Choice of calibration model, if None, no calibration is used",
     )
 
-    calibration_parser.add(
-        "--calibration-mode",
-        type=nonestr,
-        default="marginalize",
-        choices=["marginalize", "sample", None],
-        help=(
-            "How to handle calibration uncertainty. 'marginalize' averages likelihoods "
-            "over multiple calibration draws. 'sample' treats calibration parameters as "
-            "part of the posterior (importance sampling over calibration). If None or "
-            "calibration-model is None, no calibration handling is performed. "
-            "Default is 'marginalize'."
-        ),
+    dingo_parser = bilby_pipe_parser.add_argument_group(
+        title="DINGO-specific arguments",
     )
-
-    calibration_parser.add(
-        "--calibration-correction-type",
-        type=nonestr,
-        default=None,
-        help=(
-            "Allowed calibration correction types are `data` and `template`."
-            "Can either be a dictionary of correction types for each detector"
-            " or a string indicating a single correction type applied to all detectors"
-            " If `None` is passed, {H1:data, L1:data, V1:template, K1:data} is assumed"
-            " See https://bilby-dev.github.io/bilby/api/bilby.gw.detector.calibration.html "
-            "for more information."
-        ),
-    )
-
-    calibration_parser.add(
-        "--spline-calibration-envelope-dict",
-        type=nonestr,
-        default=None,
-        help=("Dictionary pointing to the spline calibration envelope files"),
-    )
-
-    calibration_parser.add(
-        "--spline-calibration-nodes",
-        type=int,
-        default=10,
-        help=("Number of calibration nodes"),
-    )
-
-    calibration_parser.add(
-        "--spline-calibration-curves",
-        type=int,
-        default=1000,
-        help=(
-            "Number of calibration curves to use when marginalizing over calibration "
-            "uncertainty. Only used when calibration-mode='marginalize'."
-        ),
-    )
-    #
-    # calibration_parser.add(
-    #     "--spline-calibration-amplitude-uncertainty-dict",
-    #     type=nonestr,
-    #     default=None,
-    #     help=(
-    #         "Dictionary of the amplitude uncertainties for the constant "
-    #         "uncertainty model"
-    #     ),
-    # )
-    #
-    # calibration_parser.add(
-    #     "--spline-calibration-phase-uncertainty-dict",
-    #     type=nonestr,
-    #     default=None,
-    #     help=(
-    #         "Dictionary of the phase uncertainties for the constant "
-    #         "uncertainty model"
-    #     ),
-    # )
-    # calibration_parser.add(
-    #     "--calibration-prior-boundary",
-    #     type=nonestr,
-    #     default="reflective",
-    #     help="Boundary methods for the calibration prior boundary",
-    # )
 
     if top_level is False:
-        parser.add("--idx", type=int, help="The level A job index", default=0)
-        parser.add(
-            "--data-dump-file",
-            type=nonestr,
-            default=None,
-            help="Filename for the data dump: only used internally by data_analysis",
-        )
-        parser.add(
+        dingo_parser.add(
             "--event-data-file",
             type=nonestr,
             default=None,
             help="Filename for the event: only used internally by sampling and "
             "importance_sampling",
         )
-        parser.add(
+        dingo_parser.add(
             "--proposal-samples-file",
             type=nonestr,
             default=None,
             help="Filename for the proposal samples: only used internally by "
             "importance_sampling",
         )
-        parser.add(
+        dingo_parser.add(
             "--importance-sampling-generation",
             action="store_true",
             help="Whether to prepare data based on the updated importance sampling "
@@ -203,371 +69,15 @@ def create_parser(top_level=True, usage=None):
             "sampling stage.",
         )
 
-    data_gen_pars = parser.add_argument_group(
-        "Data generation arguments",
-        description="How to generate the data, e.g., from a list of gps times or simulated Gaussian noise.",
+    dingo_parser.add(
+        "--asd-dataset",
+        type=nonestr,
+        default=None,
+        help="DINGO ASDDataset file to be used for injections. If specified, dingo_pipe "
+        "will generate PSD files based on random ASDs in the dataset.",
     )
 
-    data_gen_pars.add(
-        "--ignore-gwpy-data-quality-check",
-        action=StoreBoolean,
-        default=True,
-        help=(
-            "Ignores the check to see if data queried from GWpy (ie not gaussian "
-            "noise) is obtained from time when the IFOs are in science mode."
-        ),
-    )
-
-    data_gen_pars.add(
-        "--gps-tuple",
-        type=nonestr,
-        help=(
-            "Tuple of the (start, step, number) of GPS start times. For"
-            " example, (10, 1, 3) produces the gps start times [10, 11, 12]."
-            " If given, gps-file is ignored."
-        ),
-        default=None,
-    )
-    data_gen_pars.add(
-        "--gps-file",
-        type=nonestr,
-        help=(
-            "File containing segment GPS start times. This can be a multi-"
-            "column file if (a) it is comma-separated and (b) the zeroth "
-            "column contains the gps-times to use"
-        ),
-        default=None,
-    )
-    data_gen_pars.add(
-        "--timeslide-file",
-        type=nonestr,
-        help=(
-            "File containing detector timeslides. "
-            "Requires a GPS time file to also be provided. One column for each "
-            "detector. Order of detectors specified by `--detectors` argument. "
-            "Number of timeslides must correspond to the number of GPS times provided."
-        ),
-        default=None,
-    )
-    data_gen_pars.add(
-        "--timeslide-dict",
-        type=nonestr,
-        help=(
-            "Dictionary containing detector timeslides: applies a fixed offset"
-            " per detector. E.g. to apply +1s in H1, {H1: 1}"
-        ),
-        default=None,
-    )
-    data_gen_pars.add(
-        "--trigger-time",
-        default=None,
-        type=nonestr,
-        help=(
-            "Either a GPS trigger time, or the event name (e.g. GW150914). "
-            "For event names, the gwosc package is used to identify the "
-            "trigger time"
-        ),
-    )
-    data_gen_pars.add(
-        "--n-simulation",
-        type=int,
-        default=0,
-        help=(
-            "Number of simulated segments to use with gaussian-noise "
-            "Note, this must match the number of injections specified"
-        ),
-    )
-    data_gen_pars.add(
-        "--data-dict",
-        default=None,
-        type=nonestr,
-        help="Dictionary of paths to gwf, or hdf5 data files",
-    )
-    data_gen_pars.add(
-        "--data-format",
-        default=None,
-        type=nonestr,
-        help=(
-            "If given, the data format to pass to "
-            " `gwpy.timeseries.TimeSeries.read(), see "
-            " gwpy.github.io/docs/stable/timeseries/io.html"
-        ),
-    )
-    data_gen_pars.add(
-        "--allow-tape",
-        default=True,
-        action=StoreBoolean,
-        help=(
-            "If true (default), allow reading data from tape."
-            " See `gwpy.timeseries.TimeSeries.get() for more information."
-        ),
-    )
-    data_gen_pars.add(
-        "--channel-dict",
-        type=nonestr,
-        default=None,
-        help=(
-            "Channel dictionary: keys relate to the detector with values "
-            "the channel name, e.g. 'GDS-CALIB_STRAIN'. For GWOSC open data, "
-            "set the channel-dict keys to 'GWOSC'. Note, the "
-            "dictionary should follow basic python dict syntax."
-        ),
-    )
-    data_gen_pars.add(
-        "--fetch-open-data-kwargs",
-        type=nonestr,
-        default=None,
-        help=(
-            "Dictionary of additional kwargs to pass to `fetch_open_data`. "
-            "By default, bilby_pipe requests `sample_rate=16384`. This can "
-            "be overwritten by passing `sample_rate=4096` to this argument."
-        ),
-    )
-    data_gen_pars.add(
-        "--frame-type-dict",
-        type=nonestr,
-        default=None,
-        help=(
-            "Frame type to use when finding data. If not given, defaults will "
-            "be used based on the gps time using bilby_pipe.utils.default_frame_type,"
-            " e.g., {H1: H1_HOFT_C00_AR}."
-        ),
-    )
-    data_gen_pars.add(
-        "--data-find-url",
-        type=nonestr,
-        default=None,
-        help=(
-            "URL to use for datafind. This happens during the initial attempt "
-            "to locate frames by :code:`bilby_pipe` or by "
-            ":code:`bilby_pipe_generation`. In both cases, the order of "
-            "preference is: 1) the value of this argument, 2) the value of "
-            "the environment variable GWDATAFIND_SERVER, 3) the value "
-            "of the global default in bilby_pipe.utils.DEFAULT_GWDATAFIND_SERVER. "
-            "This value will override the value of GWDATAFIND_SERVER if it is set"
-            "in :code:`getenv` or :code:`environment-variables`."
-        ),
-    )
-    data_gen_pars.add(
-        "--data-find-urltype",
-        default="osdf",
-        help="URL type to use for datafind, default is osdf",
-    )
-    data_type_pars = data_gen_pars.add_mutually_exclusive_group()
-    data_type_pars.add(
-        "--gaussian-noise",
-        action="store_true",
-        help="If true, use simulated Gaussian noise",
-    )
-    data_type_pars.add(
-        "--zero-noise",
-        action="store_true",
-        help="Use a zero noise realisation",
-    )
-
-    det_parser = parser.add_argument_group(
-        title="Detector arguments",
-        description="How to set up the interferometers and power spectral density.",
-    )
-    # det_parser.add(
-    #     "--coherence-test",
-    #     action="store_true",
-    #     help=(
-    #         "Run the analysis for all detectors together and for each "
-    #         "detector separately"
-    #     ),
-    # )
-    det_parser.add(
-        "--detectors",
-        action="append",
-        help=(
-            "The names of detectors to use. If given in the ini file, "
-            "detectors are specified by `detectors=[H1, L1]`. If given "
-            "at the command line, as `--detectors H1 --detectors L1`"
-        ),
-    )
-    det_parser.add(
-        "--duration",
-        type=nonefloat,
-        # default=4,
-        default=None,
-        help="The duration of data around the event to use",
-    )
-    det_parser.add(
-        "--generation-seed",
-        default=None,
-        type=noneint,
-        help=(
-            "Random seed used during data generation. If no generation seed "
-            "provided, a random seed between 1 and 1e6 is selected. If a seed "
-            "is provided, it is used as the base seed and all generation jobs "
-            "will have their seeds set as {generation_seed = base_seed + job_idx}."
-        ),
-    )
-    # Mutually exclusive: --psd-dict / --asd-dataset
-    if _BILBY_PIPE_V1_8:
-        det_parser.add(
-            "--psd-dict", type=nonestr, default=None, help="Dictionary of PSD files to use"
-        )
-        det_parser.add(
-            "--asd-dataset",
-            type=nonestr,
-            default=None,
-            help="DINGO ASDDataset file to be used for injections. If specified, dingo_pipe "
-            "will generate PSD files based on random ASDs in the dataset.",
-        )
-    else:
-        psd_dict_parser = det_parser.add_mutually_exclusive_group()
-        psd_dict_parser.add(
-            "--psd-dict", type=nonestr, default=None, help="Dictionary of PSD files to use"
-        )
-        psd_dict_parser.add(
-            "--asd-dataset",
-            type=nonestr,
-            default=None,
-            help="DINGO ASDDataset file to be used for injections. If specified, dingo_pipe "
-            "will generate PSD files based on random ASDs in the dataset.",
-        )
-    det_parser.add(
-        "--psd-fractional-overlap",
-        # default=0.5,
-        default=0.0,
-        type=float,
-        help="Fractional overlap of segments used in estimating the PSD",
-    )
-    det_parser.add(
-        "--post-trigger-duration",
-        type=float,
-        default=2.0,
-        help=("Time (in s) after the trigger_time to the end of the segment"),
-    )
-    det_parser.add("--sampling-frequency", default=4096, type=float)
-
-    det_parser.add(
-        "--psd-length",
-        default=32,
-        type=int,
-        help=(
-            "Sets the psd duration (up to the psd-duration-maximum). PSD "
-            "duration calculated by psd-length x duration [s]. Default is 32."
-        ),
-    )
-    det_parser.add(
-        "--psd-maximum-duration",
-        default=1024,
-        type=int,
-        help=("The maximum allowed PSD duration in seconds, default is 1024s."),
-    )
-    det_parser.add(
-        "--psd-method",
-        default="median",
-        type=str,
-        help="PSD method see gwpy.timeseries.TimeSeries.psd for options",
-    )
-    det_parser.add(
-        "--psd-start-time",
-        default=None,
-        type=nonefloat,
-        help=(
-            "Start time of data (relative to the segment start) used to "
-            " generate the PSD. Defaults to psd-duration before the"
-            " segment start time"
-        ),
-    )
-    det_parser.add(
-        "--maximum-frequency",
-        default=None,
-        type=nonestr,
-        help=(
-            "The maximum frequency, given either as a float for all detectors "
-            "or as a dictionary (see minimum-frequency)"
-        ),
-    )
-    det_parser.add(
-        "--minimum-frequency",
-        # default="20",
-        default=None,
-        type=nonestr,
-        help=(
-            "The minimum frequency, given either as a float for all detectors "
-            "or as a dictionary where all keys relate the detector with values"
-            " of the minimum frequency, e.g. {H1: 10, L1: 20}. If the waveform"
-            " generation should start the minimum frequency for any of the "
-            "detectors, add another entry to the dictionary, e.g., "
-            "{H1: 40, L1: 60, waveform: 20}."
-        ),
-    )
-    det_parser.add(
-        "--tukey-roll-off",
-        default=1.0,
-        type=nonefloat,
-        help="Roll off duration of tukey window in seconds, default is 0.4s",
-    )
-    det_parser.add(
-        "--resampling-method",
-        default="lal",
-        type=str,
-        choices=["lal", "gwpy"],
-        help="Resampling method to use: lal matches the resampling used by lalinference/BayesWave",
-    )
-
-    injection_parser = parser.add_argument_group(
-        title="Injection arguments",
-        description="Whether to include software injections and how to generate them.",
-    )
-    injection_parser.add(
-        "--injection",
-        action="store_true",
-        default=False,
-        help="Create data from an injection file",
-    )
-    # Mutually exclusive: --injection-dict / --injection-file
-    if _BILBY_PIPE_V1_8:
-        injection_parser.add(
-            "--injection-dict",
-            type=nonestr,
-            default=None,
-            help="A single injection dictionary given in the ini file",
-        )
-        injection_parser.add(
-            "--injection-file",
-            type=nonestr,
-            default=None,
-            help=(
-                "Injection file to use. See `bilby_pipe_create_injection_file --help`"
-                " for supported formats"
-            ),
-        )
-    else:
-        injection_parser_input = injection_parser.add_mutually_exclusive_group()
-        injection_parser_input.add(
-            "--injection-dict",
-            type=nonestr,
-            default=None,
-            help="A single injection dictionary given in the ini file",
-        )
-        injection_parser_input.add(
-            "--injection-file",
-            type=nonestr,
-            default=None,
-            help=(
-                "Injection file to use. See `bilby_pipe_create_injection_file --help`"
-                " for supported formats"
-            ),
-        )
-    injection_parser.add(
-        "--injection-numbers",
-        action="append",
-        type=nonestr,
-        default=None,
-        help=(
-            "Specific injections rows to use from the injection_file, e.g. "
-            "`injection_numbers=[0,3] selects the zeroth and third row. Can be "
-            "a list of slice-syntax values, e.g, [0, 2:4] will produce [0, 2, 3]. "
-            "Repeated entries will be ignored."
-        ),
-    )
-    injection_parser.add(
+    dingo_parser.add(
         "--dingo-injection",
         action="store_true",
         help=(
@@ -576,44 +86,7 @@ def create_parser(top_level=True, usage=None):
             "still generated using bilby_pipe. Defaults to false."
         ),
     )
-    injection_parser.add(
-        "--injection-waveform-approximant",
-        type=nonestr,
-        default=None,
-        help="The name of the waveform approximant to use to create injections. "
-        "If none is specified, then the `waveform-approximant` will be used"
-        "as the `injection-waveform-approximant`.",
-    )
-    injection_parser.add(
-        "--injection-frequency-domain-source-model",
-        type=nonestr,
-        default=None,
-        help="Frequency domain source model to use for generating injections. "
-        "If this is None, it will default to the frequency domain source model"
-        "used for analysis.",
-    )
-    injection_parser.add(
-        "--injection-waveform-arguments",
-        type=nonestr,
-        default=None,
-        help=(
-            "A dictionary of arbitrary additional waveform-arguments to pass "
-            "to the bilby waveform generator's waveform arguments for the "
-            "injection only"
-        ),
-    )
-    injection_parser.add(
-        "--injection-waveform-generator-constructor-dict",
-        default=None,
-        type=nonestr,
-        help=(
-            "A dictionary of arbitrary arguments to pass"
-            " to the bilby waveform generator class constructor for the injection"
-            " only. The class will be the same as the one specified in"
-            " '--waveform-generator'."
-        ),
-    )
-    injection_parser.add(
+    dingo_parser.add(
         "--save-bilby-data-dump",
         action=StoreBoolean,
         default=False,
@@ -623,939 +96,61 @@ def create_parser(top_level=True, usage=None):
         ),
     )
 
-    submission_parser = parser.add_argument_group(
-        title="Job submission arguments",
-        description="How the jobs should be formatted, e.g., which job scheduler to use.",
-    )
-    submission_parser.add(
-        "--accounting",
-        type=nonestr,
-        help="Accounting group to use (see, https://accounting.ligo.org/user)",
-    )
-    submission_parser.add(
-        "--accounting-user",
-        type=nonestr,
-        help="Accounting group user to use (see, https://accounting.ligo.org/user)",
-    )
-    submission_parser.add("--label", type=str, default="label", help="Output label")
-    submission_parser.add(
-        "--local",
-        action="store_true",
-        help="Run the job locally, i.e., not through a batch submission",
-    )
-    submission_parser.add(
-        "--local-generation",
-        action="store_true",
-        help=(
-            "Run the data generation job locally. This may be useful for "
-            "running on a cluster where the compute nodes do not have "
-            "internet access. For HTCondor, this is done using the local "
-            "universe, for slurm, the jobs will be run at run-time"
-        ),
-    )
-    submission_parser.add(
-        "--generation-pool",
-        default="local-pool",
-        choices=["local", "local-pool", "igwn-pool"],
-        help=(
-            "Where to run the data generation job. Options are [local-pool, "
-            "local, igwn-pool]. If local-pool, the data generation job is "
-            "submitted to the local HTCondor pool. If local, the data "
-            "generation job is run on the submit node. If igwn-pool, the "
-            "data generation job is submitted to the IGWN HTCondor pool (osg)"
-            " if the submit node has access to the IGWN pool. In general, "
-            "the igwn-pool should be used when possible, but some large files, "
-            "e.g., ROQ bases may not be available via CVMFS and so the local-pool "
-            "should be used. (default: local-pool)"
-        ),
-    )
-    submission_parser.add(
-        "--local-plot", action="store_true", help="Run the plot job locally"
-    )
-
-    submission_parser.add(
-        "--outdir",
-        type=str,
-        default="outdir",
-        help="The output directory. If outdir already exists, an auto-incrementing naming scheme is used",
-    )
-    submission_parser.add(
-        "--overwrite-outdir",
-        action="store_true",
-        help="If given, overwrite the outdir (if it exists)",
-    )
-    # submission_parser.add(
-    #     "--periodic-restart-time",
-    #     default=28800,
-    #     type=int,
-    #     help=(
-    #         "Time after which the job will self-evict when scheduler=condor."
-    #         " After this, condor will restart the job. Default is 28800."
-    #         " This is used to decrease the chance of HTCondor hard evictions"
-    #     ),
-    # )
-    submission_parser.add(
-        "--request-disk",
-        type=float,
-        default=5,
-        help="Disk allocation request in GB. Default is 5GB.",
-    )
-    submission_parser.add(
-        "--request-memory-generation",
-        type=nonefloat,
-        # default=None,
-        default=8.0,  # Change this to None if possibility of ROQ (likely remove ROQ)
-        help="Memory allocation request (GB) for data generation step",
-    )
-    submission_parser.add(
-        "--request-memory",
-        type=float,
-        default=8.0,
-        help="Memory allocation request (GB) for sampling step. Default is 8GB",
-    )
-    submission_parser.add(
-        "--request-cpus",
-        type=int,
-        default=1,
-        help=(
-            "Use multi-processing during sampling. This options sets the number of cores to "
-            "request per job when performing sampling."
-        ),
-    )
-    submission_parser.add(
-        "--request-memory-importance-sampling",
-        type=float,
-        default=8.0,
-        help="Memory allocation request (GB) for importance sampling step. Default is 8GB",
-    )
-    submission_parser.add(
-        "--request-cpus-importance-sampling",
-        type=int,
-        default=1,
-        help=(
-            "Use multi-processing. This options sets the number of cores to "
-            "request per job when performing importance sampling. To use a pool of 8 "
-            "threads on an 8-core CPU, set request-cpus-importance-sampling=8."
-        ),
-    )
-    submission_parser.add(
-        "--conda-env",
-        type=nonestr,
-        default=None,
-        help="Either a conda environment name of a absolute path to the conda env folder.",
-    )
-    submission_parser.add(
-        "--sampling-requirements",
-        action="append",
-        help=(
-            "List of extra requirements for submitting sampling. Can be used to specify "
-            "GPU memory, e.g., [TARGET.CUDAGlobalMemoryMb>40000]."
-        ),
-    )
-    submission_parser.add(
-        "--extra-lines",
-        action="append",
-        help=("List of additional lines to include for all HTCondor submissions."),
-    )
-    submission_parser.add(
-        "--simple-submission",
-        action="store_true",
-        help=(
-            "Strip off the following lines from submission files: getenv, universe, "
-            "accounting_group, priority."
-        ),
-    )
-    submission_parser.add(
-        "--scheduler",
-        type=str,
-        default="condor",
-        help="Format submission script for specified scheduler. Currently implemented: SLURM",
-    )
-    submission_parser.add(
-        "--scheduler-args",
-        type=nonestr,
-        default=None,
-        help=(
-            "Space-separated #SBATCH command line args to pass to slurm. "
-            "The args needed will depend on the setup of your slurm scheduler."
-            "Please consult documentation for your local cluster (slurm only)."
-        ),
-    )
-    submission_parser.add(
-        "--scheduler-module",
-        type=nonestr,
-        action="append",
-        default=None,
-        help="Space-separated list of modules to load at runtime (slurm only)",
-    )
-    submission_parser.add(
-        "--scheduler-env",
-        type=nonestr,
-        default=None,
-        help="Python environment to activate (slurm only)",
-    )
-    submission_parser.add(
-        "--scheduler-analysis-time", type=nonestr, default="7-00:00:00", help=""
-    )
-    submission_parser.add(
-        "--submit",
-        action="store_true",
-        help="Attempt to submit the job after the build",
-    )
-    submission_parser.add(
-        "--condor-job-priority",
-        type=int,
-        default=0,
-        help=(
-            "Job priorities allow a user to sort their HTCondor jobs to determine "
-            "which are tried to be run first. "
-            "A job priority can be any integer: larger values denote better priority. "
-            "By default HTCondor job priority=0. "
-        ),
-    )
-    submission_parser.add(
-        "--transfer-files",
-        action=StoreBoolean,
-        default=True,
-        help=(
-            "If true (default), use the HTCondor file transfer mechanism"
-            " For non-condor schedulers, this option is ignored."
-            " Note: the log files are automatically synced, but to sync the "
-            " results during the run (e.g. to inspect progress), use the "
-            " executable bilby_pipe_htcondor_sync"
-        ),
-    )
-    submission_parser.add(
-        "--environment-variables",
-        default=None,
-        type=nonestr,
-        help=(
-            "Key value pairs for environment variables formatted as a json string, "
-            "e.g., '{'OMP_NUM_THREADS': 1, 'LAL_DATA_PATH'='/home/data'}'. These values "
-            f"take precedence over --getenv. The default values are {ENVIRONMENT_DEFAULTS}."
-        ),
-    )
-    submission_parser.add(
-        "--getenv",
-        default=None,
-        action="append",
-        type=nonestr,
-        help="List of environment variables to copy from the current session.",
-    )
-    submission_parser.add(
-        "--additional-transfer-paths",
-        action="append",
-        default=None,
-        type=nonestr,
-        help=(
-            "Additional files that should be transferred to the analysis jobs. "
-            "The default is not transferring any additional files. Additional "
-            "files can be specified as a list in the configuration file [a, b] "
-            "or on the command line as --additional-transfer-paths a "
-            "--additonal-transfer-paths b"
-        ),
-    )
-    submission_parser.add(
-        "--disable-hdf5-locking",
-        action=StoreBoolean,
-        default=False,
-        help=(
-            "If true (default), disable HDF5 locking. This can improve "
-            "stability on some clusters, but may cause issues if multiple "
-            "processes are reading/writing to the same file."
-            "This argument is deprecated and should be passed through --environment-variables"
-        ),
-    )
-    submission_parser.add(
-        "--log-directory",
-        type=nonestr,
-        default=None,
-        help="If given, an alternative path for the log output",
-    )
-    submission_parser.add(
-        "--osg",
-        action="store_true",
-        default=False,
-        help="If true, format condor submission for running on OSG, default is False",
-    )
-    submission_parser.add(
-        "--gpu-desired-sites",
-        type=nonestr,
-        help=(
-            "A comma-separated list of desired sites, wrapped in quoates."
-            " e.g., desired-sites='site1,site2'. This can be used on the OSG"
-            " to specify specific run nodes. This determines which GPU site to use."
-        ),
-    )
-    submission_parser.add(
-        "--cpu-desired-sites",
-        type=nonestr,
-        help=(
-            "A comma-separated list of desired sites, wrapped in quoates."
-            " e.g., desired-sites='site1,site2'. This can be used on the OSG"
-            " to specify specific run nodes. This determines which CPU site to use."
-        ),
-    )
-    submission_parser.add(
-        "--generation-desired-sites",
-        type=nonestr,
-        help=(
-            "A comma-separated list of desired sites, wrapped in quoates."
-            " e.g., desired-sites='site1,site2'. This can be used on the OSG"
-            " to specify specific run nodes. This determines which site to use during data generation."
-        ),
-    )
-    submission_parser.add(
-        "--analysis-executable",
-        default=None,
-        type=nonestr,
-        help=(
-            "Path to an executable to replace bilby_pipe_analysis, be aware"
-            " that this executable will pass the complete ini file (in the"
-            " outdir.)"
-        ),
-    )
-    submission_parser.add(
-        "--analysis-executable-parser",
-        default=None,
-        type=nonestr,
-        help=(
-            "Python path to the analysis executable parser, used in conjunction"
-            " with analysis-executable. Note, if this is not provided any"
-            " new arguments to analysis-executable will raise a warning, but"
-            " they will be passed to the executable directly."
-        ),
-    )
-    submission_parser.add(
-        "--scitoken-issuer",
-        default=None,
-        type=nonestr,
-        choices=[None, "None", "igwn", "local"],
-        help=(
-            "The issuer of the scitoken to use for accessing IGWN proprietary "
-            "data/services. If not given, this is automatically set based on "
-            "the machine being used. This should only be set if you are planning "
-            "to submit from a different machine to the one you are running on. "
-            "The allowed options are :code:`igwn` and :code:`local`. "
-            "For more details see "
-            "https://computing.docs.ligo.org/guide/htcondor/credentials."
-        ),
-    )
-    submission_parser.add(
-        "--container",
-        default=None,
-        type=nonestr,
-        help=(
-            "(Optional) singularity image to use, see "
-            "https://computing.docs.ligo.org/guide/htcondor/software "
-            "and https://computing.docs.ligo.org/guide/dhtc/containers "
-            "for more details."
-        ),
-    )
-    likelihood_parser = parser.add_argument_group(
-        title="Likelihood arguments",
-        description="Options for setting up the likelihood.",
-    )
-    # likelihood_parser.add(
-    #     "--distance-marginalization",
-    #     action="store_true",
-    #     default=False,
-    #     help="Boolean. If true, use a distance-marginalized likelihood",
-    # )
-    # likelihood_parser.add(
-    #     "--distance-marginalization-lookup-table",
-    #     default=None,
-    #     type=nonestr,
-    #     help="Path to the distance-marginalization lookup table",
-    # )
-    #
-    # likelihood_parser.add(
-    #     "--phase-marginalization",
-    #     action="store_true",
-    #     default=False,
-    #     help="Boolean. If true, use a phase-marginalized likelihood",
-    # )
-    # likelihood_parser.add(
-    #     "--time-marginalization",
-    #     action="store_true",
-    #     default=False,
-    #     help="Boolean. If true, use a time-marginalized likelihood",
-    # )
-    # likelihood_parser.add(
-    #     "--jitter-time",
-    #     action=StoreBoolean,
-    #     default=True,
-    #     help="Boolean. If true, and using a time-marginalized likelihood 'time jittering' will be performed",
-    # )
-    # likelihood_parser.add(
-    #     "--reference-frame",
-    #     default="sky",
-    #     type=str,
-    #     help="Reference frame for the sky parameterisation, either 'sky' (default) or, e.g., 'H1L1'",
-    # )
-    likelihood_parser.add(
-        "--time-reference",
-        default="geocent",
-        type=str,
-        help="Time parameter to sample in, either 'geocent' (default) or, e.g., 'H1'",
-    )
-    # likelihood_parser.add(
-    #     "--likelihood-type",
-    #     default="GravitationalWaveTransient",
-    #     help=(
-    #         "The likelihood. Can be one of [GravitationalWaveTransient, "
-    #         "ROQGravitationalWaveTransient, zero] or python path to a bilby "
-    #         "likelihood class available in the users installation. "
-    #         "The --roq-folder or both --linear-matrix and --quadratic-matrix "
-    #         "are required if the ROQ likelihood used. If both the options are "
-    #         "specified, ROQ data are taken from roq-folder, and linear-matrix "
-    #         "and quadratic-matrix are ignored."
-    #         "If `zero` is given, a testing ZeroLikelihood is used which always"
-    #         "return zero."
-    #     ),
-    # )
-    # likelihood_parser.add(
-    #     "--roq-folder", type=nonestr, default=None, help="The data for ROQ"
-    # )
-    # likelihood_parser.add(
-    #     "--roq-linear-matrix",
-    #     type=nonestr,
-    #     default=None,
-    #     help="Path to ROQ basis for linear inner products. This option is ignored if roq-folder is not None.",
-    # )
-    # likelihood_parser.add(
-    #     "--roq-quadratic-matrix",
-    #     type=nonestr,
-    #     default=None,
-    #     help="Path to ROQ basis for quadratic inner products. This option is ignored if roq-folder is not None.",
-    # )
-    # likelihood_parser.add(
-    #     "--roq-weights",
-    #     type=nonestr,
-    #     default=None,
-    #     help=(
-    #         "If given, the ROQ weights to use (rather than building them). "
-    #         "This must be given along with the roq-folder for checking"
-    #     ),
-    # )
-    # likelihood_parser.add(
-    #     "--roq-weight-format",
-    #     type=nonestr,
-    #     default=None,
-    #     help=(
-    #         "File format of roq weights. This should be npz, hdf5, or json. "
-    #         "If not specified, it is set to npz if basis file is specified "
-    #         "through roq-folder, and hdf5 if through roq-linear-matrix and "
-    #         "roq-quadratic-matrix"
-    #     ),
-    # )
-    # likelihood_parser.add(
-    #     "--roq-scale-factor",
-    #     default=1,
-    #     type=float,
-    #     help="Rescaling factor for the ROQ, default is 1 (no rescaling)",
-    # )
-    # likelihood_parser.add(
-    #     "--extra-likelihood-kwargs",
-    #     type=nonestr,
-    #     default=None,
-    #     help="Additional keyword arguments to pass to the likelihood. Any arguments "
-    #     "which are named bilby_pipe arguments, e.g., distance_marginalization "
-    #     "should NOT be included. This is only used if you are not using the "
-    #     "GravitationalWaveTransient or ROQGravitationalWaveTransient likelihoods",
-    # )
-
-    output_parser = parser.add_argument_group(
-        title="Output arguments", description="What kind of output/summary to generate."
-    )
-    # output_parser.add_argument(
-    #     "--plot-trace",
-    #     action="store_true",
-    #     help="Create traceplots during the run",
-    # )
-    output_parser.add_argument(
-        "--plot-data",
-        action="store_true",
-        help="Create plot of the frequency domain data",
-    )
-    output_parser.add_argument(
-        "--plot-injection",
-        action="store_true",
-        help="Create time-domain plot of the injection",
-    )
-    output_parser.add_argument(
-        "--plot-spectrogram",
-        action="store_true",
-        help="Create spectrogram plot",
-    )
-    # output_parser.add_argument(
-    #     "--plot-calibration",
-    #     action="store_true",
-    #     help="Create calibration posterior plot",
-    # )
-    output_parser.add_argument(
-        "--plot-corner",
-        action="store_true",
-        help="Create corner plot",
-    )
-    output_parser.add_argument(
-        "--plot-weights",
-        action="store_true",
-        help="Create scatter plot of importance weights",
-    )
-    output_parser.add_argument(
-        "--plot-log-probs",
-        action="store_true",
-        help="Create scatter plot of target versus proposal log probabilities",
-    )
-    output_parser.add_argument(
-        "--plot-pp",
-        action="store_true",
-        help="Create PP plot based on several injections.",
-    )
-    # output_parser.add_argument(
-    #     "--plot-marginal",
-    #     action="store_true",
-    #     help="Create 1-d marginal posterior plots",
-    # )
-    # output_parser.add_argument(
-    #     "--plot-skymap", action="store_true", help="Create posterior skymap"
-    # )
-    # output_parser.add_argument(
-    #     "--plot-waveform", action="store_true", help="Create waveform posterior plot"
-    # )
-    # output_parser.add_argument(
-    #     "--plot-format",
-    #     default="png",
-    #     help="Format for making bilby_pipe plots, can be [png, pdf, html]. "
-    #     "If specified format is not supported, will default to png.",
-    # )
-    #
-    output_parser.add(
-        "--create-summary", action="store_true", help="Create a PESummary page"
-    )
-    output_parser.add("--email", type=nonestr, help="Email for notifications")
-    output_parser.add(
-        "--notification",
-        type=nonestr,
-        default="Never",
-        help=(
-            "Notification setting for HTCondor jobs. "
-            "One of 'Always','Complete','Error','Never'. "
-            "If defined by 'Always', "
-            "the owner will be notified whenever the job "
-            "produces a checkpoint, as well as when the job completes. "
-            "If defined by 'Complete', "
-            "the owner will be notified when the job terminates. "
-            "If defined by 'Error', "
-            "the owner will only be notified if the job terminates abnormally, "
-            "or if the job is placed on hold because of a failure, "
-            "and not by user request. "
-            "If defined by 'Never' (the default), "
-            "the owner will not receive e-mail, regardless to what happens to the job. "
-            "Note, an `email` arg is also required for notifications to be emailed. "
-        ),
-    )
-    output_parser.add(
-        "--queue",
-        type=nonestr,
-        help="Condor job queue. Use Online_PE for online parameter estimation runs.",
-    )
-    output_parser.add(
-        "--existing-dir",
-        type=nonestr,
-        default=None,
-        help=(
-            "If given, add results to an directory with an an existing"
-            " summary.html file"
-        ),
-    )
-    output_parser.add(
-        "--webdir",
-        type=nonestr,
-        default=None,
-        help=(
-            "Directory to store summary pages. If not given, defaults to "
-            "outdir/results_page"
-        ),
-    )
-    output_parser.add(
-        "--summarypages-arguments",
-        type=nonestr,
-        default=None,
-        help="Arguments (in the form of a dictionary) to pass to the summarypages executable",
-    )
-    output_parser.add(
-        "--result-format",
-        type=str,
-        default="hdf5",
-        choices=["json", "hdf5", "pickle"],
-        help="Format to save the result file in.",
-    )
-    output_parser.add(
-        "--final-result",
-        action=StoreBoolean,
-        default=True,
-        help="If true (default), generate a set of lightweight downsamples final results.",
-    )
-    output_parser.add(
-        "--final-result-nsamples",
-        default=20000,
-        type=int,
-        help="Maximum number of samples to keep in the final results",
-    )
-
-    prior_parser = parser.add_argument_group(
-        title="Prior arguments", description="Specify the prior settings."
-    )
-    prior_parser.add(
-        "--default-prior",
-        default="BBHPriorDict",
-        type=str,
-        help=(
-            "The name of the prior set to base the prior on. Can be one of"
-            "[PriorDict, BBHPriorDict, BNSPriorDict, CalibrationPriorDict]"
-            "or a python path to a bilby prior class available in the user's installation."
-        ),
-    )
-    prior_parser.add(
-        "--deltaT",
-        type=nonefloat,
-        default=None,
-        help=(
-            "The symmetric width (in s) around the trigger time to"
-            " search over the coalescence time"
-        ),
-    )
-    prior_parser.add(
-        "--Toffset",
-        type=nonefloat,
-        default=None,
-        help=(
-            "Offset of the center of the time prior from the trigger time (in s). "
-            "Useful for DeltaFunction priors. Generally set by DINGO model."
-        ),
-    )
-    prior_parser.add(
-        "--prior-dict-updates",
-        type=nonestr,
-        default=None,
-        help=(
-            "A dictionary of priors. Multiline "
-            "dictionaries are supported, but each line must contain a single"
-            "parameter specification and finish with a comma. Dingo priors are set at "
-            "network training time, so the prior-dict-update is used at importance "
-            "sampling "
-            "time to re-weight to the new prior. The prior-dict does not have to be "
-            "a prior over the entire set of parameters, only the parameters for which "
-            "the prior is changed."
-        ),
-    )
-    # Mutually exclusive: --prior-file / --prior-dict
-    if _BILBY_PIPE_V1_8:
-        prior_parser.add("--prior-file", type=nonestr, default=None, help="The prior file")
-        prior_parser.add(
-            "--prior-dict",
-            type=nonestr,
-            default=None,
-            help=(
-                "A dictionary of priors (alternative to prior-file). Multiline "
-                "dictionaries are supported, but each line must contain a single"
-                "parameter specification and finish with a comma. Dingo priors are set at "
-                "network training time, so the prior-dict should not be provided by the "
-                "user! Use 'prior-dict-update' to update the prior for importance sampling."
-            ),
-        )
-    else:
-        prior_parser_main = prior_parser.add_mutually_exclusive_group()
-        prior_parser_main.add("--prior-file", type=nonestr, default=None, help="The prior file")
-        prior_parser_main.add(
-            "--prior-dict",
-            type=nonestr,
-            default=None,
-            help=(
-                "A dictionary of priors (alternative to prior-file). Multiline "
-                "dictionaries are supported, but each line must contain a single"
-                "parameter specification and finish with a comma. Dingo priors are set at "
-                "network training time, so the prior-dict should not be provided by the "
-                "user! Use 'prior-dict-update' to update the prior for importance sampling."
-            ),
-        )
-    prior_parser.add(
-        "--enforce-signal-duration",
-        action=StoreBoolean,
-        default=True,
-        help=(
-            "Whether to require that all signals fit within the segment duration. "
-            "The signal duration is calculated using a post-Newtonian approximation."
-        ),
-    )
-
-    # postprocessing_parser = parser.add_argument_group(
-    #     title="Post processing arguments",
-    #     description="What post-processing to perform.",
-    # )
-    # postprocessing_parser.add(
-    #     "--postprocessing-executable",
-    #     type=nonestr,
-    #     default=None,
-    #     help=(
-    #         "An executable name for postprocessing. A single postprocessing "
-    #         " job is run as a child of all analysis jobs"
-    #     ),
-    # )
-    # postprocessing_parser.add(
-    #     "--postprocessing-arguments",
-    #     type=nonestr,
-    #     default=None,
-    #     help="Arguments to pass to the postprocessing executable",
-    # )
-    # postprocessing_parser.add(
-    #     "--single-postprocessing-executable",
-    #     type=nonestr,
-    #     default=None,
-    #     help=(
-    #         "An executable name for postprocessing. A single postprocessing "
-    #         "job is run as a child for each analysis jobs: note the "
-    #         "difference with respect postprocessing-executable"
-    #     ),
-    # )
-    # postprocessing_parser.add(
-    #     "--single-postprocessing-arguments",
-    #     type=nonestr,
-    #     default=None,
-    #     help=(
-    #         "Arguments to pass to the single postprocessing executable. The "
-    #         "str '$RESULT' will be replaced by the path to the individual "
-    #         "result file"
-    #     ),
-    # )
-
-    # sampler_parser = parser.add_argument_group(title="Sampler arguments")
-    # sampler_parser.add("--sampler", type=str, default="dynesty", help="Sampler to use")
-    # sampler_parser.add(
-    #     "--sampling-seed", default=None, type=noneint, help="Random sampling seed"
-    # )
-
-    # sampler_parser.add(
-    #     "--sampler-kwargs",
-    #     type=str,
-    #     default="DynestyDefault",
-    #     help=(
-    #         "Dictionary of sampler-kwargs to pass in, e.g., {nlive: 1000} OR "
-    #         "pass pre-defined set of sampler-kwargs {DynestyDefault, BilbyMCMCDefault, FastTest}"
-    #     ),
-    # )
-
-    # Waveform arguments
-    waveform_parser = parser.add_argument_group(
-        title="Waveform arguments", description="Setting for the waveform generator"
-    )
-    # waveform_parser.add(
-    #     "--waveform-generator",
-    #     default="bilby.gw.waveform_generator.LALCBCWaveformGenerator",
-    #     type=str,
-    #     help="The waveform generator class, should be a python path. This will "
-    #     "not be able to use any arguments not passed to the default.",
-    # )
-    # waveform_parser.add(
-    #     "--waveform-generator-constructor-dict",
-    #     default=None,
-    #     type=nonestr,
-    #     help=(
-    #         "A dictionary of arbitrary arguments to pass"
-    #         " to the bilby waveform generator class constructor."
-    #     ),
-    # )
-    waveform_parser.add(
-        "--reference-frequency",
-        default=None,
-        type=nonefloat,
-        help="The reference " "frequency",
-    )
-    waveform_parser.add(
-        "--waveform-approximant",
-        default=None,
-        type=nonestr,
-        help="The name of the waveform approximant to use for PE.",
-    )
-    waveform_parser.add(
-        "--catch-waveform-errors",
-        default=True,
-        action=StoreBoolean,
-        help="Turns on waveform error catching",
-    )
-    # waveform_parser.add(
-    #     "--pn-spin-order",
-    #     default=-1,
-    #     type=int,
-    #     help="Post-newtonian order to use for the spin",
-    # )
-    # waveform_parser.add(
-    #     "--pn-tidal-order",
-    #     default=-1,
-    #     type=int,
-    #     help="Post-Newtonian order to use for tides",
-    # )
-    # waveform_parser.add(
-    #     "--pn-phase-order",
-    #     default=-1,
-    #     type=int,
-    #     help="post-Newtonian order to use for the phase",
-    # )
-    # waveform_parser.add(
-    #     "--pn-amplitude-order",
-    #     default=0,
-    #     type=int,
-    #     help="Post-Newtonian order to use for the amplitude. Also "
-    #     "used to determine the waveform starting frequency.",
-    # )
-    waveform_parser.add(
-        "--numerical-relativity-file",
-        default=None,
-        type=nonestr,
-        help=(
-            "Path to a h5 numerical relativity file to inject, see"
-            "https://git.ligo.org/waveforms/lvcnr-lfs for examples"
-        ),
-    )
-    # waveform_parser.add(
-    # "--waveform-arguments-dict",
-    # default=None,
-    # type=nonestr,
-    # help=(
-    # "A dictionary of arbitrary additional waveform-arguments to pass"
-    # "  to the bilby waveform generator's `waveform_arguments`. Only used "
-    # "for injections"
-    # ),
-    # )
-    # waveform_parser.add(
-    #     "--mode-array",
-    #     default=None,
-    #     type=nonestr,
-    #     action="append",
-    #     help="Array of modes to use for the waveform. Should be "
-    #     "a list of lists, eg. [[2,2], [2,-2]]",
-    # )
-    # waveform_parser.add(
-    #     "--frequency-domain-source-model",
-    #     default="lal_binary_black_hole",
-    #     type=str,
-    #     help=(
-    #         "Name of the frequency domain source model. Can be one of"
-    #         "[lal_binary_black_hole, lal_binary_neutron_star,"
-    #         "lal_eccentric_binary_black_hole_no_spins, sinegaussian, "
-    #         "supernova, supernova_pca_model] or any python  path to a bilby "
-    #         " source function the users installation, e.g. examp.source.bbh"
-    #     ),
-    # )
-    # waveform_parser.add(
-    #     "--conversion-function",
-    #     default=None,
-    #     type=nonestr,
-    #     help=(
-    #         "Optional python path to a user-specified conversion function "
-    #         "If unspecified, this is determined by the frequency_domain_source_model."
-    #         "If the source-model contains binary_black_hole, "
-    #         "the conversion function is bilby.gw.conversion.convert_to_lal_binary_black_hole_parameters. "
-    #         "If the source-model contains binary_neutron_star, "
-    #         "the generation function is bilby.gw.conversion.convert_to_lal_binary_black_hole_parameters. "
-    #         "If you specify your own function, you may wish to use the I/O of those functions as templates."
-    #         "If given as 'noconvert' (case insensitive), no conversion is used'"
-    #     ),
-    # )
-    # waveform_parser.add(
-    #     "--generation-function",
-    #     default=None,
-    #     type=nonestr,
-    #     help=(
-    #         "Optional python path to a user-specified generation function "
-    #         "If unspecified, this is determined by the frequency_domain_source_model."
-    #         "If the source-model contains binary_black_hole, "
-    #         "the generation function is bilby.gw.conversion.generate_all_bbh_parameters. "
-    #         "If the source-model contains binary_neutron_star, "
-    #         "the generation function is bilby.gw.conversion.generate_all_bns_parameters. "
-    #         "If you specify your own function, you may wish to use the I/O of those functions as templates"
-    #         "If given as 'noconvert' (case insensitive), no generation is used'"
-    #     ),
-    # )
-
-    # # Constants arguments
-    # global_settings_parser = parser.add_argument_group(
-    #     title="Global settings",
-    #     description="Settings for global configuration",
-    # )
-    # global_settings_parser.add(
-    #     "--cosmology",
-    #     default="Planck15",
-    #     type=str,
-    #     help=(
-    #         "The name of the cosmology to use. "
-    #         "Defaults to Planck15, see "
-    #         ":external:py:func:`bilby.gw.cosmology.get_available_cosmologies` "
-    #         "for a list of the available cosmologies."
-    #     ),
-    # )
-
-    #
     # Added for Dingo.
-    #
-
-    sampler_parser = parser.add_argument_group(title="Sampler arguments")
-    sampler_parser.add(
+    dingo_parser.add(
         "--model",
         type=str,
         required=True,
         help="Neural network model for generating posterior samples.",
     )
-    sampler_parser.add(
+    dingo_parser.add(
         "--model-init",
         type=nonestr,
         default=None,
         help="Neural network model for generating samples to initialize Gibbs sampling."
         "Must be provided if the main model is a GNPE model. ",
     )
-    sampler_parser.add(
+    dingo_parser.add(
         "--model-reference-time",
         type=nonefloat,
         default=None,
         help="Reference time for neural network. Do not add this manually as it is "
         "specified by the network.",
     )
-    sampler_parser.add(
+    dingo_parser.add(
         "--recover-log-prob",
         action=StoreBoolean,
         default=True,
         help="For GNPE models, whether to recover the log probability by training an "
         "unconditional flow for the GNPE proxies.",
     )
-    sampler_parser.add(
+    dingo_parser.add(
         "--device",
         type=str,
         default="cuda",
         choices=["cuda", "cpu"],
         help="Device to use for sampling. Choices are 'cpu' and 'cuda'. Default 'cuda'.",
     )
-    sampler_parser.add(
+    dingo_parser.add(
         "--num-gnpe-iterations",
         type=int,
         default=30,
         help="Number of GNPE iterations to perform when using a GNPE model. Default 30.",
     )
-    sampler_parser.add(
+    dingo_parser.add(
         "--num-samples",
         type=int,
         default=50000,
         help="Number of posterior samples desired. Default is 50000",
     )
-    sampler_parser.add(
+    dingo_parser.add(
         "--batch-size",
         type=int,
         default=50000,
         help="Number of samples per batch. This is limited by the amount of GPU RAM. "
         "Default is 50000",
     )
-    sampler_parser.add(
+    dingo_parser.add(
         "--density-recovery-settings",
         type=str,
         default="ProxyRecoveryDefault",
@@ -1565,13 +160,13 @@ def create_parser(top_level=True, usage=None):
             "density-recovery-settings {ProxyRecoveryDefault}"
         ),
     )
-    sampler_parser.add(
+    dingo_parser.add(
         "--importance-sample",
         action=StoreBoolean,
         default=True,
         help=("Whether to perform importance sampling on result. (Default: True)"),
     )
-    sampler_parser.add(
+    dingo_parser.add(
         "--importance-sampling-settings",
         type=str,
         default="Default",
@@ -1581,7 +176,7 @@ def create_parser(top_level=True, usage=None):
             "pre-defined set of density-recovery-settings {PhaseRecoveryDefault}"
         ),
     )
-    sampler_parser.add(
+    dingo_parser.add(
         "--importance-sampling-updates",
         type=str,
         default="{}",
@@ -1593,16 +188,5 @@ def create_parser(top_level=True, usage=None):
             "that networks were trained with."
         ),
     )
-    sampler_parser.add(
-        "--n-parallel",
-        type=int,
-        default=1,
-        help=(
-            "This sets the number of parallel condor jobs for importance sampling. Each"
-            "of these jobs can in turn be parallelized across several CPU cores. The "
-            "total number of processes is n-parallel * "
-            "request-cpus-importance-sampling."
-        ),
-    )
 
-    return parser
+    return bilby_pipe_parser


### PR DESCRIPTION
Major refactor of parser and data generation:

1. Clearly separate DINGO-specific code from inherited bilby_pipe functionality
2. Removes ~1600 duplicate lines by only defining DINGO-specific arguments and delegating to bilby_pipe where possible
   (this removes the need for explicit pre/post bilby1.8 logic)
3. Eliminates deprecated logic and comment blocks
4. Retrieves settings from DINGO model metadata when available

This is a draft so I can build more on top and see if the overall logic fits with what is wanted. I have a few tests, which however require a network so it's not immediately obvious how to test without adding O(MB) of data to the repo.