### PR TITLE
Cherry-pick rejection_sample/clip_weights (PR #357) onto seobnrv5ehm

### DIFF
--- a/dingo/core/result.py
+++ b/dingo/core/result.py
@@ -30,6 +30,31 @@ DATA_KEYS = [
 ]
 
 
+def _clip_weights(weights: np.ndarray, num_clip: int) -> np.ndarray:
+    """Replace the ``num_clip`` largest weights with their mean, then re-normalize.
+
+    Clipping to the mean (rather than the minimum) preserves the total weight of
+    the clipped group, which minimises the bias introduced by the operation.
+
+    Parameters
+    ----------
+    weights : np.ndarray
+        1-D array of non-negative importance weights (need not be normalized).
+    num_clip : int
+        Number of largest weights to clip.
+
+    Returns
+    -------
+    np.ndarray
+        Clipped weights normalized to mean 1.
+    """
+    weights = weights.copy()
+    clip_idx = np.argpartition(-weights, num_clip)[:num_clip]
+    weights[clip_idx] = weights[clip_idx].mean()
+    weights /= weights.mean()
+    return weights
+
+
 class Result(DingoDataset):
     """
     A dataset class to hold a collection of samples, implementing I/O, importance
@@ -397,6 +422,112 @@ class Result(DingoDataset):
             random_state=random_state,
         )
         return unweighted_samples.drop(["weights"], axis=1)
+
+    def rejection_sample(
+        self,
+        max_samples_per_draw: int = 1,
+        clip_weights: bool = False,
+        random_state=None,
+    ):
+        """
+        Generate unweighted posterior samples from weighted ones via rejection sampling.
+
+        Each original sample contributes at most ``max_samples_per_draw`` copies to
+        the output, so the result avoids the excessive duplication that
+        :meth:`sampling_importance_resampling` can produce for high-weight samples.
+
+        **Algorithm (unbiased, maximum efficiency)**
+
+        The weights are first scaled so that the largest weight equals
+        ``max_samples_per_draw``.  Each sample ``i`` then contributes
+
+        * ``floor(w_scaled[i])`` copies deterministically (integer part), and
+        * one additional copy with probability ``w_scaled[i] - floor(w_scaled[i])``
+          (fractional part, a single Bernoulli draw).
+
+        The expected number of copies of sample ``i`` is therefore exactly
+        ``w_scaled[i] ∝ w[i]``, which guarantees an unbiased representation of the
+        posterior.  Using the integer part deterministically (rather than rounding
+        stochastically) maximises the expected total number of output samples for a
+        given ``max_samples_per_draw``.
+
+        **Optional weight clipping**
+
+        When ``clip_weights=True``, the ``ceil(sqrt(N))`` largest weights are
+        replaced by their mean and the weights are re-normalized to mean 1 before
+        rejection sampling.  This number of clips is the theoretically optimal
+        choice that yields asymptotically unbiased results [1]_.  Using the mean
+        (rather than the minimum) of the clipped group preserves their total weight,
+        which minimises the bias introduced by clipping.  The net effect is reduced
+        weight variance and a larger expected number of output samples.
+
+        If the samples DataFrame has no ``weights`` column the samples are already
+        unweighted and are returned unchanged.
+
+        Parameters
+        ----------
+        max_samples_per_draw : int
+            Maximum number of copies any single input sample may contribute to the
+            output.  Default is 1 (standard rejection sampling, no duplicates).
+        clip_weights : bool
+            Whether to clip the ``ceil(sqrt(N))`` largest weights to their mean
+            before rejection sampling.  Default is False.
+        random_state : int or None
+            Seed for the random number generator, for reproducibility.
+
+        Returns
+        -------
+        pd.DataFrame
+            Unweighted samples (the ``weights`` column is dropped).
+
+        References
+        ----------
+        .. [1] Elvira et al., "A Comparison Of Clipping Strategies For Importance Sampling"
+               https://ieeexplore.ieee.org/document/8450722
+        """
+        if max_samples_per_draw < 1:
+            raise ValueError("max_samples_per_draw must be >= 1.")
+
+        if "weights" not in self.samples:
+            return self.samples.copy()
+
+        rng = np.random.default_rng(random_state)
+        weights = self.samples["weights"].to_numpy(dtype=float)
+
+        print(
+            f"Rejection sampling: {self.num_samples} samples, "
+            f"ESS = {self.effective_sample_size:.0f} "
+            f"(efficiency = {100 * self.sample_efficiency:.1f}%)"
+        )
+
+        if clip_weights:
+            num_clip = math.ceil(math.sqrt(len(weights)))
+            weights = _clip_weights(weights, num_clip)
+
+        # Scale so the maximum weight maps to max_samples_per_draw.
+        # Expected copies of sample i = w_scaled[i] ∝ w[i]  →  unbiased.
+        w_scaled = weights * (max_samples_per_draw / weights.max())
+
+        # Deterministic part: floor(w_scaled[i]) copies always included.
+        n_det = np.floor(w_scaled).astype(int)
+
+        # Stochastic part: one extra copy with probability = fractional remainder.
+        p_frac = w_scaled - n_det
+        extra = (rng.random(len(weights)) < p_frac).astype(int)
+
+        n_copies = n_det + extra
+
+        # Build the output by repeating each row according to its copy count.
+        indices = np.repeat(np.arange(len(weights)), n_copies)
+        unweighted = self.samples.iloc[indices].reset_index(drop=True)
+        # Drop columns that are only meaningful for weighted samples: weights and
+        # log_prob are tied to the proposal distribution, and delta_log_prob_target
+        # is an auxiliary correction term used during importance sampling.
+        unweighted = unweighted.drop(
+            columns=["weights", "log_prob", "delta_log_prob_target"], errors="ignore"
+        )
+        print(f"Produced {len(unweighted)} unweighted samples.")
+        return unweighted
 
     def parameter_subset(self, parameters):
         """

--- a/dingo/core/utils/plotting.py
+++ b/dingo/core/utils/plotting.py
@@ -76,16 +76,29 @@ def plot_corner_multi(
     else:
         parameter_labels = common_parameters
 
+    # Compute a common parameter range across all sample sets. This ensures
+    # every corner call uses identical bins, so the 1D marginal densities are
+    # on a consistent scale regardless of sample size or weight distribution.
+    all_data = pd.concat([s[common_parameters] for s in samples], ignore_index=True)
+    common_range = [
+        (all_data[p].min(), all_data[p].max()) for p in common_parameters
+    ]
+
     fig = None
     handles = []
     for i, (s, w, l) in enumerate(zip_longest(samples, weights, labels)):
         color = mpl.colors.rgb2hex(plt.get_cmap(cmap)(i))
+        # Normalize weights to sum to 1 so that smoothed 1D marginals are
+        # comparable across sample sets with different sizes or total weights.
+        n = len(s)
+        w_normalized = np.ones(n) / n if w is None else np.asarray(w) / np.sum(w)
         fig = corner.corner(
             s[common_parameters].to_numpy(),
             labels=parameter_labels,
-            weights=w,
+            weights=w_normalized,
             color=color,
             no_fill_contours=True,
+            range=common_range,
             fig=fig,
             **corner_params,
         )

--- a/dingo/gw/result.py
+++ b/dingo/gw/result.py
@@ -1,4 +1,5 @@
 import copy
+import os
 import time
 from typing import Optional
 
@@ -690,7 +691,7 @@ class Result(CoreResult):
             num_processes=num_processes,
         )
 
-    def get_pesummary_samples(self, num_processes=1):
+    def get_pesummary_samples(self, num_processes=1, resampling_method=None):
         """Samples in a form suitable for PESummary.
 
         These samples are adjusted to undo certain conventions used internally by
@@ -705,13 +706,42 @@ class Result(CoreResult):
             ``spin_1z``/``spin_2z`` so that PESummary's standard-name
             dictionary recognises them and derives ``a_1``, ``a_2``,
             ``chi_eff``, etc.
+
+        Parameters
+        ----------
+        num_processes : int
+            Number of processes for spin conversion.
+        resampling_method : str, optional
+            Method for producing unweighted samples from weighted ones.
+            'clip+rejection': clip extreme weights then rejection sample.
+            'sir': sampling importance resampling (old behavior).
+            If None (default), the value of the ``DINGO_RESAMPLING_METHOD``
+            environment variable is used, falling back to 'clip+rejection'.
+            The env-var hook lets callers that cannot pass this argument
+            through (e.g. PESummary's dingo reader) still select the method.
         """
+        if resampling_method is None:
+            resampling_method = os.environ.get(
+                "DINGO_RESAMPLING_METHOD", "clip+rejection"
+            )
+
         if hasattr(self, "_pesummary_samples"):
             return self._pesummary_samples
 
         # Unweighted samples.
         if "weights" in self.samples:
-            samples = self.sampling_importance_resampling(random_state=RANDOM_STATE)
+            if resampling_method == "clip+rejection":
+                samples = self.rejection_sample(
+                    clip_weights=True,
+                    random_state=RANDOM_STATE,
+                )
+            elif resampling_method == "sir":
+                samples = self.sampling_importance_resampling(random_state=RANDOM_STATE)
+            else:
+                raise ValueError(
+                    f"Unknown resampling_method '{resampling_method}'. "
+                    "Use 'clip+rejection' or 'sir'."
+                )
         else:
             samples = self.samples.copy()
 

--- a/tests/core/test_result.py
+++ b/tests/core/test_result.py
@@ -1,0 +1,235 @@
+import math
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from dingo.core.result import Result, _clip_weights
+
+
+def make_result_with_weights(weights, extra_col=True):
+    """Construct a minimal Result whose samples DataFrame has the given weights."""
+    n = len(weights)
+    data = {"x": np.arange(n, dtype=float), "weights": np.asarray(weights, dtype=float)}
+    if extra_col:
+        data["log_prob"] = np.zeros(n)
+    samples = pd.DataFrame(data)
+    return Result(dictionary={"samples": samples})
+
+
+# ---------------------------------------------------------------------------
+# rejection_sample tests
+# ---------------------------------------------------------------------------
+
+
+def test_no_weights_returns_copy():
+    """When samples have no weights column, return an unchanged copy."""
+    samples = pd.DataFrame({"x": [1.0, 2.0, 3.0]})
+    result = Result(dictionary={"samples": samples})
+    out = result.rejection_sample()
+    pd.testing.assert_frame_equal(out, samples)
+    assert out is not result.samples  # must be a copy
+
+
+def test_weights_column_dropped():
+    """Output must not contain the 'weights' column."""
+    result = make_result_with_weights([1.0, 2.0, 0.5])
+    out = result.rejection_sample()
+    assert "weights" not in out.columns
+
+
+def test_columns_dropped_and_preserved():
+    """Parameter columns must appear in the output; weights, log_prob, and
+    delta_log_prob_target must be dropped as they are no longer meaningful."""
+    result = make_result_with_weights([1.0, 2.0, 0.5])
+    out = result.rejection_sample()
+    assert "x" in out.columns
+    assert "weights" not in out.columns
+    assert "log_prob" not in out.columns
+
+
+def test_max_one_copy_per_sample_default():
+    """With default max_samples_per_draw=1 no sample appears more than once."""
+    weights = np.array([0.1, 5.0, 3.0, 0.5, 2.0])
+    result = make_result_with_weights(weights)
+    out = result.rejection_sample(random_state=0)
+    # Each x value is unique in the input, so value counts should all be 1.
+    assert out["x"].value_counts().max() == 1
+
+
+def test_max_copies_respected():
+    """With max_samples_per_draw=k no sample should appear more than k times."""
+    rng = np.random.default_rng(42)
+    weights = rng.exponential(scale=2.0, size=200)
+    result = make_result_with_weights(weights, extra_col=False)
+    for k in (1, 2, 5, 10):
+        out = result.rejection_sample(max_samples_per_draw=k, random_state=k)
+        counts = out["x"].value_counts()
+        assert counts.max() <= k, f"k={k}: max count {counts.max()} exceeds limit"
+
+
+def test_unbiasedness():
+    """Expected copies per sample must be proportional to weight (unbiasedness).
+
+    We run many independent rejection-sampling draws and compare the empirical
+    inclusion rate of each sample against its expected rate.  The tolerance is
+    chosen to be 10 standard deviations so the test is highly unlikely to fail
+    due to random fluctuations.
+    """
+    rng_weights = np.random.default_rng(0)
+    n_samples = 50
+    weights = rng_weights.exponential(scale=1.0, size=n_samples)
+    result = make_result_with_weights(weights, extra_col=False)
+
+    n_trials = 5_000
+    max_k = 3
+    counts = np.zeros(n_samples, dtype=float)
+    for seed in range(n_trials):
+        out = result.rejection_sample(max_samples_per_draw=max_k, random_state=seed)
+        for idx in out["x"].astype(int):
+            counts[idx] += 1
+
+    # Expected copies ∝ w_i; expected total across all trials:
+    w_max = weights.max()
+    w_scaled = weights * (max_k / w_max)
+    expected_counts = w_scaled * n_trials  # E[total copies of sample i]
+
+    # Allow 10-sigma tolerance for each sample.
+    # Variance of Bernoulli(p_frac) term per trial + deterministic floor:
+    # Var[copies_i per trial] ≤ 0.25  (Bernoulli variance ≤ 0.25)
+    sigma = np.sqrt(n_trials * 0.25)
+    np.testing.assert_allclose(counts, expected_counts, atol=10 * sigma)
+
+
+def test_reproducibility():
+    """Same random_state must yield identical output."""
+    weights = np.array([1.0, 3.0, 0.5, 2.0, 0.1])
+    result = make_result_with_weights(weights)
+    out1 = result.rejection_sample(random_state=7)
+    out2 = result.rejection_sample(random_state=7)
+    pd.testing.assert_frame_equal(out1, out2)
+
+
+def test_different_seeds_differ():
+    """Different random states should (very likely) produce different outputs."""
+    weights = np.array([1.0, 3.0, 0.5, 2.0, 0.1] * 20)
+    result = make_result_with_weights(weights, extra_col=False)
+    out1 = result.rejection_sample(random_state=1)
+    out2 = result.rejection_sample(random_state=2)
+    # It is astronomically unlikely that both draws are identical.
+    assert not out1["x"].reset_index(drop=True).equals(out2["x"].reset_index(drop=True))
+
+
+def test_invalid_max_samples_per_draw():
+    """max_samples_per_draw < 1 must raise a ValueError."""
+    result = make_result_with_weights([1.0, 2.0, 3.0])
+    with pytest.raises(ValueError):
+        result.rejection_sample(max_samples_per_draw=0)
+    with pytest.raises(ValueError):
+        result.rejection_sample(max_samples_per_draw=-1)
+
+
+def test_uniform_weights_all_accepted():
+    """With equal weights and max_samples_per_draw=1 every sample is accepted
+    (scaled weight = 1 for all, so fractional part = 0 and floor = 1)."""
+    n = 20
+    weights = np.ones(n)
+    result = make_result_with_weights(weights, extra_col=False)
+    out = result.rejection_sample(random_state=0)
+    assert len(out) == n
+
+
+def test_higher_max_increases_output():
+    """Increasing max_samples_per_draw should yield at least as many output samples."""
+    rng = np.random.default_rng(99)
+    weights = rng.exponential(size=100)
+    result = make_result_with_weights(weights, extra_col=False)
+    counts = [
+        len(result.rejection_sample(max_samples_per_draw=k, random_state=0))
+        for k in range(1, 6)
+    ]
+    # Expected output grows monotonically with k (stochastically, but very reliably).
+    for i in range(len(counts) - 1):
+        assert counts[i] <= counts[i + 1], (
+            f"k={i+1} gave {counts[i]} samples but k={i+2} gave {counts[i+1]}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# _clip_weights tests
+# ---------------------------------------------------------------------------
+
+
+def test_clip_weights_output_mean_is_one():
+    """Clipped weights must be re-normalized to mean 1."""
+    rng = np.random.default_rng(0)
+    weights = rng.exponential(size=100)
+    n = len(weights)
+    clipped = _clip_weights(weights, math.ceil(math.sqrt(n)))
+    np.testing.assert_allclose(clipped.mean(), 1.0, rtol=1e-10)
+
+
+def test_clip_weights_top_values_equalized():
+    """The num_clip largest weights must all equal their original mean."""
+    weights = np.array([10.0, 8.0, 6.0, 1.0, 1.0, 1.0])
+    num_clip = 3
+    original_top_mean = np.mean([10.0, 8.0, 6.0])
+    clipped = _clip_weights(weights, num_clip)
+    # Re-scale back to unnormalized to check equality of top values.
+    # After normalization mean=1, so original scale factor = mean of raw clipped array.
+    raw_clipped = weights.copy()
+    raw_clipped[:3] = original_top_mean
+    np.testing.assert_allclose(
+        np.sort(clipped)[::-1][:num_clip],
+        np.full(num_clip, raw_clipped[:3].mean() / raw_clipped.mean()),
+        rtol=1e-10,
+    )
+
+
+def test_clip_weights_does_not_modify_input():
+    """_clip_weights must not mutate the input array."""
+    weights = np.array([5.0, 3.0, 1.0, 1.0])
+    original = weights.copy()
+    _clip_weights(weights, 2)
+    np.testing.assert_array_equal(weights, original)
+
+
+# ---------------------------------------------------------------------------
+# clip_weights option in rejection_sample
+# ---------------------------------------------------------------------------
+
+
+def test_clip_weights_increases_output():
+    """clip_weights=True should yield at least as many samples as clip_weights=False."""
+    # Use a highly skewed weight distribution so clipping makes a big difference.
+    rng = np.random.default_rng(7)
+    weights = rng.exponential(size=400)
+    weights[0] = weights.max() * 20  # one very dominant weight
+    result = make_result_with_weights(weights, extra_col=False)
+
+    n_no_clip = len(result.rejection_sample(clip_weights=False, random_state=0))
+    n_clip = len(result.rejection_sample(clip_weights=True, random_state=0))
+    assert n_clip >= n_no_clip
+
+
+def test_clip_weights_num_clip_is_ceil_sqrt_n():
+    """The num_clip used internally must be ceil(sqrt(N))."""
+    n = 100
+    weights = np.ones(n)
+    weights[0] = 1000.0  # one extreme outlier
+    result = make_result_with_weights(weights, extra_col=False)
+
+    # With clip_weights=True, the outlier should be clipped: check that the
+    # max output count is 1 (since after clipping all weights are ~equal).
+    out = result.rejection_sample(clip_weights=True, random_state=0)
+    assert out["x"].value_counts().max() == 1
+
+
+def test_clip_weights_reproducible():
+    """clip_weights=True with the same random_state must give identical results."""
+    rng = np.random.default_rng(3)
+    weights = rng.exponential(size=50)
+    result = make_result_with_weights(weights, extra_col=False)
+    out1 = result.rejection_sample(clip_weights=True, random_state=42)
+    out2 = result.rejection_sample(clip_weights=True, random_state=42)
+    pd.testing.assert_frame_equal(out1, out2)


### PR DESCRIPTION
Brings dingo's rejection_sample + _clip_weights Result methods and the get_pesummary_samples(resampling_method=...) selector onto the seobnrv5ehm branch without dropping SEOBNRv5EHM support. get_pesummary_samples keeps the aligned-spin chi_1/chi_2 -> spin_1z/spin_2z rename and the phi_jl guard from seobnrv5ehm, and defaults to clip+rejection.

Adds an env-var hook: when resampling_method is None it reads DINGO_RESAMPLING_METHOD (default 'clip+rejection'), so callers that cannot pass the argument through (e.g. PESummary's dingo reader) can still select the method.

Cherry-picked from c5fe3c18 (#357).