### PR TITLE
ENH: Add get_one_dimensional_median_and_error_bar in result

### DIFF
--- a/dingo/core/result.py
+++ b/dingo/core/result.py
@@ -923,6 +923,84 @@ class Result(DingoDataset):
         else:
             return np.nan
 
+    def get_one_dimensional_median_and_error_bar(self, key: str, weighted: bool = False, fmt: str = '.2f', quantiles: list = [0.16, 0.84]):
+        """ 
+        Calculate the median and error bar for a given key
+
+        Parameters
+        ==========
+        key: str
+            The parameter key for which to calculate the median and error bar
+        weighted: bool, optional
+            Whether to use sample weights in calculating the median and error bar
+        fmt: str, ('.2f')
+            A format string
+        quantiles: list, 
+            A length-2 list of the lower and upper-quantiles to calculate the errors bars for.
+
+        Returns
+        =======
+        summary: namedtuple
+            An object with attributes, median, lower, upper and string
+
+        """
+        summary = namedtuple('summary', ['median', 'lower', 'upper', 'string'])
+
+        if len(quantiles) != 2:
+            raise ValueError("quantiles must be of length 2")
+
+        quants_to_compute = np.array([quantiles[0], 0.5, quantiles[1]]) 
+
+        theta = self._cleaned_samples()
+        if weighted:
+            weights = theta["weights"]
+        else:
+            weights = np.ones(len(theta))
+
+        quants = self._percentile(theta[key], weights, quants_to_compute)
+        summary.median = quants[1]
+        summary.plus = quants[2] - summary.median
+        summary.minus = summary.median - quants[0]
+
+        fmt = "{{0:{0}}}".format(fmt).format
+        string_template = r"${{{0}}}_{{-{1}}}^{{+{2}}}$"
+        summary.string = string_template.format(
+            fmt(summary.median), fmt(summary.minus), fmt(summary.plus))
+        return summary    
+
+    def _percentile(self, samples, weights, quants_to_compute):
+        """
+        Compute weighted percentiles of an array of samples.
+    
+        Parameters
+        ----------
+        samples : array-like
+            The samples.
+        weights : array-like
+            The weights for each sample.
+        percentiles : array-like
+            List or array of percentiles in [0, 100].
+    
+        Returns
+        -------
+        np.ndarray
+            Array of weighted percentile values corresponding to the input percentiles.
+        """
+        samples = np.asarray(samples)
+        weights = np.asarray(weights)
+        quants_to_compute = np.asarray(quants_to_compute)
+    
+        # Sort samples and weights by the sample values
+        sorter = np.argsort(samples)
+        samples_sorted = samples[sorter]
+        weights_sorted = weights[sorter]
+    
+        # Cumulative sum of weights
+        cumulative_weights = np.cumsum(weights_sorted)
+        cumulative_weights /= cumulative_weights[-1]  # normalize to 1
+    
+        # Interpolate for all requested percentiles at once
+        return np.interp(quants_to_compute, cumulative_weights, samples_sorted)
 
 def make_pp_plot(
     results: list[Result],

--- a/dingo/core/result.py
+++ b/dingo/core/result.py
@@ -924,27 +924,33 @@ class Result(DingoDataset):
             return np.nan
 
     def get_one_dimensional_median_and_error_bar(self, key: str, weighted: bool = False, fmt: str = '.2f', quantiles: list = [0.16, 0.84]):
-        """ 
-        Calculate the median and error bar for a given key
+        """
+        Calculate the median and the lower and upper error bars for a given
+        parameter, based on the specified quantiles.
 
         Parameters
-        ==========
+        ---------
         key: str
             The parameter key for which to calculate the median and error bar
         weighted: bool, optional
-            Whether to use sample weights in calculating the median and error bar
+            If True, use the importance weights stored in the "weights" 
+            column of the samples. Default is False.
         fmt: str, ('.2f')
-            A format string
-        quantiles: list, 
-            A length-2 list of the lower and upper-quantiles to calculate the errors bars for.
+            Format string used for the values in the returned LaTeX string.
+            Default is '.2f'.
+        quantiles: list, optional
+            A length-2 list with the lower and upper quantiles defining the
+            error bars. Default is [0.16, 0.84] (68% credible interval).
 
         Returns
-        =======
+        ---------
         summary: namedtuple
-            An object with attributes, median, lower, upper and string
-
+            An object with attributes median, lower, upper, and string, where 
+            string is a LaTeX representation of the form 
+            $median_{-lower}^{+upper}$.
         """
-        summary = namedtuple('summary', ['median', 'lower', 'upper', 'string'])
+        
+        Summary = namedtuple('summary', ['median', 'lower', 'upper', 'string'])
 
         if len(quantiles) != 2:
             raise ValueError("quantiles must be of length 2")
@@ -958,15 +964,15 @@ class Result(DingoDataset):
             weights = np.ones(len(theta))
 
         quants = self._percentile(theta[key], weights, quants_to_compute)
-        summary.median = quants[1]
-        summary.plus = quants[2] - summary.median
-        summary.minus = summary.median - quants[0]
+        median = quants[1]
+        upper = quants[2] - median
+        lower = median - quants[0]
 
         fmt = "{{0:{0}}}".format(fmt).format
         string_template = r"${{{0}}}_{{-{1}}}^{{+{2}}}$"
-        summary.string = string_template.format(
-            fmt(summary.median), fmt(summary.minus), fmt(summary.plus))
-        return summary    
+        string = string_template.format(
+            fmt(median), fmt(lower), fmt(upper))
+        return Summary(median=median, lower=lower, upper=upper, string=string)    
 
     def _percentile(self, samples, weights, quants_to_compute):
         """


### PR DESCRIPTION
I've added a new method to [`dingo/core/result.py`](https://github.com/dingo-gw/dingo/compare/main...filippo-santoliquido:dingo-ET:feature/result-percentile?expand=1#diff-f2e161644a8b69e9d915ad15f9552062d5a98cd1fe16013d29ef0e6df7464a2e) that computes the one-dimensional median and error bar. It mirrors the equivalent method in [`bilby`](https://github.com/bilby-dev/bilby/blob/main/bilby/core/result.py#L1014-L1049), with the addition of support for importance weights.