### PR TITLE
Guard deprecated astype copy keyword by pandas version in recursive_hdf5_load

### DIFF
--- a/dingo/core/dataset.py
+++ b/dingo/core/dataset.py
@@ -6,6 +6,9 @@ import pandas as pd
 from numpy.typing import DTypeLike
 
 from dingo.core.utils.misc import get_version
+from packaging.version import Version
+
+PANDAS_VERSION = Version(pd.__version__)
 
 # A mapping from group/dataset names to either a numpy dtype or a nested mapping
 # of the same form (allowing per-subgroup dtype specifications).
@@ -115,7 +118,10 @@ def recursive_hdf5_load(
                     d[k] = pd.DataFrame(d[k])
                     # Apply dtype conversion to DataFrame if specified
                     if effective_dtype is not None:
-                        d[k] = d[k].astype(effective_dtype, copy=False)
+                        if PANDAS_VERSION < Version("3.0"):
+                            d[k] = d[k].astype(effective_dtype, copy=False)
+                        else:
+                            d[k] = d[k].astype(effective_dtype)
                 # Convert 0-dimensional arrays to scalars
                 elif d[k].ndim == 0:
                     d[k] = d[k].item()


### PR DESCRIPTION
# PR: Guard deprecated astype copy keyword by pandas version in recursive_hdf5_load

Fixes #400

## Changes

Guard the deprecated `copy` keyword of `DataFrame.astype` by pandas
version in `recursive_hdf5_load`, so behaviour is preserved on every
supported version:

- `dingo/core/dataset.py`: module-level
  `PANDAS_VERSION = Version(pd.__version__)` (from `packaging`, already
  a transitive dependency of pandas), and

  ```python
  if PANDAS_VERSION < Version("3.0"):
      d[k] = d[k].astype(effective_dtype, copy=False)
  else:
      d[k] = d[k].astype(effective_dtype)
  ```

  — the same pattern as NVIDIA/cuml#8142.

## Verification

The `copy` keyword never affects the **result** of `astype` on any
pandas version, only whether an extra copy is made; the branch keeps
that behaviour exactly as it was on each side of the boundary. Runtime
checks on pandas 2.3.3 and 3.0.5 (structured array → `DataFrame` →
branch):

- pandas 2.3.3 takes the `copy=False` branch, results identical.
- pandas 3.0.5 takes the plain branch: no `Pandas4Warning` is emitted,
  results identical (the `copy` keyword is a documented no-op under
  Copy-on-Write).
- The modified file passes `python -m py_compile`.