### PR TITLE
Speed up TEOB phase-grid likelihood: batched deferred time shift

### DIFF
--- a/dingo/gw/likelihood.py
+++ b/dingo/gw/likelihood.py
@@ -382,22 +382,11 @@ class StationaryGaussianGWLikelihood(GWSignal, Likelihood):
         pol_m = self.signal_m({**theta, "phase": 0})
         pol_m = {k: pol["waveform"] for k, pol in pol_m.items()}
 
-        # For TEOB, generate_hplus_hcross_m applies a phase-dependent time shift
-        # bookkept in wfg._deferred_timeshift_data. The analytical precomputation
-        # below assumes mu(phi) = sum_m mu_m(0) * exp(-i m phi), which is only
-        # valid when that timeshift is absent. When it's present we fall back to
-        # a per-phase resum so the phase-grid likelihood stays consistent with
-        # the full direct likelihood.
-        dts = getattr(self.waveform_generator, "_deferred_timeshift_data", None)
-        if dts is not None:
-            return self._log_likelihood_phase_grid_mode_decomposed_with_dts(
-                pol_m, d, phases, dts
-            )
-
-        # Step 2: Precompute complex inner products (mu, mu) and (d, mu) for the
-        # individual modes m.
+        # Step 2: Precompute the pieces of the likelihood that do not depend on the
+        # phase. Restricting to frequencies >= f_min (min_idx) matches inner_product.
         min_idx = self.data_domain.min_idx
         m_vals = sorted(pol_m.keys())
+        phases = np.atleast_1d(np.asarray(phases, dtype=float))
 
         # rho2opt is defined as the inner product of the waveform mu with itself.
         # Since we work with whitened data, the inner product simply reads
@@ -411,25 +400,32 @@ class StationaryGaussianGWLikelihood(GWSignal, Likelihood):
         #   (mu^_m, mu^_n) = [(mu_m.conj() * mu_n) * exp(-i * (n - m) * phi)].real.
         #
         # Below we precompute the cross terms sum(mu_m.conj() * mu_n) and the constant
-        # contribution for m = n.
+        # contribution for m = n. Both are invariant under a common time shift of all
+        # modes, since exp(-2 pi i f dt) has unit modulus.
         rho2opt_const = 0
-        rho2opt_crossterms = {}
+        cross_pairs = []
+        cross_values = []
         for idx, m in enumerate(m_vals):
             mu_m = pol_m[m]
-            # contribution to rho2opt_const
             rho2opt_const += sum(
                 [inner_product(mu_ifo, mu_ifo, min_idx) for mu_ifo in mu_m.values()]
             )
-            # cross terms
             for n in m_vals[idx + 1 :]:
                 mu_n = pol_m[n]
                 # factor 2, since (m, n) and (n, m) cross terms contribute symmetrically
-                rho2opt_crossterms[(m, n)] = 2 * sum(
-                    [
-                        inner_product_complex(mu_m_ifo, mu_n_ifo, min_idx)
-                        for mu_m_ifo, mu_n_ifo in zip(mu_m.values(), mu_n.values())
-                    ]
+                cross_pairs.append(n - m)
+                cross_values.append(
+                    2
+                    * sum(
+                        [
+                            inner_product_complex(mu_m_ifo, mu_n_ifo, min_idx)
+                            for mu_m_ifo, mu_n_ifo in zip(mu_m.values(), mu_n.values())
+                        ]
+                    )
                 )
+        cross_pairs = np.array(cross_pairs)
+        cross_values = np.array(cross_values)
+
         # kappa2 is given by
         #
         #   (d, mu) = sum(d.conj() * mu).real.
@@ -439,103 +435,59 @@ class StationaryGaussianGWLikelihood(GWSignal, Likelihood):
         #
         #   (d, mu^_m) = [(d.conj() * mu_m) * exp(-i * m * phi)].real.
         #
-        # Below we precompute (d.conj() * mu_m) for the different modes m.
-        kappa2_modes = {}
-        for m in m_vals:
-            mu_m = pol_m[m]
-            kappa2_modes[m] = sum(
-                [
-                    inner_product_complex(d_ifo, mu_ifo, min_idx)
-                    for d_ifo, mu_ifo in zip(d.values(), mu_m.values())
-                ]
-            )
-
-        log_likelihoods = np.ones(len(phases))
-        kappa2_all = []
-        rho2opt_all = []
-        for idx, phase in enumerate(phases):
-            # get rho2opt
-            rho2opt = rho2opt_const
-            for (m, n), c in rho2opt_crossterms.items():
-                rho2opt += (c * np.exp(-1j * (n - m) * phase)).real
-            # get kappa2
-            kappa2 = 0
-            for m in m_vals:
-                kappa2 += (kappa2_modes[m] * np.exp(-1j * m * phase)).real
-            rho2opt_all.append(rho2opt)
-            kappa2_all.append(kappa2)
-
-            log_likelihoods[idx] = self.log_Zn + kappa2 - 1 / 2.0 * rho2opt
-
-            # # comment out for cross check:
-            # mu = sum_contributions_m(pol_m, phase_shift=phase)
-            # rho2opt_ref = sum([inner_product(mu_ifo, mu_ifo) for mu_ifo in mu.values()])
-            # kappa2_ref = sum(
-            #     [
-            #         inner_product(d_ifo, mu_ifo)
-            #         for d_ifo, mu_ifo in zip(d.values(), mu.values())
-            #     ]
-            # )
-            # assert rho2opt - rho2opt_ref < 1e-10
-            # assert kappa2 - kappa2_ref < 1e-10
-
-        # # Test that this works:
-        # idx = len(phases) // 3
-        # phase = phases[idx]
-        # log_likelihood_ref = self.log_likelihood({**theta, "phase": phase})
-        # print(log_likelihoods[idx] - log_likelihood_ref)
-
-        return log_likelihoods
-
-    def _log_likelihood_phase_grid_mode_decomposed_with_dts(
-        self, pol_m, d, phases, dts
-    ):
-        """Variant of _log_likelihood_phase_grid_mode_decomposed for approximants
-        (currently TEOB) whose mode decomposition carries a phase-dependent time
-        shift recorded in `dts` (= wfg._deferred_timeshift_data).
-
-        We cannot use the analytical precomputation trick because the timeshift
-        depends on the argmax of the TD-resummed h+, which varies with phase.
-        Instead we resum modes per phase and apply the exp(-2 pi i f dt(phi))
-        correction before computing inner products. The geocenter-level time
-        shift commutes with detector projection, so we can apply it directly to
-        the per-detector signals returned by signal_m.
-        """
-        m_vals = sorted(pol_m.keys())
-        ifos = list(d.keys())
-        freqs = self.data_domain()
-
-        log_likelihoods = np.empty(len(phases))
-        for idx, phi in enumerate(phases):
-            # Analytical resum of per-detector mode contributions.
-            mu = {
-                ifo: sum(
-                    pol_m[m][ifo] * np.exp(-1j * m * phi) for m in m_vals
+        # Below we precompute d.conj() * mu_m for the different modes m, summed over
+        # detectors but kept per frequency bin so that a time shift can still be
+        # applied (needed for the TEOB deferred time shift, see below).
+        d_mu_m = np.stack(
+            [
+                sum(
+                    [
+                        d_ifo[min_idx:].conj() * mu_ifo[min_idx:]
+                        for d_ifo, mu_ifo in zip(d.values(), pol_m[m].values())
+                    ]
                 )
-                for ifo in ifos
-            }
-            # Deferred-timeshift correction (no-op when phi == 0.0).
-            if phi != 0.0:
-                target_phase = dts["phase_ref"] + phi
-                epoch_target = wfg_utils.compute_epoch_from_resized_td_modes(
-                    dts["resized_td_modes"], dts["iota"], target_phase,
-                    dts["delta_t"],
-                )
-                dt_target = 1.0 / dts["delta_f"] + epoch_target
-                dt_correction = dt_target - dts["dt_ref"]
-                shift = np.exp(-2j * np.pi * dt_correction * freqs)
-                for ifo in ifos:
-                    mu[ifo] = mu[ifo] * shift
+                for m in m_vals
+            ],
+            axis=1,
+        )  # shape (num_frequencies, num_modes)
 
-            rho2opt = sum(
-                inner_product(mu_ifo, mu_ifo) for mu_ifo in mu.values()
+        # For TEOB, generate_hplus_hcross_m applies a phase-dependent time shift
+        # bookkept in wfg._deferred_timeshift_data: the epoch is set by the peak of
+        # h+ (as in gwsignal), which moves with the phase. The full signal at phase
+        # phi is then
+        #
+        #   mu(phi) = exp(-2 pi i f dt(phi)) * sum_m mu_m * exp(-i m phi),
+        #
+        # where dt(phi) = -argmax(hp(phi)) * delta_t (relative to the reference
+        # epoch) is quantized to the time grid and hence takes only a handful of
+        # distinct values across the phase grid. We compute dt for all phases at
+        # once and evaluate (d, mu_m) once per distinct time shift.
+        dts = getattr(self.waveform_generator, "_deferred_timeshift_data", None)
+        if dts is None:
+            kappa2_modes = d_mu_m.sum(axis=0)[np.newaxis, :]  # (1, num_modes)
+            shift_index = np.zeros(len(phases), dtype=int)
+        else:
+            epochs = wfg_utils.compute_epochs_from_resized_td_modes(
+                dts["resized_td_modes"],
+                dts["iota"],
+                dts["phase_ref"] + phases,
+                dts["delta_t"],
             )
-            kappa2 = sum(
-                inner_product(d_ifo, mu_ifo)
-                for d_ifo, mu_ifo in zip(d.values(), mu.values())
-            )
-            log_likelihoods[idx] = self.log_Zn + kappa2 - 0.5 * rho2opt
-        return log_likelihoods
+            dt_correction = (1.0 / dts["delta_f"] + epochs) - dts["dt_ref"]
+            unique_dt, shift_index = np.unique(dt_correction, return_inverse=True)
+            time_shifts = np.exp(
+                -2j * np.pi * np.outer(unique_dt, self.data_domain()[min_idx:])
+            )  # (num_shifts, num_frequencies)
+            kappa2_modes = time_shifts @ d_mu_m  # (num_shifts, num_modes)
+
+        # Step 3: Evaluate on the phase grid.
+        phase_factors = np.exp(-1j * np.outer(np.array(m_vals), phases))  # (M, P)
+        kappa2 = (kappa2_modes[shift_index] * phase_factors.T).sum(axis=1).real
+        rho2opt = (
+            rho2opt_const
+            + (cross_values @ np.exp(-1j * np.outer(cross_pairs, phases))).real
+        )
+        return self.log_Zn + kappa2 - 1 / 2.0 * rho2opt
 
     def _log_likelihood_phase_marginalized(self, theta):
         """

--- a/dingo/gw/waveform_generator/wfg_utils.py
+++ b/dingo/gw/waveform_generator/wfg_utils.py
@@ -326,6 +326,82 @@ def compute_epoch_from_resized_td_modes(resized_td_modes, iota, phase, delta_t):
     return -np.argmax(hp) * delta_t
 
 
+def compute_epochs_from_resized_td_modes(
+    resized_td_modes, iota, phases, delta_t, num_candidates=64, chunk_size=1024
+):
+    """Vectorized version of compute_epoch_from_resized_td_modes for many phases.
+
+    Returns exactly the same epochs as calling the scalar routine for each phase,
+    but evaluates the peak search for all phases at once. Two observations make
+    this cheap:
+
+    1. Spin-weighted spherical harmonics satisfy Y_lm(iota, pi/2 - phase)
+       = Y_lm(iota, pi/2) exp(-i m phase). Hence, with
+       H_m(t) = sum_l Y_lm(iota, pi/2) h_lm(t) collapsed over l once,
+       hp(t, phase) = Re sum_m exp(-i m phase) H_m(t) is a small matrix product.
+    2. hp(t, phase) <= A(t) := sum_m |H_m(t)| for every phase, so the argmax of hp
+       at a given phase can only lie where A(t) >= max_t hp(t, phase). A lower
+       bound for that maximum is obtained from a few candidate samples near the
+       peak of A, which restricts the search to a short window around the merger.
+
+    Parameters
+    ----------
+    resized_td_modes: dict
+        Dictionary with (l,m) keys and numpy complex arrays of resized TD modes.
+    iota: float
+        Inclination angle in radians.
+    phases: array_like
+        Reference phases for spherical harmonic evaluation (scalar or 1D array).
+    delta_t: float
+        Time step of the TD data.
+    num_candidates: int
+        Number of largest-envelope samples used to bound the peak from below.
+    chunk_size: int
+        Number of phases processed per block, to bound memory use.
+
+    Returns
+    -------
+    epochs: np.ndarray, shape (len(phases),)
+        The epoch values (negative of peak index times delta_t), one per phase.
+    """
+    phases = np.atleast_1d(np.asarray(phases, dtype=float))
+
+    # Collapse the l-dependence: H_m(t) = sum_l Y_lm(iota, pi/2) h_lm(t).
+    H = {}
+    for (l, m), h_data in resized_td_modes.items():
+        ylm = lal.SpinWeightedSphericalHarmonic(iota, np.pi / 2, -2, l, m)
+        H[m] = H.get(m, 0.0) + ylm * np.asarray(h_data)
+    m_vals = np.array(sorted(H))
+    H = np.stack([H[m] for m in m_vals])  # (M, T)
+
+    # Phase factors exp(-i m phase), shape (M, P); hp = Re(H^T E) evaluated below via
+    # real arithmetic as Re(H)^T Re(E) - Im(H)^T Im(E).
+    E = np.exp(-1j * np.outer(m_vals, phases))
+    H_re, H_im = np.ascontiguousarray(H.real), np.ascontiguousarray(H.imag)
+    E_re, E_im = np.ascontiguousarray(E.real), np.ascontiguousarray(E.imag)
+
+    def hp_at(indices, phase_slice):
+        return H_re[:, indices].T @ E_re[:, phase_slice] - H_im[:, indices].T @ E_im[
+            :, phase_slice
+        ]
+
+    # Envelope bound and lower bound of the per-phase maximum.
+    envelope = np.abs(H).sum(axis=0)
+    num_candidates = min(num_candidates, len(envelope))
+    candidates = np.sort(np.argpartition(envelope, -num_candidates)[-num_candidates:])
+    lower_bound = hp_at(candidates, slice(None)).max(axis=0)  # (P,)
+    # Samples that can host the argmax for at least one of the phases. Sorted so that
+    # ties resolve to the first index, as in np.argmax over the full array.
+    window = np.flatnonzero(envelope >= lower_bound.min())
+
+    peak_index = np.empty(len(phases), dtype=int)
+    for start in range(0, len(phases), chunk_size):
+        block = slice(start, start + chunk_size)
+        peak_index[block] = window[np.argmax(hp_at(window, block), axis=0)]
+
+    return -peak_index * delta_t
+
+
 def apply_time_shift_to_fd_modes(hlm_fd_raw, resized_td_modes, iota, phase, domain):
     """Apply a phase-dependent time shift to raw (unshifted) FD modes.
 

--- a/tests/gw/test_likelihood_phase_grid_teob.py
+++ b/tests/gw/test_likelihood_phase_grid_teob.py
@@ -1,0 +1,153 @@
+"""Phase-grid likelihood for TEOBResumSDALI.
+
+TEOB modes carry a phase-dependent time shift (the epoch is set by the peak of h+,
+following gwsignal), bookkept in wfg._deferred_timeshift_data. The phase-grid
+likelihood must (a) agree with the direct likelihood at any phase, and (b) agree
+with an explicit per-phase resum of the modes, while (c) not recomputing the epoch
+one phase at a time."""
+
+import numpy as np
+import pytest
+
+from dingo.gw.domains import UniformFrequencyDomain
+from dingo.gw.injection import Injection
+from dingo.gw.likelihood import StationaryGaussianGWLikelihood, inner_product
+from dingo.gw.prior import build_prior_with_defaults
+from dingo.gw.waveform_generator import wfg_utils
+from dingo.gw.waveform_generator.waveform_generator import sum_contributions_m
+
+pytest.importorskip("EOBRun_module")
+
+T_REF = 1126259462.391
+WFG_KWARGS = {
+    "approximant": "TEOBResumSDALI",
+    "f_ref": 10.0,
+    "f_start": 10.0,
+    "spin_conversion_phase": 0.0,
+    "new_interface": True,
+}
+THETA_INJ = {
+    "chirp_mass": 40.0,
+    "mass_ratio": 0.8,
+    "chi_1": 0.2,
+    "chi_2": -0.1,
+    "eccentricity": 0.15,
+    "mean_per_ano": 1.0,
+    "theta_jn": 0.9,
+    "luminosity_distance": 300.0,
+    "geocent_time": 0.01,
+    "ra": 1.2,
+    "dec": -0.4,
+    "psi": 0.7,
+    "phase": 0.0,
+}
+
+
+@pytest.fixture(scope="module")
+def teob_likelihood():
+    domain = UniformFrequencyDomain(f_min=20.0, f_max=512.0, delta_f=0.25)
+    ifos = ["H1", "L1", "V1"]
+    prior = build_prior_with_defaults(
+        {
+            "chirp_mass": "bilby.gw.prior.UniformInComponentsChirpMass(minimum=25.0, maximum=60.0)",
+            "mass_ratio": "bilby.gw.prior.UniformInComponentsMassRatio(minimum=0.125, maximum=1.0)",
+            "chi_1": 'bilby.gw.prior.AlignedSpin(name="chi_1", a_prior=Uniform(minimum=0, maximum=0.9))',
+            "chi_2": 'bilby.gw.prior.AlignedSpin(name="chi_2", a_prior=Uniform(minimum=0, maximum=0.9))',
+            "eccentricity": "bilby.core.prior.Uniform(minimum=0.0, maximum=0.3)",
+            "mean_per_ano": "bilby.core.prior.Uniform(minimum=0.0, maximum=2*np.pi)",
+            "theta_jn": "bilby.core.prior.Sine(minimum=0.0, maximum=np.pi)",
+            "phase": 'bilby.core.prior.Uniform(minimum=0.0, maximum=2*np.pi, boundary="periodic")',
+            "luminosity_distance": "bilby.core.prior.Uniform(minimum=100.0, maximum=5000.0)",
+            "geocent_time": "bilby.core.prior.Uniform(minimum=-0.1, maximum=0.1)",
+            "ra": 'bilby.core.prior.Uniform(minimum=0.0, maximum=2*np.pi, boundary="periodic")',
+            "dec": "bilby.core.prior.Cosine(minimum=-np.pi/2, maximum=np.pi/2)",
+            "psi": 'bilby.core.prior.Uniform(minimum=0.0, maximum=np.pi, boundary="periodic")',
+        }
+    )
+    injection = Injection(
+        prior=prior,
+        wfg_kwargs=WFG_KWARGS,
+        wfg_domain=domain,
+        data_domain=domain,
+        ifo_list=ifos,
+        t_ref=T_REF,
+    )
+    injection.asd = {ifo: np.full(len(domain), 1e-22) for ifo in ifos}
+    np.random.seed(42)
+    event_data = injection.injection(THETA_INJ)
+
+    return StationaryGaussianGWLikelihood(
+        wfg_kwargs=WFG_KWARGS,
+        wfg_domain=domain,
+        data_domain=domain,
+        event_data=event_data,
+        t_ref=T_REF,
+    )
+
+
+@pytest.fixture(scope="module")
+def theta():
+    # Slightly off the injection so the likelihood has non-trivial structure.
+    return {**THETA_INJ, "chirp_mass": 40.05, "mean_per_ano": 1.1}
+
+
+def test_phase_grid_matches_explicit_per_phase_resum(teob_likelihood, theta):
+    likelihood = teob_likelihood
+    phases = np.linspace(0, 2 * np.pi, 257)
+
+    grid = likelihood.log_likelihood_phase_grid(theta, phases)
+
+    pol_m = likelihood.signal_m({**theta, "phase": 0.0})
+    pol_m = {m: pol["waveform"] for m, pol in pol_m.items()}
+    dts = likelihood.waveform_generator._deferred_timeshift_data
+    assert dts is not None, "TEOB should set a deferred time shift"
+    d = likelihood.whitened_strains
+
+    reference = np.empty(len(phases))
+    for idx, phi in enumerate(phases):
+        mu = sum_contributions_m(pol_m, phase_shift=phi, deferred_timeshift_data=dts)
+        rho2opt = sum(inner_product(mu_ifo, mu_ifo) for mu_ifo in mu.values())
+        kappa2 = sum(inner_product(d[ifo], mu[ifo]) for ifo in mu)
+        reference[idx] = likelihood.log_Zn + kappa2 - 0.5 * rho2opt
+
+    # The logL varies by O(100) over the grid; agreement should be at rounding level.
+    assert np.ptp(reference) > 10
+    np.testing.assert_allclose(grid, reference, rtol=0, atol=1e-6 * np.ptp(reference))
+
+
+def test_phase_grid_matches_direct_likelihood(teob_likelihood, theta):
+    likelihood = teob_likelihood
+    phases = np.linspace(0, 2 * np.pi, 7)[:-1]
+
+    grid = likelihood.log_likelihood_phase_grid(theta, phases)
+    direct = np.array(
+        [likelihood.log_likelihood({**theta, "phase": phi}) for phi in phases]
+    )
+
+    # The mode path tapers/FFTs individual modes while the direct path conditions the
+    # polarizations, so differences of O(0.1) nats are expected at this SNR (the
+    # likelihood spans ~60 nats over the phase circle). A wrong time shift would be
+    # off by many nats.
+    np.testing.assert_allclose(grid, direct, rtol=0, atol=0.3)
+
+
+def test_phase_grid_does_not_recompute_epoch_per_phase(
+    teob_likelihood, theta, monkeypatch
+):
+    """Generating the TEOB modes legitimately computes the epoch once (at the
+    reference phase). The phase grid must not call the scalar routine once more per
+    grid phase on top of that."""
+    calls = []
+    original = wfg_utils.compute_epoch_from_resized_td_modes
+
+    def _counting(*args, **kwargs):
+        calls.append(args[2])  # the phase argument
+        return original(*args, **kwargs)
+
+    monkeypatch.setattr(wfg_utils, "compute_epoch_from_resized_td_modes", _counting)
+
+    phases = np.linspace(0, 2 * np.pi, 101)
+    grid = teob_likelihood.log_likelihood_phase_grid(theta, phases)
+
+    assert np.all(np.isfinite(grid))
+    assert len(calls) == 1, f"scalar epoch routine called {len(calls)} times"

--- a/tests/gw/waveform_generator/test_wfg_utils_epochs.py
+++ b/tests/gw/waveform_generator/test_wfg_utils_epochs.py
@@ -1,0 +1,63 @@
+"""Tests for the batched (vectorized over phase) epoch computation used by the
+TEOB deferred time shift. The batched function must reproduce the scalar
+compute_epoch_from_resized_td_modes exactly, for every phase."""
+
+import numpy as np
+import pytest
+
+from dingo.gw.waveform_generator import wfg_utils
+
+
+@pytest.fixture
+def synthetic_resized_td_modes():
+    """Non-precessing-like set of TD modes with a peak near the middle of the array,
+    plus low-level broadband content everywhere so that the peak search has to
+    discriminate against many candidate samples."""
+    rng = np.random.default_rng(1234)
+    n = 4096
+    delta_t = 1.0 / 1024
+    t = np.arange(n) * delta_t
+    t_peak = t[n // 2]
+    envelope = np.exp(-(((t - t_peak) / 0.015) ** 2))
+    background = 0.02 * (rng.standard_normal(n) + 1j * rng.standard_normal(n))
+
+    modes = {}
+    for (l, m), amp in [((2, 2), 1.0), ((2, 1), 0.2), ((3, 3), 0.3), ((4, 4), 0.15)]:
+        frequency = 120.0 * m / 2  # crude harmonic scaling of the (2,2) frequency
+        h = amp * envelope * np.exp(-1j * (2 * np.pi * frequency * t + rng.uniform(0, 2 * np.pi)))
+        h = h + amp * background
+        modes[(l, m)] = h
+        modes[(l, -m)] = (-1) ** l * np.conj(h)
+    return modes, delta_t
+
+
+def test_batched_epochs_match_scalar_for_every_phase(synthetic_resized_td_modes):
+    modes, delta_t = synthetic_resized_td_modes
+    iota = 0.7
+    phases = np.linspace(0, 2 * np.pi, 733)
+
+    expected = np.array(
+        [
+            wfg_utils.compute_epoch_from_resized_td_modes(modes, iota, p, delta_t)
+            for p in phases
+        ]
+    )
+    # The test is only meaningful if the epoch actually varies with phase.
+    assert len(np.unique(expected)) > 1
+
+    got = wfg_utils.compute_epochs_from_resized_td_modes(modes, iota, phases, delta_t)
+
+    assert got.shape == phases.shape
+    np.testing.assert_array_equal(got, expected)
+
+
+def test_batched_epochs_accept_scalar_phase(synthetic_resized_td_modes):
+    modes, delta_t = synthetic_resized_td_modes
+    iota = 1.9
+    phase = 2.3
+
+    expected = wfg_utils.compute_epoch_from_resized_td_modes(modes, iota, phase, delta_t)
+    got = wfg_utils.compute_epochs_from_resized_td_modes(modes, iota, phase, delta_t)
+
+    assert got.shape == (1,)
+    assert got[0] == expected


### PR DESCRIPTION
The TEOB branch of _log_likelihood_phase_grid_mode_decomposed resummed all modes, recomputed the h+-peak epoch and evaluated full-length inner products once per grid phase (5001x per sample). Two facts make an exact closed form possible: the epoch is quantized to the time grid, so dt(phi) takes only a few dozen distinct values across the phase grid, and a common time shift leaves <mu, mu> invariant, so only <d, mu_m> depends on it.

- wfg_utils.compute_epochs_from_resized_td_modes: vectorized peak search for an array of phases (Y_lm(iota, pi/2 - phi) = Y_lm(iota, pi/2) exp(-i m phi), search restricted to a provably sufficient window around the peak). Returns the same epochs as the scalar routine.
- likelihood: compute dt for all phases at once, evaluate <d, mu_m> once per distinct shift, then use the analytic phase resum for TEOB and non-TEOB alike. The per-phase Python loop is replaced by matrix products, and the _with_dts variant is removed.

Measured on v3 PP samples (head node, 5001 phases): TEOB high mass 2.5 s ->
0.2 s per sample (max |diff| 4e-5 nats over a 440-nat range), SEOB high mass 0.33 s -> 0.18 s (identical to 4e-12 nats).

