### PR TITLE
BUG: Fix injection_parameters lost on GWSampler.context assignment

### DIFF
--- a/dingo/core/result.py
+++ b/dingo/core/result.py
@@ -870,10 +870,9 @@ class Result(DingoDataset):
         if keys is None:
             keys = self.search_parameter_keys
         if self.injection_parameters is None:
-            raise (
-                TypeError,
+            raise TypeError(
                 "Result object has no 'injection_parameters'. "
-                "Cannot compute credible levels.",
+                "Cannot compute credible levels."
             )
         credible_levels = {
             key: self.get_injection_credible_level(key, weighted=weighted)
@@ -902,10 +901,9 @@ class Result(DingoDataset):
         float: credible level
         """
         if self.injection_parameters is None:
-            raise (
-                TypeError,
+            raise TypeError(
                 "Result object has no 'injection_parameters'. "
-                "Cannot compute credible levels.",
+                "Cannot compute credible levels."
             )
         theta = self._cleaned_samples()
 

--- a/dingo/core/samplers.py
+++ b/dingo/core/samplers.py
@@ -109,9 +109,9 @@ class Sampler(object):
     @context.setter
     def context(self, value):
         if value is not None and "parameters" in value:
-            if self.event_metadata is None:
-                self.event_metadata = {}
-            self.event_metadata["injection_parameters"] = value.pop("parameters")
+            if self._event_metadata is None:
+                self._event_metadata = {}
+            self._event_metadata["injection_parameters"] = value.pop("parameters")
         self._context = value
 
     @property


### PR DESCRIPTION
#### Summary

Setting `sampler.context = injection` on a `GWSampler` fails to store the injection parameters, so they are missing from the saved `Result` and `result.injection_parameters` returns `None`. This breaks `get_injection_credible_level`, `get_all_injection_credible_levels`, and PP-plot generation. 

#### Cause

The base `Sampler.context` setter stores the truths by in-place mutation:
```
self.event_metadata["injection_parameters"] = value.pop("parameters")
```
This relies on the `event_metadata` getter returning the underlying dict. On a GWSampler, reading `sampler.event_metadata` doesn't give you the stored dictionary — it runs a function that builds a brand-new copy every time you read it, and tacks on `minimum_frequency` and `maximum_frequency` before handing it back. The assignment therefore writes to a temporary copy that is immediately discarded, while `value.pop("parameters")` still removes the truths from the input dict — so they are lost entirely. 

### Fix

Write to the backing attribute `_event_metadata` directly in the context setter, bypassing the copy-returning getter. 

Also fixes a malformed raise (TypeError, ...) (a tuple, not an exception) in `get_injection_credible_level` and `get_all_injection_credible_levels`.

#### Verification

Truths now are stored on the sampler at assignment, carried into the `Result`, and preserved across HDF5 save/reload; `get_injection_credible_level('chirp_mass')` returns a valid credible level.
