### PR TITLE
Optional torch.compile and TF32 for training

### DIFF
--- a/dingo/core/nn/compile_utils.py
+++ b/dingo/core/nn/compile_utils.py
@@ -26,6 +26,15 @@ def eager_mode():
         yield
 
 
+def is_compiled(network: torch.nn.Module) -> bool:
+    """True if ``network`` is (or wraps) a ``torch.compile``-d module."""
+    while network is not None:
+        if hasattr(network, "_orig_mod"):  # torch.compile OptimizedModule
+            return True
+        network = getattr(network, "module", None)  # DDP
+    return False
+
+
 def compile_network(
     network: torch.nn.Module, rank: int = None, cache_dir: str = None
 ) -> torch.nn.Module:
@@ -41,15 +50,40 @@ def compile_network(
         Inductor/Triton cache: the ranks compile concurrently and would otherwise
         race on the shared cache files.
     cache_dir : str, optional
-        Base directory for the per-rank caches (default: the system temp dir). It
-        must be **node-local**: Triton shared objects written to a network
-        filesystem can be unloadable from another process, which hangs the run.
+        Base directory for the on-disk Inductor/Triton cache (default: the system
+        temp dir). It must be **node-local**: Triton shared objects written to a
+        network filesystem can be unloadable from another process, which hangs
+        the run.
     """
-    if rank is not None:
-        # in case the default cache dir is not available
+    if rank is not None or cache_dir is not None:
         base = cache_dir or tempfile.gettempdir()
-        # naming the cache so that different DDP ranks do not interferej
-        rank_cache = os.path.join(base, f"dingo_inductor_rank{rank}")
-        os.environ["TORCHINDUCTOR_CACHE_DIR"] = rank_cache
-        os.environ["TRITON_CACHE_DIR"] = os.path.join(rank_cache, "triton")
+        name = "dingo_inductor" if rank is None else f"dingo_inductor_rank{rank}"
+        cache = os.path.join(base, name)
+        os.environ["TORCHINDUCTOR_CACHE_DIR"] = cache
+        os.environ["TRITON_CACHE_DIR"] = os.path.join(cache, "triton")
     return torch.compile(network)
+
+
+def reset_graphs_if_requires_grad_changes(
+    network: torch.nn.Module, name_contains: str, requires_grad: bool
+) -> bool:
+    """Discard the compiled graphs of ``network`` if setting ``requires_grad`` on the
+    parameters whose name contains ``name_contains`` would change their state.
+
+    Dynamo does not guard on ``requires_grad`` of parameters: a graph traced while
+    a layer was frozen is reused after the layer is unfrozen, and its backward
+    never produces gradients for that layer (no error, the loss looks normal).
+    Call this *before* flipping the flags at a stage boundary; the next forward
+    then re-traces with the new set of trainable parameters. Returns True if the
+    graphs were reset. No-op for uncompiled networks.
+    """
+    if not is_compiled(network):
+        return False
+    params = [p for n, p in network.named_parameters() if name_contains in n]
+    if not params:
+        return False
+    currently_trainable = any(p.requires_grad for p in params)
+    if currently_trainable == bool(requires_grad):
+        return False
+    torch.compiler.reset()
+    return True

--- a/dingo/core/nn/compile_utils.py
+++ b/dingo/core/nn/compile_utils.py
@@ -1,57 +1,28 @@
-"""``torch.compile`` support for the flow network (``local.torch_compile``).
-
+"""
 The neural spline flow launches tens of thousands of tiny CUDA kernels per step
 (one per spline/indexing op in every coupling transform), so on a modern GPU the
 step is bound by kernel-launch overhead rather than by arithmetic. ``torch.compile``
 fuses these kernels and removes most of that overhead.
-
-This only works if the rational-quadratic spline in ``glasflow.nflows`` is written
-with static shapes. The original implementation selects the points inside/outside
-the spline tails with data-dependent boolean-mask indexing and a host-syncing
-``torch.any`` branch, which force graph breaks and stop the kernels from fusing;
-with it, ``torch.compile`` is a net *slowdown*. A numerically identical static-shape
-rewrite lives in the ``compile-friendly-rqs`` branch of
-https://github.com/nihargupte-ph/nflows (vendored by the matching branch of
-https://github.com/nihargupte-ph/glasflow) until it is merged upstream.
 """
 
 import contextlib
-import inspect
 import os
 import tempfile
 
 import torch
-
-GLASFLOW_INSTALL_HINT = (
-    "pip install git+https://github.com/nihargupte-ph/glasflow@compile-friendly-rqs"
-)
-
-
-def spline_is_compile_friendly() -> bool:
-    """Whether the installed glasflow ships the static-shape RQ spline.
-
-    The rewrite added a ``check_domain`` argument to ``rational_quadratic_spline``
-    (so the clamped call can skip its host-syncing domain check); its presence is
-    used as the marker.
-    """
-    from glasflow.nflows.transforms.splines import rational_quadratic as rq
-
-    return "check_domain" in inspect.signature(rq.rational_quadratic_spline).parameters
 
 
 @contextlib.contextmanager
 def eager_mode():
     """Run compiled networks eagerly inside the block, without (re)compiling.
 
-    The test epoch runs the network in eval mode, which would otherwise trigger a
-    second full compilation (several minutes for a production-size network) that
-    a test epoch of a few hundred steps never amortizes.
+    The test epoch runs the network in eval mode. This is a different graph than 
+    what you would see at training. Therefore, it would trigger a
+    second full compilation. Instead, we do eager evaluation (not using the 
+    fused kernels) to avoid the test loop taking a long time. We could also 
+    compile a "test time" graph, but it does not amortize as well as training time. 
     """
-    set_stance = getattr(torch.compiler, "set_stance", None)
-    if set_stance is None:  # torch < 2.6
-        yield
-        return
-    with set_stance("force_eager"):
+    with torch.compiler.set_stance("force_eager"):
         yield
 
 
@@ -73,23 +44,11 @@ def compile_network(
         Base directory for the per-rank caches (default: the system temp dir). It
         must be **node-local**: Triton shared objects written to a network
         filesystem can be unloadable from another process, which hangs the run.
-
-    Raises
-    ------
-    RuntimeError
-        If the installed glasflow lacks the static-shape spline, since compiling
-        would then be slower than eager mode.
     """
-    if not spline_is_compile_friendly():
-        raise RuntimeError(
-            "torch_compile requires a glasflow with the static-shape "
-            "rational-quadratic spline; the installed version would compile with "
-            "graph breaks and run slower than eager mode. Install it with\n"
-            f"    {GLASFLOW_INSTALL_HINT}\n"
-            "or set torch_compile: false."
-        )
     if rank is not None:
+        # in case the default cache dir is not available
         base = cache_dir or tempfile.gettempdir()
+        # naming the cache so that different DDP ranks do not interferej
         rank_cache = os.path.join(base, f"dingo_inductor_rank{rank}")
         os.environ["TORCHINDUCTOR_CACHE_DIR"] = rank_cache
         os.environ["TRITON_CACHE_DIR"] = os.path.join(rank_cache, "triton")

--- a/dingo/core/nn/compile_utils.py
+++ b/dingo/core/nn/compile_utils.py
@@ -1,0 +1,79 @@
+"""``torch.compile`` support for the flow network (``local.torch_compile``).
+
+The neural spline flow launches tens of thousands of tiny CUDA kernels per step
+(one per spline/indexing op in every coupling transform), so on a modern GPU the
+step is bound by kernel-launch overhead rather than by arithmetic. ``torch.compile``
+fuses these kernels and removes most of that overhead.
+
+This only works if the rational-quadratic spline in ``glasflow.nflows`` is written
+with static shapes. The original implementation selects the points inside/outside
+the spline tails with data-dependent boolean-mask indexing and a host-syncing
+``torch.any`` branch, which force graph breaks and stop the kernels from fusing;
+with it, ``torch.compile`` is a net *slowdown*. A numerically identical static-shape
+rewrite lives in the ``compile-friendly-rqs`` branch of
+https://github.com/nihargupte-ph/nflows (vendored by the matching branch of
+https://github.com/nihargupte-ph/glasflow) until it is merged upstream.
+"""
+
+import inspect
+import os
+import tempfile
+
+import torch
+
+GLASFLOW_INSTALL_HINT = (
+    "pip install git+https://github.com/nihargupte-ph/glasflow@compile-friendly-rqs"
+)
+
+
+def spline_is_compile_friendly() -> bool:
+    """Whether the installed glasflow ships the static-shape RQ spline.
+
+    The rewrite added a ``check_domain`` argument to ``rational_quadratic_spline``
+    (so the clamped call can skip its host-syncing domain check); its presence is
+    used as the marker.
+    """
+    from glasflow.nflows.transforms.splines import rational_quadratic as rq
+
+    return "check_domain" in inspect.signature(rq.rational_quadratic_spline).parameters
+
+
+def compile_network(
+    network: torch.nn.Module, rank: int = None, cache_dir: str = None
+) -> torch.nn.Module:
+    """Return ``torch.compile(network)``, set up for (optionally) DDP training.
+
+    Parameters
+    ----------
+    network : torch.nn.Module
+        The network to compile. Under DDP pass the DDP-wrapped network, so that
+        the gradient all-reduce can still overlap with the backward pass.
+    rank : int, optional
+        DDP rank. When given, each rank is pointed at its own on-disk
+        Inductor/Triton cache: the ranks compile concurrently and would otherwise
+        race on the shared cache files.
+    cache_dir : str, optional
+        Base directory for the per-rank caches (default: the system temp dir). It
+        must be **node-local**: Triton shared objects written to a network
+        filesystem can be unloadable from another process, which hangs the run.
+
+    Raises
+    ------
+    RuntimeError
+        If the installed glasflow lacks the static-shape spline, since compiling
+        would then be slower than eager mode.
+    """
+    if not spline_is_compile_friendly():
+        raise RuntimeError(
+            "torch_compile requires a glasflow with the static-shape "
+            "rational-quadratic spline; the installed version would compile with "
+            "graph breaks and run slower than eager mode. Install it with\n"
+            f"    {GLASFLOW_INSTALL_HINT}\n"
+            "or set torch_compile: false."
+        )
+    if rank is not None:
+        base = cache_dir or tempfile.gettempdir()
+        rank_cache = os.path.join(base, f"dingo_inductor_rank{rank}")
+        os.environ["TORCHINDUCTOR_CACHE_DIR"] = rank_cache
+        os.environ["TRITON_CACHE_DIR"] = os.path.join(rank_cache, "triton")
+    return torch.compile(network)

--- a/dingo/core/nn/compile_utils.py
+++ b/dingo/core/nn/compile_utils.py
@@ -15,6 +15,7 @@ https://github.com/nihargupte-ph/nflows (vendored by the matching branch of
 https://github.com/nihargupte-ph/glasflow) until it is merged upstream.
 """
 
+import contextlib
 import inspect
 import os
 import tempfile
@@ -36,6 +37,22 @@ def spline_is_compile_friendly() -> bool:
     from glasflow.nflows.transforms.splines import rational_quadratic as rq
 
     return "check_domain" in inspect.signature(rq.rational_quadratic_spline).parameters
+
+
+@contextlib.contextmanager
+def eager_mode():
+    """Run compiled networks eagerly inside the block, without (re)compiling.
+
+    The test epoch runs the network in eval mode, which would otherwise trigger a
+    second full compilation (several minutes for a production-size network) that
+    a test epoch of a few hundred steps never amortizes.
+    """
+    set_stance = getattr(torch.compiler, "set_stance", None)
+    if set_stance is None:  # torch < 2.6
+        yield
+        return
+    with set_stance("force_eager"):
+        yield
 
 
 def compile_network(

--- a/dingo/core/posterior_models/base_model.py
+++ b/dingo/core/posterior_models/base_model.py
@@ -19,7 +19,6 @@ import torch
 import torch.distributed as dist
 from threadpoolctl import threadpool_limits
 from torch.amp import autocast
-from torch.nn.parallel import DistributedDataParallel as DDP
 from torch.utils.data import Dataset
 
 try:
@@ -42,6 +41,7 @@ import dingo.core.utils as utils
 import dingo.core.utils.trainutils
 from dingo.core.utils.backward_compatibility import update_model_config
 from dingo.core.utils.misc import get_version
+from dingo.core.utils.torchutils import get_ddp_module, unwrap_network
 from dingo.core.utils.trainutils import EarlyStopping, RuntimeLimits
 
 
@@ -259,11 +259,9 @@ class BasePosteriorModel(ABC):
             saved, e.g. optimizer state dict
 
         """
-        # Strip the DDP wrapper so the checkpoint can be loaded on any number of GPUs.
-        if isinstance(self.network, DDP):
-            model_state_dict = self.network.module.state_dict()
-        else:
-            model_state_dict = self.network.state_dict()
+        # Strip the DDP and torch.compile wrappers so the checkpoint can be loaded
+        # on any number of GPUs, with or without compilation.
+        model_state_dict = unwrap_network(self.network).state_dict()
 
         model_dict = {
             "model_kwargs": self.model_kwargs,
@@ -648,7 +646,7 @@ def train_epoch(
         if scaler is None:
             scaler = _build_grad_scaler(pm.device)
 
-    is_ddp = isinstance(pm.network, DDP)
+    ddp_module = get_ddp_module(pm.network)
 
     for batch_idx, data in enumerate(dataloader):
         loss_info.update_timer("Dataloader")
@@ -663,7 +661,9 @@ def train_epoch(
         # Under DDP, gradients only need to be all-reduced on the final backward
         # pass of an accumulation window; skip the synchronization otherwise.
         sync_ctx = (
-            pm.network.no_sync() if is_ddp and not is_step_batch else nullcontext()
+            ddp_module.no_sync()
+            if ddp_module is not None and not is_step_batch
+            else nullcontext()
         )
 
         # Gradients are summed over the accumulated mini-batches, so divide each

--- a/dingo/core/posterior_models/base_model.py
+++ b/dingo/core/posterior_models/base_model.py
@@ -39,6 +39,7 @@ except ImportError:
 
 import dingo.core.utils as utils
 import dingo.core.utils.trainutils
+from dingo.core.nn.compile_utils import eager_mode
 from dingo.core.utils.backward_compatibility import update_model_config
 from dingo.core.utils.misc import get_version
 from dingo.core.utils.torchutils import get_ddp_module, unwrap_network
@@ -725,7 +726,9 @@ def test_epoch(
     float
         Average loss over the test set.
     """
-    with torch.no_grad():
+    # eager_mode: evaluating a compiled network in eval mode would trigger another
+    # full compilation, which a short test epoch never amortizes.
+    with torch.no_grad(), eager_mode():
         pm.network.eval()
 
         if pm.rank is None:

--- a/dingo/core/utils/torchutils.py
+++ b/dingo/core/utils/torchutils.py
@@ -400,8 +400,10 @@ def build_train_and_test_loaders(
     rank : int, optional
         Rank of the current DDP process.
     drop_last : bool
-        Drop the last, smaller batch of each epoch. Used with ``torch.compile``,
-        which would otherwise recompile the network for the odd batch shape.
+        Drop the last, smaller batch of each training epoch, so that a compiled
+        network (specialized to the batch shape) is not recompiled for it. The test
+        loader always keeps its last batch: the test epoch runs eagerly, and dropping
+        it could leave a small per-rank test split with no batches at all.
 
     Returns
     -------
@@ -442,7 +444,7 @@ def build_train_and_test_loaders(
             num_workers=num_workers,
             worker_init_fn=fix_random_seeds,
             persistent_workers=persistent_workers,
-            drop_last=drop_last,
+            drop_last=False,
         )
     else:
         train_sampler = None
@@ -464,7 +466,7 @@ def build_train_and_test_loaders(
             num_workers=num_workers,
             worker_init_fn=fix_random_seeds,
             persistent_workers=persistent_workers,
-            drop_last=drop_last,
+            drop_last=False,
         )
 
     return train_loader, test_loader, train_sampler

--- a/dingo/core/utils/torchutils.py
+++ b/dingo/core/utils/torchutils.py
@@ -129,6 +129,32 @@ def replace_BatchNorm_with_SyncBatchNorm(network: nn.Module) -> nn.Module:
     return nn.SyncBatchNorm.convert_sync_batchnorm(network)
 
 
+def get_ddp_module(network: nn.Module) -> Optional[DDP]:
+    """Return the DDP wrapper inside *network* (looking through a ``torch.compile``
+    wrapper), or ``None`` if the network is not DDP-wrapped."""
+    while True:
+        if isinstance(network, DDP):
+            return network
+        if hasattr(network, "_orig_mod"):  # torch.compile OptimizedModule
+            network = network._orig_mod
+        else:
+            return None
+
+
+def unwrap_network(network: nn.Module) -> nn.Module:
+    """Strip ``torch.compile`` and DDP wrappers, returning the bare network.
+
+    Used to save checkpoints whose state-dict keys carry no wrapper prefixes, so
+    they load on any number of GPUs with or without compilation."""
+    while True:
+        if isinstance(network, DDP):
+            network = network.module
+        elif hasattr(network, "_orig_mod"):  # torch.compile OptimizedModule
+            network = network._orig_mod
+        else:
+            return network
+
+
 def print_number_of_model_parameters(network: nn.Module) -> None:
     """
     Print the number of fixed and learnable parameters of *network*.

--- a/dingo/core/utils/torchutils.py
+++ b/dingo/core/utils/torchutils.py
@@ -355,6 +355,7 @@ def build_train_and_test_loaders(
     num_workers: int,
     world_size: Optional[int] = None,
     rank: Optional[int] = None,
+    drop_last: bool = False,
 ) -> Tuple[DataLoader, DataLoader, Optional[DistributedSampler]]:
     """
     Split the dataset into train and test sets, and build corresponding DataLoaders.
@@ -376,6 +377,9 @@ def build_train_and_test_loaders(
         Total number of DDP processes (GPUs).
     rank : int, optional
         Rank of the current DDP process.
+    drop_last : bool
+        Drop the last, smaller batch of each epoch. Used with ``torch.compile``,
+        which would otherwise recompile the network for the odd batch shape.
 
     Returns
     -------
@@ -406,6 +410,7 @@ def build_train_and_test_loaders(
             num_workers=num_workers,
             worker_init_fn=fix_random_seeds,
             persistent_workers=persistent_workers,
+            drop_last=drop_last,
         )
         test_loader = DataLoader(
             test_dataset,
@@ -415,6 +420,7 @@ def build_train_and_test_loaders(
             num_workers=num_workers,
             worker_init_fn=fix_random_seeds,
             persistent_workers=persistent_workers,
+            drop_last=drop_last,
         )
     else:
         train_sampler = None
@@ -426,6 +432,7 @@ def build_train_and_test_loaders(
             num_workers=num_workers,
             worker_init_fn=fix_random_seeds,
             persistent_workers=persistent_workers,
+            drop_last=drop_last,
         )
         test_loader = DataLoader(
             test_dataset,
@@ -435,6 +442,7 @@ def build_train_and_test_loaders(
             num_workers=num_workers,
             worker_init_fn=fix_random_seeds,
             persistent_workers=persistent_workers,
+            drop_last=drop_last,
         )
 
     return train_loader, test_loader, train_sampler

--- a/dingo/core/utils/torchutils.py
+++ b/dingo/core/utils/torchutils.py
@@ -21,6 +21,26 @@ def fix_random_seeds(_):
         pass
 
 
+def set_float32_matmul_precision(local_settings: dict) -> None:
+    """Apply ``local.float32_matmul_precision`` (``highest`` | ``high`` | ``medium``).
+
+    ``high`` lets float32 matrix multiplications use TensorFloat-32 on Ampere and
+    newer GPUs (10-bit mantissa inputs, fp32 accumulation), roughly doubling the
+    speed of the network's linear layers; ``medium`` additionally allows bfloat16
+    inputs. PyTorch's default, ``highest``, keeps full fp32 and is left unchanged
+    when the setting is absent.
+    """
+    precision = local_settings.get("float32_matmul_precision")
+    if precision is None:
+        return
+    if precision not in ("highest", "high", "medium"):
+        raise ValueError(
+            f"float32_matmul_precision must be 'highest', 'high' or 'medium', "
+            f"got {precision!r}."
+        )
+    torch.set_float32_matmul_precision(precision)
+
+
 def get_cuda_info() -> dict[str, Any]:
     """Get information about the CUDA devices available in the system."""
     if not torch.cuda.is_available():

--- a/dingo/core/utils/torchutils.py
+++ b/dingo/core/utils/torchutils.py
@@ -166,6 +166,8 @@ def unwrap_network(network: nn.Module) -> nn.Module:
 
     Used to save checkpoints whose state-dict keys carry no wrapper prefixes, so
     they load on any number of GPUs with or without compilation."""
+    # we need a while loop here because the network can be wrapped twice
+    # once by the DDP and once by torch.compile
     while True:
         if isinstance(network, DDP):
             network = network.module

--- a/dingo/gw/training/train_pipeline.py
+++ b/dingo/gw/training/train_pipeline.py
@@ -16,6 +16,7 @@ from threadpoolctl import threadpool_limits
 from torch.nn.parallel import DistributedDataParallel as DDP
 from torch.utils.data import DataLoader, DistributedSampler
 
+from dingo.core.nn.compile_utils import compile_network
 from dingo.core.posterior_models.base_model import BasePosteriorModel
 from dingo.core.posterior_models.build_model import (
     autocomplete_model_kwargs,
@@ -535,6 +536,11 @@ def run_training(
     else:
         pm, wfd = prepare_training_resume(ckpt_file, local_settings, train_dir)
 
+    if local_settings.get("torch_compile", False):
+        pm.network = compile_network(
+            pm.network, cache_dir=local_settings.get("torch_compile_cache_dir")
+        )
+
     with threadpool_limits(limits=1, user_api="blas"):
         complete, resume_flag = train_stages(
             pm=pm,
@@ -651,6 +657,15 @@ def run_training_ddp(
                 )
             pm.network = replace_BatchNorm_with_SyncBatchNorm(pm.network)
         pm.network = DDP(pm.network, device_ids=[rank])
+
+        # Compile after the DDP wrap so the gradient all-reduce keeps overlapping
+        # with the backward pass (torch.compile splits the graph at DDP buckets).
+        if local_settings.get("torch_compile", False):
+            pm.network = compile_network(
+                pm.network,
+                rank=rank,
+                cache_dir=local_settings.get("torch_compile_cache_dir"),
+            )
 
         with threadpool_limits(limits=1, user_api="blas"):
             complete, resume_flag = train_stages(

--- a/dingo/gw/training/train_pipeline.py
+++ b/dingo/gw/training/train_pipeline.py
@@ -16,7 +16,10 @@ from threadpoolctl import threadpool_limits
 from torch.nn.parallel import DistributedDataParallel as DDP
 from torch.utils.data import DataLoader, DistributedSampler
 
-from dingo.core.nn.compile_utils import compile_network
+from dingo.core.nn.compile_utils import (
+    compile_network,
+    reset_graphs_if_requires_grad_changes,
+)
 from dingo.core.posterior_models.base_model import BasePosteriorModel
 from dingo.core.posterior_models.build_model import (
     autocomplete_model_kwargs,
@@ -296,6 +299,15 @@ def initialize_stage(
 
     # Freeze/unfreeze RB layer if necessary
     if "freeze_rb_layer" in stage:
+        if reset_graphs_if_requires_grad_changes(
+            pm.network,
+            name_contains="layers_rb",
+            requires_grad=not stage["freeze_rb_layer"],
+        ) and print_output:
+            print(
+                "freeze_rb_layer changes the trainable parameters: compiled graphs "
+                "(if any) discarded, the next training step (re)compiles."
+            )
         if stage["freeze_rb_layer"]:
             if world_size is not None and world_size > 1:
                 raise ValueError(
@@ -515,6 +527,13 @@ def get_num_gpus(local_settings: dict) -> int:
     return 1
 
 
+def _record_float32_matmul_precision(pm: BasePosteriorModel) -> None:
+    """Store the matmul precision in the checkpoint metadata: unlike torch_compile
+    it changes the numerics of training, so it belongs with the model."""
+    if isinstance(pm.metadata, dict):
+        pm.metadata["float32_matmul_precision"] = torch.get_float32_matmul_precision()
+
+
 def run_training(
     train_settings: Optional[dict],
     local_settings: dict,
@@ -544,6 +563,7 @@ def run_training(
         pm, wfd = prepare_training_new(train_settings, train_dir, local_settings)
     else:
         pm, wfd = prepare_training_resume(ckpt_file, local_settings, train_dir)
+    _record_float32_matmul_precision(pm)
 
     if local_settings.get("torch_compile", False):
         pm.network = compile_network(
@@ -655,6 +675,8 @@ def run_training_ddp(
                     )
                 except ImportError:
                     print("WandB is enabled but not installed.")
+
+        _record_float32_matmul_precision(pm)
 
         if contains_BatchNorm(pm.network):
             if rank == 0:

--- a/dingo/gw/training/train_pipeline.py
+++ b/dingo/gw/training/train_pipeline.py
@@ -215,6 +215,7 @@ def initialize_stage(
     world_size: Optional[int] = None,
     rank: Optional[int] = None,
     resume: bool = False,
+    drop_last: bool = False,
 ) -> Tuple[DataLoader, DataLoader, Optional[DistributedSampler]]:
     """
     Initializes training based on PosteriorModel metadata and current stage:
@@ -280,6 +281,7 @@ def initialize_stage(
         num_workers=num_workers_per_gpu,
         world_size=world_size,
         rank=rank,
+        drop_last=drop_last,
     )
 
     if not resume:
@@ -346,6 +348,9 @@ def train_stages(
     rank = local_settings.get("rank", None)
     world_size = local_settings.get("world_size", None)
     print_primary = rank is None or rank == 0
+    # A compiled network is specialized to the batch shape; skip the smaller last
+    # batch of each epoch rather than compiling a second graph for it.
+    drop_last = bool(local_settings.get("torch_compile", False))
 
     # Extract list of stages from settings dict
     stages = []
@@ -375,6 +380,7 @@ def train_stages(
                 world_size=world_size,
                 rank=rank,
                 resume=False,
+                drop_last=drop_last,
             )
         else:
             if print_primary:
@@ -388,6 +394,7 @@ def train_stages(
                 world_size=world_size,
                 rank=rank,
                 resume=True,
+                drop_last=drop_last,
             )
 
         early_stopping = None

--- a/dingo/gw/training/train_pipeline.py
+++ b/dingo/gw/training/train_pipeline.py
@@ -32,6 +32,7 @@ from dingo.core.utils.torchutils import (
     contains_BatchNorm,
     document_gpus,
     replace_BatchNorm_with_SyncBatchNorm,
+    set_float32_matmul_precision,
     set_seed_based_on_rank,
     setup_ddp,
 )
@@ -538,6 +539,7 @@ def run_training(
     -------
     (complete, resume, epoch) : (bool, bool, int)
     """
+    set_float32_matmul_precision(local_settings)
     if not resume:
         pm, wfd = prepare_training_new(train_settings, train_dir, local_settings)
     else:
@@ -598,6 +600,7 @@ def run_training_ddp(
         # avoid collisions between their process groups.
         setup_ddp(rank, world_size, port=local_settings.get("ddp_port", 12355))
         set_seed_based_on_rank(rank)
+        set_float32_matmul_precision(local_settings)
 
         if rank == 0:
             document_gpus(train_dir)

--- a/docs/source/training.md
+++ b/docs/source/training.md
@@ -72,6 +72,7 @@ training:
     optimizer:
       type: adam
       lr: 0.0001
+#     fused: false         # True selects the fused CUDA kernel; see the multi-GPU guide.
     scheduler:
       type: cosine
       T_max: 300

--- a/docs/source/training.md
+++ b/docs/source/training.md
@@ -101,6 +101,7 @@ local:
                 # freeze_rb_layer: False in all stages. When using
                 # dingo_train_condor, request_gpus is set automatically.
 # ddp_port: 12355  # Rendezvous port for DDP; change when running several jobs on one node.
+# torch_compile: False  # Fuse the network kernels with torch.compile; see the multi-GPU guide.
 #  wandb:
 #    project: dingo
 #    group: my_project

--- a/docs/source/training.md
+++ b/docs/source/training.md
@@ -102,6 +102,7 @@ local:
                 # dingo_train_condor, request_gpus is set automatically.
 # ddp_port: 12355  # Rendezvous port for DDP; change when running several jobs on one node.
 # torch_compile: False  # Fuse the network kernels with torch.compile; see the multi-GPU guide.
+# float32_matmul_precision: highest  # 'high' enables TensorFloat-32 matmuls (A100+); see the multi-GPU guide.
 #  wandb:
 #    project: dingo
 #    group: my_project

--- a/docs/source/training_multi_gpu.md
+++ b/docs/source/training_multi_gpu.md
@@ -153,8 +153,7 @@ modern GPU the step is bound by kernel-launch overhead rather than by arithmetic
 utilization plateaus well below 100% even at large batch sizes). Setting `torch_compile: true`
 in the `local` section wraps the network with
 [`torch.compile`](https://pytorch.org/docs/stable/generated/torch.compile.html), which fuses
-these kernels. **This option is experimental** until the static-shape spline (see the glasflow note
-below) is part of a glasflow release. The gain depends on how launch-bound the network is: for the `npe_model` example
+these kernels. The gain depends on how launch-bound the network is: for the `npe_model` example
 network (30 flow steps, `hidden_dim` 1024) trained on a 10M-waveform dataset at a per-GPU batch
 size of 4096 (A100), the training step is 1.22× faster on one GPU and 1.14× faster on four GPUs;
 with `hidden_dim` 512 it is 1.4× / 1.35×. Peak GPU memory drops by about 20%. The speedup is
@@ -175,11 +174,6 @@ Notes:
   loader drops the last, smaller batch of each epoch (the compiled graph is specialized to the
   batch shape; the test loader keeps it) and the test epoch runs the network eagerly (an
   eval-mode graph would cost another compilation that a short test epoch never amortizes).
-- `torch.compile` only pays off with a static-shape rational-quadratic spline. The spline in
-  released glasflow selects its tails with mask indexing, which breaks the compiled graph in
-  every transform, so with it `torch_compile: true` runs but is *slower* than eager. Until the
-  rewrite is released, install the fork:
-  `pip install git+https://github.com/nihargupte-ph/glasflow@compile-friendly-rqs`.
 - A stage boundary that changes `freeze_rb_layer` discards the compiled graphs and the next
   step recompiles (a compiled graph does not track which parameters are trainable).
 - `torch_compile_cache_dir` sets the base directory of the on-disk Inductor/Triton cache

--- a/docs/source/training_multi_gpu.md
+++ b/docs/source/training_multi_gpu.md
@@ -175,13 +175,13 @@ Notes:
   ```
   Dingo raises an error if `torch_compile: true` is set without it. The rewrite is numerically
   identical, so checkpoints are interchangeable.
-- Compilation is slow: 4–12 minutes per graph for a production-size network, and the network
-  is compiled once per distinct batch shape and mode. In practice that is four compilations in
-  the first epoch (the training graph, the smaller last batch of the epoch, and the same two
-  for the test epoch), i.e. 10–40 minutes of overhead per run, plus a recompilation at every
-  stage boundary that changes which parameters are trainable. The compiled steps that follow
-  are the fast ones, so `torch_compile` pays off for trainings of tens of epochs or more, not
-  for short runs.
+- Compilation is slow: 4–12 minutes for a production-size network, paid on the first training
+  step of a run and again at every stage boundary that changes which parameters are trainable.
+  The compiled steps that follow are the fast ones, so `torch_compile` pays off for trainings
+  of tens of epochs or more, not for short runs. To avoid further compilations the last,
+  smaller batch of each epoch is dropped (the compiled graph is specialized to the batch
+  shape) and the test epoch runs the network eagerly (an eval-mode graph would cost another
+  compilation that a short test epoch never amortizes).
 - Under DDP each rank compiles into its own on-disk Inductor/Triton cache. That cache must live
   on **node-local** disk. If the system temp directory is a shared network filesystem, set
   `torch_compile_cache_dir` to a node-local path (e.g. the HTCondor scratch directory);

--- a/docs/source/training_multi_gpu.md
+++ b/docs/source/training_multi_gpu.md
@@ -146,6 +146,50 @@ If a network with `BatchNorm` layers is trained on multiple GPUs, they are conve
 `LayerNorm` is only available for `base_transform_type: rq-coupling`. For `rq-autoregressive` transforms
 it would break the causal structure of the MADE layers, so `BatchNorm` or `null` must be used there.
 
+### Compiling the network (`torch_compile`)
+
+The neural spline flow launches tens of thousands of small CUDA kernels per step, so on a
+modern GPU the step is bound by kernel-launch overhead rather than by arithmetic (GPU
+utilization plateaus well below 100% even at large batch sizes). Setting `torch_compile: true`
+in the `local` section wraps the network with
+[`torch.compile`](https://pytorch.org/docs/stable/generated/torch.compile.html), which fuses
+these kernels. The gain depends on how launch-bound the network is: for the `npe_model` example
+network (30 flow steps, `hidden_dim` 1024) trained on a 10M-waveform dataset at a per-GPU batch
+size of 4096 (A100), the training step is 1.22× faster on one GPU and 1.14× faster on four GPUs;
+with `hidden_dim` 512 it is 1.4× / 1.35×. Peak GPU memory drops by about 20%. The speedup is
+independent of `num_gpus` and larger at smaller per-GPU batch sizes.
+
+```yaml
+local:
+  torch_compile: true                    # default: false
+  torch_compile_cache_dir: /scratch/tmp  # optional; see note below
+```
+
+Notes:
+
+- Compilation requires a `glasflow` whose rational-quadratic spline is written with static
+  shapes (the released version uses data-dependent indexing, which breaks the compiled graph
+  and makes `torch.compile` a net slowdown). Until the rewrite is merged upstream, install
+  ```
+  pip install git+https://github.com/nihargupte-ph/glasflow@compile-friendly-rqs
+  ```
+  Dingo raises an error if `torch_compile: true` is set without it. The rewrite is numerically
+  identical, so checkpoints are interchangeable.
+- Compilation is slow: 4–12 minutes per graph for a production-size network, and the network
+  is compiled once per distinct batch shape and mode. In practice that is four compilations in
+  the first epoch (the training graph, the smaller last batch of the epoch, and the same two
+  for the test epoch), i.e. 10–40 minutes of overhead per run, plus a recompilation at every
+  stage boundary that changes which parameters are trainable. The compiled steps that follow
+  are the fast ones, so `torch_compile` pays off for trainings of tens of epochs or more, not
+  for short runs.
+- Under DDP each rank compiles into its own on-disk Inductor/Triton cache. That cache must live
+  on **node-local** disk. If the system temp directory is a shared network filesystem, set
+  `torch_compile_cache_dir` to a node-local path (e.g. the HTCondor scratch directory);
+  otherwise a just-compiled kernel can be unloadable on another rank and the run hangs on an
+  NCCL timeout.
+- Once the network step is faster, the dataloader can become the bottleneck: watch
+  `Time Dataloader` in the log and raise `num_workers` if needed.
+
 ### Freezing layers
 
 It is currently not possible to set `freeze_rb_layer: True` in DDP. The reason is that when starting the separate 

--- a/docs/source/training_multi_gpu.md
+++ b/docs/source/training_multi_gpu.md
@@ -153,7 +153,8 @@ modern GPU the step is bound by kernel-launch overhead rather than by arithmetic
 utilization plateaus well below 100% even at large batch sizes). Setting `torch_compile: true`
 in the `local` section wraps the network with
 [`torch.compile`](https://pytorch.org/docs/stable/generated/torch.compile.html), which fuses
-these kernels. The gain depends on how launch-bound the network is: for the `npe_model` example
+these kernels. **This option is experimental** until the static-shape spline (see the glasflow note
+below) is part of a glasflow release. The gain depends on how launch-bound the network is: for the `npe_model` example
 network (30 flow steps, `hidden_dim` 1024) trained on a 10M-waveform dataset at a per-GPU batch
 size of 4096 (A100), the training step is 1.22× faster on one GPU and 1.14× faster on four GPUs;
 with `hidden_dim` 512 it is 1.4× / 1.35×. Peak GPU memory drops by about 20%. The speedup is
@@ -170,15 +171,22 @@ Notes:
 - Compilation is slow: 4–12 minutes for a production-size network, paid on the first training
   step of a run and again at every stage boundary that changes which parameters are trainable.
   The compiled steps that follow are the fast ones, so `torch_compile` pays off for trainings
-  of tens of epochs or more, not for short runs. To avoid further compilations the last,
-  smaller batch of each epoch is dropped (the compiled graph is specialized to the batch
-  shape) and the test epoch runs the network eagerly (an eval-mode graph would cost another
-  compilation that a short test epoch never amortizes).
-- Under DDP each rank compiles into its own on-disk Inductor/Triton cache. That cache must live
-  on **node-local** disk. If the system temp directory is a shared network filesystem, set
-  `torch_compile_cache_dir` to a node-local path (e.g. the HTCondor scratch directory);
-  otherwise a just-compiled kernel can be unloadable on another rank and the run hangs on an
-  NCCL timeout.
+  of tens of epochs or more, not for short runs. To avoid further compilations the *training*
+  loader drops the last, smaller batch of each epoch (the compiled graph is specialized to the
+  batch shape; the test loader keeps it) and the test epoch runs the network eagerly (an
+  eval-mode graph would cost another compilation that a short test epoch never amortizes).
+- `torch.compile` only pays off with a static-shape rational-quadratic spline. The spline in
+  released glasflow selects its tails with mask indexing, which breaks the compiled graph in
+  every transform, so with it `torch_compile: true` runs but is *slower* than eager. Until the
+  rewrite is released, install the fork:
+  `pip install git+https://github.com/nihargupte-ph/glasflow@compile-friendly-rqs`.
+- A stage boundary that changes `freeze_rb_layer` discards the compiled graphs and the next
+  step recompiles (a compiled graph does not track which parameters are trainable).
+- `torch_compile_cache_dir` sets the base directory of the on-disk Inductor/Triton cache
+  (default: the system temp directory); under DDP each rank gets its own subdirectory. That
+  cache must live on **node-local** disk. If the system temp directory is a shared network
+  filesystem, set it to a node-local path (e.g. the HTCondor scratch directory); otherwise a
+  just-compiled kernel can be unloadable on another rank and the run hangs on an NCCL timeout.
 - Once the network step is faster, the dataloader can become the bottleneck: watch
   `Time Dataloader` in the log and raise `num_workers` if needed.
 
@@ -197,7 +205,13 @@ float32 is kept, and accumulation, weights, gradients and optimizer state stay f
 the `npe_model` network (`hidden_dim` 1024) this roughly doubles the speed of the network step
 and combines with `torch_compile`: with both (and the fused optimizer below) the network step
 drops from 0.85 s to 0.28 s per 4096 samples on an A100, a 3× gain in GPU time. All non-matmul
-operations (splines, normalization, the optimizer) are unaffected. 
+operations (splines, normalization, the optimizer) are unaffected.
+
+TF32 and `automatic_mixed_precision` are alternatives, not a stack: under AMP the matmuls
+already run in float16, so `float32_matmul_precision: high` changes nothing there. On the
+`npe_model` network TF32 alone and AMP alone give the same speedup (0.90 to 0.47 s per step);
+TF32 is the option for trainings that stay in float32. The value in effect is stored in the
+checkpoint metadata (`float32_matmul_precision`).
 
 ### Fused optimizer (`fused`)
 
@@ -217,8 +231,8 @@ training:
 ```
 
 Each stage builds its own optimizer, so this has to be repeated in every stage that should use
-it. It is supported by `adam`, `adamw` and `sgd` (not `lbfgs` or `adagrad`) and requires all
-network parameters to be on the GPU.
+it. It is supported by `adam`, `adamw`, `adagrad` and `sgd` (not `lbfgs`); the fused kernel
+exists for CUDA and (since PyTorch 2.4) CPU tensors, the speedup matters on the GPU.
 
 ### Freezing layers
 

--- a/docs/source/training_multi_gpu.md
+++ b/docs/source/training_multi_gpu.md
@@ -190,7 +190,35 @@ Notes:
 - Once the network step is faster, the dataloader can become the bottleneck: watch
   `Time Dataloader` in the log and raise `num_workers` if needed.
 
-### Freezing layers
+### TensorFloat-32 matrix multiplications (`float32_matmul_precision`)
+
+PyTorch runs float32 matrix multiplications at full precision by default, which leaves the
+tensor cores of Ampere and newer GPUs unused. Setting
+
+```yaml
+local:
+  float32_matmul_precision: high   # default: highest
+```
+
+lets them use TensorFloat-32: matmul inputs are rounded to 10 mantissa bits (the range of
+float32 is kept, and accumulation, weights, gradients and optimizer state stay float32). For
+the `npe_model` network (`hidden_dim` 1024) this roughly doubles the speed of the network step
+and combines with `torch_compile`: with both (and the fused optimizer below) the network step
+drops from 0.85 s to 0.28 s per 4096 samples on an A100, a 3× gain in GPU time. All non-matmul
+operations (splines, normalization, the optimizer) are unaffected. In a 3-epoch production
+training the train and test losses matched full-precision training to within run-to-run noise;
+validate longer trainings before adopting it as a default, since the reduced input precision is
+a numerical change.
+
+Once the network step is this fast, the data pipeline usually becomes the limit: each worker
+decompresses and whitens its batch on the CPU at a few milliseconds per sample, so with 24
+workers per GPU the realised step was 0.40 s on one GPU (2.1× over fp32) and 0.62 s on four GPUs
+(1.4×), where a slow batch on any rank stalls all ranks at the gradient all-reduce. Watch
+`Time Dataloader` and give each GPU as many workers as the node allows.
+
+For the optimizer, `fused: true` under the `optimizer` settings selects the fused CUDA Adam
+kernel, which is about 10% faster per step for large networks.
+
 
 It is currently not possible to set `freeze_rb_layer: True` in DDP. The reason is that when starting the separate 
 DDP processes, it is fixed which network parameters have to be synced across GPUs and GPU memory is allocated 

--- a/docs/source/training_multi_gpu.md
+++ b/docs/source/training_multi_gpu.md
@@ -167,14 +167,6 @@ local:
 
 Notes:
 
-- Compilation requires a `glasflow` whose rational-quadratic spline is written with static
-  shapes (the released version uses data-dependent indexing, which breaks the compiled graph
-  and makes `torch.compile` a net slowdown). Until the rewrite is merged upstream, install
-  ```
-  pip install git+https://github.com/nihargupte-ph/glasflow@compile-friendly-rqs
-  ```
-  Dingo raises an error if `torch_compile: true` is set without it. The rewrite is numerically
-  identical, so checkpoints are interchangeable.
 - Compilation is slow: 4–12 minutes for a production-size network, paid on the first training
   step of a run and again at every stage boundary that changes which parameters are trainable.
   The compiled steps that follow are the fast ones, so `torch_compile` pays off for trainings
@@ -205,20 +197,30 @@ float32 is kept, and accumulation, weights, gradients and optimizer state stay f
 the `npe_model` network (`hidden_dim` 1024) this roughly doubles the speed of the network step
 and combines with `torch_compile`: with both (and the fused optimizer below) the network step
 drops from 0.85 s to 0.28 s per 4096 samples on an A100, a 3× gain in GPU time. All non-matmul
-operations (splines, normalization, the optimizer) are unaffected. In a 3-epoch production
-training the train and test losses matched full-precision training to within run-to-run noise;
-validate longer trainings before adopting it as a default, since the reduced input precision is
-a numerical change.
+operations (splines, normalization, the optimizer) are unaffected. 
 
-Once the network step is this fast, the data pipeline usually becomes the limit: each worker
-decompresses and whitens its batch on the CPU at a few milliseconds per sample, so with 24
-workers per GPU the realised step was 0.40 s on one GPU (2.1× over fp32) and 0.62 s on four GPUs
-(1.4×), where a slow batch on any rank stalls all ranks at the gradient all-reduce. Watch
-`Time Dataloader` and give each GPU as many workers as the node allows.
+### Fused optimizer (`fused`)
 
-For the optimizer, `fused: true` under the `optimizer` settings selects the fused CUDA Adam
-kernel, which is about 10% faster per step for large networks.
+Unlike the settings above, this one is not in the `local` section: it belongs to the
+`optimizer` block of an individual training stage, and is passed straight through to the
+PyTorch optimizer. Setting `fused: true` selects the fused CUDA kernel, which performs the
+whole optimizer update in one kernel instead of one per step of the update math, and is about
+10% faster per step for large networks:
 
+```yaml
+training:
+  stage_0:
+    optimizer:
+      type: adam
+      lr: 0.0001
+      fused: true   # default: false
+```
+
+Each stage builds its own optimizer, so this has to be repeated in every stage that should use
+it. It is supported by `adam`, `adamw` and `sgd` (not `lbfgs` or `adagrad`) and requires all
+network parameters to be on the GPU.
+
+### Freezing layers
 
 It is currently not possible to set `freeze_rb_layer: True` in DDP. The reason is that when starting the separate 
 DDP processes, it is fixed which network parameters have to be synced across GPUs and GPU memory is allocated 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,7 @@ dependencies = [
     "scikit-learn",
     "scipy",
     "threadpoolctl",
-    "torch>=2.0",
+    "torch>=2.6",  
     "torchdiffeq",
     "torchvision",
     "tqdm",

--- a/tests/core/test_compile.py
+++ b/tests/core/test_compile.py
@@ -1,0 +1,144 @@
+"""
+Tests for the optional ``torch.compile`` support (``local.torch_compile``).
+
+The compile path needs a glasflow whose rational-quadratic spline is written with
+static shapes; tests that exercise it are skipped when the installed glasflow does
+not provide it.
+"""
+
+import os
+from datetime import timedelta
+
+import pytest
+import torch
+import torch.distributed as dist
+import torch.nn as nn
+from torch.nn.parallel import DistributedDataParallel as DDP
+
+from dingo.core.nn.compile_utils import (
+    compile_network,
+    spline_is_compile_friendly,
+)
+from dingo.core.nn.nsf import create_nsf_model
+from dingo.core.posterior_models.normalizing_flow import NormalizingFlowPosteriorModel
+from dingo.core.utils.torchutils import get_ddp_module, unwrap_network
+
+needs_static_spline = pytest.mark.skipif(
+    not spline_is_compile_friendly(),
+    reason="installed glasflow lacks the static-shape RQ spline",
+)
+
+_TINY_NSF_KWARGS = {
+    "input_dim": 2,
+    "context_dim": 4,
+    "num_flow_steps": 2,
+    "base_transform_kwargs": {
+        "hidden_dim": 8,
+        "num_transform_blocks": 1,
+        "activation": "elu",
+        "dropout_probability": 0.0,
+        "norm": None,
+        "num_bins": 4,
+        "base_transform_type": "rq-coupling",
+    },
+}
+
+_TINY_FLOW_METADATA = {
+    "train_settings": {
+        "model": {
+            "posterior_model_type": "normalizing_flow",
+            "posterior_kwargs": _TINY_NSF_KWARGS,
+        }
+    }
+}
+
+
+@pytest.fixture
+def free_port():
+    import socket
+
+    with socket.socket() as s:
+        s.bind(("", 0))
+        return s.getsockname()[1]
+
+
+@pytest.fixture
+def single_process_group(free_port):
+    """A one-rank gloo process group, so DDP can be constructed in-process."""
+    os.environ["MASTER_ADDR"] = "localhost"
+    os.environ["MASTER_PORT"] = str(free_port)
+    dist.init_process_group(
+        backend="gloo", rank=0, world_size=1, timeout=timedelta(seconds=60)
+    )
+    yield
+    dist.destroy_process_group()
+
+
+class TestUnwrapNetwork:
+    def test_plain_module_is_returned_unchanged(self):
+        net = nn.Linear(2, 2)
+        assert unwrap_network(net) is net
+        assert get_ddp_module(net) is None
+
+    def test_strips_compile_wrapper(self):
+        net = nn.Linear(2, 2)
+        compiled = torch.compile(net)
+        assert compiled is not net
+        assert unwrap_network(compiled) is net
+        assert get_ddp_module(compiled) is None
+
+    def test_strips_ddp_and_compile_wrappers(self, single_process_group):
+        net = nn.Linear(2, 2)
+        ddp = DDP(net)
+        compiled = torch.compile(ddp)
+        assert unwrap_network(ddp) is net
+        assert unwrap_network(compiled) is net
+        assert get_ddp_module(compiled) is ddp
+        assert get_ddp_module(ddp) is ddp
+
+    def test_save_model_strips_compile_wrapper(self, tmp_path):
+        pm = NormalizingFlowPosteriorModel(metadata=_TINY_FLOW_METADATA, device="cpu")
+        expected_keys = set(pm.network.state_dict().keys())
+        pm.network = torch.compile(pm.network)
+        path = tmp_path / "model.pt"
+        pm.save_model(str(path), save_training_info=False)
+        saved = torch.load(path, weights_only=False)
+        assert set(saved["model_state_dict"].keys()) == expected_keys
+
+
+class TestCompileNetwork:
+    def test_raises_without_static_spline(self, monkeypatch):
+        monkeypatch.setattr(
+            "dingo.core.nn.compile_utils.spline_is_compile_friendly", lambda: False
+        )
+        with pytest.raises(RuntimeError, match="glasflow"):
+            compile_network(nn.Linear(2, 2))
+
+    @needs_static_spline
+    def test_returns_compiled_module(self):
+        net = nn.Linear(2, 2)
+        compiled = compile_network(net)
+        assert unwrap_network(compiled) is net
+
+    @needs_static_spline
+    def test_per_rank_cache_dirs(self, monkeypatch, tmp_path):
+        monkeypatch.delenv("TORCHINDUCTOR_CACHE_DIR", raising=False)
+        monkeypatch.delenv("TRITON_CACHE_DIR", raising=False)
+        compile_network(nn.Linear(2, 2), rank=3, cache_dir=str(tmp_path))
+        inductor = os.environ["TORCHINDUCTOR_CACHE_DIR"]
+        assert inductor.startswith(str(tmp_path))
+        assert "rank3" in inductor
+        assert os.environ["TRITON_CACHE_DIR"].startswith(inductor)
+
+    @needs_static_spline
+    def test_flow_compiles_without_graph_breaks(self):
+        """The full NSF (coupling transforms + RQ splines) must trace as one graph."""
+        torch.manual_seed(0)
+        flow = create_nsf_model(**_TINY_NSF_KWARGS)
+        theta = torch.randn(16, 2) * 3.0  # inside and outside the spline tails
+        context = torch.randn(16, 4)
+        eager = flow.log_prob(theta, context)
+        compiled_log_prob = torch.compile(
+            flow.log_prob, fullgraph=True, backend="aot_eager"
+        )
+        assert torch.allclose(compiled_log_prob(theta, context), eager, atol=1e-5)

--- a/tests/core/test_compile.py
+++ b/tests/core/test_compile.py
@@ -1,10 +1,4 @@
-"""
-Tests for the optional ``torch.compile`` support (``local.torch_compile``).
-
-The compile path needs a glasflow whose rational-quadratic spline is written with
-static shapes; tests that exercise it are skipped when the installed glasflow does
-not provide it.
-"""
+"""Tests for the optional ``torch.compile`` support (``local.torch_compile``)."""
 
 import os
 from datetime import timedelta
@@ -15,19 +9,10 @@ import torch.distributed as dist
 import torch.nn as nn
 from torch.nn.parallel import DistributedDataParallel as DDP
 
-from dingo.core.nn.compile_utils import (
-    compile_network,
-    eager_mode,
-    spline_is_compile_friendly,
-)
+from dingo.core.nn.compile_utils import compile_network, eager_mode
 from dingo.core.nn.nsf import create_nsf_model
 from dingo.core.posterior_models.normalizing_flow import NormalizingFlowPosteriorModel
 from dingo.core.utils.torchutils import get_ddp_module, unwrap_network
-
-needs_static_spline = pytest.mark.skipif(
-    not spline_is_compile_friendly(),
-    reason="installed glasflow lacks the static-shape RQ spline",
-)
 
 _TINY_NSF_KWARGS = {
     "input_dim": 2,
@@ -123,20 +108,11 @@ class TestEagerMode:
 
 
 class TestCompileNetwork:
-    def test_raises_without_static_spline(self, monkeypatch):
-        monkeypatch.setattr(
-            "dingo.core.nn.compile_utils.spline_is_compile_friendly", lambda: False
-        )
-        with pytest.raises(RuntimeError, match="glasflow"):
-            compile_network(nn.Linear(2, 2))
-
-    @needs_static_spline
     def test_returns_compiled_module(self):
         net = nn.Linear(2, 2)
         compiled = compile_network(net)
         assert unwrap_network(compiled) is net
 
-    @needs_static_spline
     def test_per_rank_cache_dirs(self, monkeypatch, tmp_path):
         monkeypatch.delenv("TORCHINDUCTOR_CACHE_DIR", raising=False)
         monkeypatch.delenv("TRITON_CACHE_DIR", raising=False)
@@ -146,7 +122,6 @@ class TestCompileNetwork:
         assert "rank3" in inductor
         assert os.environ["TRITON_CACHE_DIR"].startswith(inductor)
 
-    @needs_static_spline
     def test_flow_compiles_without_graph_breaks(self):
         """The full NSF (coupling transforms + RQ splines) must trace as one graph."""
         torch.manual_seed(0)

--- a/tests/core/test_compile.py
+++ b/tests/core/test_compile.py
@@ -60,6 +60,17 @@ def single_process_group(free_port):
     dist.destroy_process_group()
 
 
+def _spline_is_compile_friendly() -> bool:
+    """True if the installed glasflow has the static-shape RQ spline (marked by the
+    check_domain kwarg of the compile-friendly-rqs fork); released glasflow selects the
+    spline tails with mask indexing, which breaks the compiled graph."""
+    import inspect
+
+    from glasflow.nflows.transforms.splines import rational_quadratic as rq
+
+    return "check_domain" in inspect.signature(rq.rational_quadratic_spline).parameters
+
+
 class TestUnwrapNetwork:
     def test_plain_module_is_returned_unchanged(self):
         net = nn.Linear(2, 2)
@@ -122,6 +133,10 @@ class TestCompileNetwork:
         assert "rank3" in inductor
         assert os.environ["TRITON_CACHE_DIR"].startswith(inductor)
 
+    @pytest.mark.skipif(
+        not _spline_is_compile_friendly(),
+        reason="requires the static-shape RQ spline (glasflow compile-friendly-rqs fork)",
+    )
     def test_flow_compiles_without_graph_breaks(self):
         """The full NSF (coupling transforms + RQ splines) must trace as one graph."""
         torch.manual_seed(0)

--- a/tests/core/test_compile.py
+++ b/tests/core/test_compile.py
@@ -17,6 +17,7 @@ from torch.nn.parallel import DistributedDataParallel as DDP
 
 from dingo.core.nn.compile_utils import (
     compile_network,
+    eager_mode,
     spline_is_compile_friendly,
 )
 from dingo.core.nn.nsf import create_nsf_model
@@ -104,6 +105,21 @@ class TestUnwrapNetwork:
         pm.save_model(str(path), save_training_info=False)
         saved = torch.load(path, weights_only=False)
         assert set(saved["model_state_dict"].keys()) == expected_keys
+
+
+class TestEagerMode:
+    def test_compiled_module_runs_without_tracing(self):
+        import torch._dynamo
+
+        torch._dynamo.reset()
+        net = torch.compile(nn.Linear(2, 2))
+        x = torch.randn(3, 2)
+        with eager_mode():
+            out = net(x)
+        assert torch.allclose(out, unwrap_network(net)(x))
+        assert torch._dynamo.utils.counters["frames"]["total"] == 0
+        net(x)  # outside the context the module is traced and compiled
+        assert torch._dynamo.utils.counters["frames"]["total"] > 0
 
 
 class TestCompileNetwork:

--- a/tests/core/test_compile.py
+++ b/tests/core/test_compile.py
@@ -9,7 +9,12 @@ import torch.distributed as dist
 import torch.nn as nn
 from torch.nn.parallel import DistributedDataParallel as DDP
 
-from dingo.core.nn.compile_utils import compile_network, eager_mode
+from dingo.core.nn.compile_utils import (
+    compile_network,
+    eager_mode,
+    is_compiled,
+    reset_graphs_if_requires_grad_changes,
+)
 from dingo.core.nn.nsf import create_nsf_model
 from dingo.core.posterior_models.normalizing_flow import NormalizingFlowPosteriorModel
 from dingo.core.utils.torchutils import get_ddp_module, unwrap_network
@@ -148,3 +153,75 @@ class TestCompileNetwork:
             flow.log_prob, fullgraph=True, backend="aot_eager"
         )
         assert torch.allclose(compiled_log_prob(theta, context), eager, atol=1e-5)
+
+
+class TestResetGraphsOnRequiresGradChange:
+    """Dynamo does not guard on requires_grad of parameters: a graph traced with a
+    frozen layer is reused after unfreezing and never produces its gradient."""
+
+    @staticmethod
+    def _net():
+        torch.manual_seed(0)
+        net = nn.Sequential(nn.Linear(4, 8), nn.Linear(8, 1))
+        return net
+
+    @staticmethod
+    def _set_rb(net, requires_grad):
+        for p in net[0].parameters():  # parameters "0.weight", "0.bias" play the RB layer
+            p.requires_grad_(requires_grad)
+
+    def test_unfreeze_without_reset_gives_no_gradient(self):
+        net = self._net()
+        self._set_rb(net, False)
+        compiled = torch.compile(net, backend="aot_eager")
+        x = torch.randn(8, 4)
+        compiled(x).sum().backward()
+        self._set_rb(net, True)
+        net.zero_grad(set_to_none=True)
+        compiled(x).sum().backward()
+        assert net[0].weight.grad is None  # the bug this module guards against
+
+    def test_reset_restores_gradient_after_unfreeze(self):
+        net = self._net()
+        self._set_rb(net, False)
+        compiled = torch.compile(net, backend="aot_eager")
+        x = torch.randn(8, 4)
+        compiled(x).sum().backward()
+        assert reset_graphs_if_requires_grad_changes(
+            compiled, name_contains="0.", requires_grad=True
+        )
+        self._set_rb(net, True)
+        net.zero_grad(set_to_none=True)
+        compiled(x).sum().backward()
+        assert net[0].weight.grad is not None
+        assert torch.any(net[0].weight.grad != 0)
+
+    def test_no_reset_when_state_unchanged_or_uncompiled(self):
+        net = self._net()
+        self._set_rb(net, False)
+        assert not reset_graphs_if_requires_grad_changes(net, "0.", requires_grad=True)
+        compiled = torch.compile(net, backend="aot_eager")
+        assert not reset_graphs_if_requires_grad_changes(
+            compiled, "0.", requires_grad=False
+        )
+        assert not reset_graphs_if_requires_grad_changes(
+            compiled, "no_such_layer", requires_grad=True
+        )
+
+    def test_is_compiled_sees_through_ddp(self, single_process_group):
+        net = nn.Linear(2, 2)
+        assert not is_compiled(net)
+        assert is_compiled(torch.compile(net))
+        assert is_compiled(torch.compile(DDP(net)))
+        assert is_compiled(DDP(torch.compile(net)))
+
+
+class TestSingleGpuCacheDir:
+    def test_cache_dir_honored_without_rank(self, monkeypatch, tmp_path):
+        monkeypatch.delenv("TORCHINDUCTOR_CACHE_DIR", raising=False)
+        monkeypatch.delenv("TRITON_CACHE_DIR", raising=False)
+        compile_network(nn.Linear(2, 2), cache_dir=str(tmp_path))
+        inductor = os.environ["TORCHINDUCTOR_CACHE_DIR"]
+        assert inductor.startswith(str(tmp_path))
+        assert "rank" not in inductor
+        assert os.environ["TRITON_CACHE_DIR"].startswith(inductor)

--- a/tests/core/test_multi_gpu.py
+++ b/tests/core/test_multi_gpu.py
@@ -189,6 +189,26 @@ class TestDDPStateDictStripping:
 
 
 class TestBuildTrainAndTestLoaders:
+    def test_drop_last_default_keeps_partial_batch(self):
+        dataset = TensorDataset(torch.randn(100, 4))
+        train_loader, test_loader, _ = build_train_and_test_loaders(
+            dataset=dataset, train_fraction=0.8, batch_size=30, num_workers=0
+        )
+        assert [len(b[0]) for b in train_loader] == [30, 30, 20]
+        assert not train_loader.drop_last and not test_loader.drop_last
+
+    def test_drop_last_drops_partial_batch(self):
+        dataset = TensorDataset(torch.randn(100, 4))
+        train_loader, test_loader, _ = build_train_and_test_loaders(
+            dataset=dataset,
+            train_fraction=0.8,
+            batch_size=30,
+            num_workers=0,
+            drop_last=True,
+        )
+        assert [len(b[0]) for b in train_loader] == [30, 30]
+        assert train_loader.drop_last and test_loader.drop_last
+
     def test_single_gpu_returns_none_sampler(self):
         dataset = TensorDataset(torch.randn(100, 4))
         train_loader, test_loader, sampler = build_train_and_test_loaders(

--- a/tests/core/test_multi_gpu.py
+++ b/tests/core/test_multi_gpu.py
@@ -22,6 +22,7 @@ from torch.utils.data import TensorDataset
 from dingo.core.utils.torchutils import (
     build_train_and_test_loaders,
     get_cuda_info,
+    set_float32_matmul_precision,
     set_seed_based_on_rank,
 )
 from dingo.core.utils.trainutils import LossInfo, RuntimeLimits
@@ -98,6 +99,25 @@ class TestGetNumGpus:
 
     def test_returns_int(self):
         assert isinstance(get_num_gpus({"num_gpus": "2"}), int)
+
+
+class TestSetFloat32MatmulPrecision:
+    def test_default_leaves_torch_setting_unchanged(self):
+        before = torch.get_float32_matmul_precision()
+        set_float32_matmul_precision({})
+        assert torch.get_float32_matmul_precision() == before
+
+    def test_applies_setting(self):
+        before = torch.get_float32_matmul_precision()
+        try:
+            set_float32_matmul_precision({"float32_matmul_precision": "high"})
+            assert torch.get_float32_matmul_precision() == "high"
+        finally:
+            torch.set_float32_matmul_precision(before)
+
+    def test_rejects_unknown_value(self):
+        with pytest.raises(ValueError, match="float32_matmul_precision"):
+            set_float32_matmul_precision({"float32_matmul_precision": "fast"})
 
 
 class TestGetCudaInfo:

--- a/tests/core/test_multi_gpu.py
+++ b/tests/core/test_multi_gpu.py
@@ -227,7 +227,8 @@ class TestBuildTrainAndTestLoaders:
             drop_last=True,
         )
         assert [len(b[0]) for b in train_loader] == [30, 30]
-        assert train_loader.drop_last and test_loader.drop_last
+        assert train_loader.drop_last
+        assert not test_loader.drop_last  # eager test epoch; never empty a small split
 
     def test_single_gpu_returns_none_sampler(self):
         dataset = TensorDataset(torch.randn(100, 4))

--- a/uv.lock
+++ b/uv.lock
@@ -972,7 +972,7 @@ requires-dist = [
     { name = "sphinxcontrib-bibtex", marker = "extra == 'dev'" },
     { name = "sphinxcontrib-mermaid", marker = "extra == 'dev'" },
     { name = "threadpoolctl" },
-    { name = "torch" },
+    { name = "torch", specifier = ">=2.6" },
     { name = "torchdiffeq" },
     { name = "torchvision" },
     { name = "tqdm" },
@@ -1374,17 +1374,17 @@ wheels = [
 
 [[package]]
 name = "htcondor"
-version = "25.7.2"
+version = "25.13.2"
 source = { registry = "https://pypi.org/simple" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/da/7c/b88e13d03ab47c930da456bdfbe0428e9098fe8341c099e4f200f44c6830/htcondor-25.7.2-cp310-cp310-manylinux_2_28_aarch64.whl", hash = "sha256:2c30fff3d704437786ce5526d6a8e444c1246b2996d264a07254c31415488562", size = 50208679, upload-time = "2026-03-12T15:42:42.497Z" },
-    { url = "https://files.pythonhosted.org/packages/ba/0e/87386e8028934d502d63b8314d830aaa6b9fe209a2b3173a423fb7ab54a3/htcondor-25.7.2-cp310-cp310-manylinux_2_28_x86_64.whl", hash = "sha256:ac6bc73c338828b73f44fdcd4ff5407f70810314bd1e160a99fcd2c3f2e54f34", size = 51634164, upload-time = "2026-03-12T15:42:46.353Z" },
-    { url = "https://files.pythonhosted.org/packages/bf/fa/027cd625887cf4e37ddff4c33dc9e9c5e9ef18d620b14babc3da98f175c3/htcondor-25.7.2-cp311-cp311-manylinux_2_28_aarch64.whl", hash = "sha256:60fb891fae4680743b5f72108ec29020094edbf7fb3214a49055bcd79ac7fd00", size = 50208821, upload-time = "2026-03-12T15:42:50.351Z" },
-    { url = "https://files.pythonhosted.org/packages/c5/06/6a48f90656c2d252c79449821f694612d002a6ad37d822778df51a2d3bef/htcondor-25.7.2-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:c020d64225daf8bb3c765fab933859dfa73e899485fcd57767c46d736ab9dfe5", size = 51640592, upload-time = "2026-03-12T15:42:54.822Z" },
-    { url = "https://files.pythonhosted.org/packages/a5/82/536f95681b0a1bea5f3709917dba270133e93b14626cff36e80959bea13a/htcondor-25.7.2-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:94af431820294fea9b28abae7298ca3d7d52ab584f2c79327d27eff03f8cc5ae", size = 50209472, upload-time = "2026-03-12T15:42:58.991Z" },
-    { url = "https://files.pythonhosted.org/packages/90/ef/4725f304f0e718cb0f0fca00fdf44a21ff3d42116553a62ee9026a52ed43/htcondor-25.7.2-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:d462cf68b7ca39ee91923c3716ee9e0c46713a153232b5f7b68643cb91448621", size = 51631016, upload-time = "2026-03-12T15:43:04.048Z" },
-    { url = "https://files.pythonhosted.org/packages/88/03/afef2f6d0d3cacefa2c2a97736439ad44c3b77148d77caa20bbfa507ac16/htcondor-25.7.2-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:5097700ec9c609c752f2e76665031b9925633cff2cba6fe1db2d2ef270e88dcd", size = 50212296, upload-time = "2026-03-12T15:43:08.521Z" },
-    { url = "https://files.pythonhosted.org/packages/d8/94/350a5e0c412095666cf1e771969e226072ab6233ebceabd5994337aad726/htcondor-25.7.2-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:306bf1f714299341b556d46b3ea662822d8ef58780b450177bce5b720ce24e3b", size = 51645252, upload-time = "2026-03-12T15:43:13.913Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/03/14733c6301e57fe54224455bc777a76e9f48dc8e8907a2594d7b69c4fe98/htcondor-25.13.2-cp310-cp310-manylinux_2_28_aarch64.whl", hash = "sha256:958bfb54c2a9bae86a46c917f737af52bd998de9a4465ef0281a9a9dac5e29f2", size = 8466839, upload-time = "2026-08-20T15:08:58.525Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/63/81f7513fc52141a309a22516f44df7ea671fe018e4a902aa67742cab817a/htcondor-25.13.2-cp310-cp310-manylinux_2_28_x86_64.whl", hash = "sha256:8745c1f6cd4e05ee2cb3f45085fb876fc3ed907229ca479e1016be60427efea1", size = 8893754, upload-time = "2026-08-20T15:09:00.609Z" },
+    { url = "https://files.pythonhosted.org/packages/90/68/bc7938f009bbcea18557ac6882f5205095302befd7a3c0c078c1b56aff92/htcondor-25.13.2-cp311-cp311-manylinux_2_28_aarch64.whl", hash = "sha256:0fe244cf584ec30b45f8401cfb66e174b188b2efd99146ef0ba0872218784cf1", size = 8466914, upload-time = "2026-08-20T15:09:02.581Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/77/fbd0900b766df465e69f93952100fb528caa502e23e1c9cdce14b93cd49d/htcondor-25.13.2-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:e90370ef7bb5c35bc955071235ab21af5c647400abd23d3b715985e484a34a18", size = 8893786, upload-time = "2026-08-20T15:09:04.489Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/e5/112f7c57e7ed2f74241c2c124b05236cac423a029e32a45f053b14a7e9e8/htcondor-25.13.2-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:e35cf79adfb19c3b2579e0a1594b24adcd21dc72637fd41cf160dd43c5ff2d8c", size = 8467035, upload-time = "2026-08-20T15:09:06.323Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/ff/abd9d0c10f8fa3eb838d469ee497490311fc1481c3c362deb9c447011902/htcondor-25.13.2-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:08ce85621eea1f1d2b18919bf639961585cc5792d87e14a46277c612001988af", size = 8894001, upload-time = "2026-08-20T15:09:08.708Z" },
+    { url = "https://files.pythonhosted.org/packages/33/2a/03603686b16e748aace35a15eedf1469163983ef708492ca7d91fb79f09b/htcondor-25.13.2-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:a5ab97098f99eae2506bf1ea88836cdf3133343ca2e7048c8b6175301dca5526", size = 8466984, upload-time = "2026-08-20T15:09:10.984Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/ec/ec9170223a5eee43e38fcf0b171b5e033892c89d8d5bc1e27822dae435ce/htcondor-25.13.2-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:a2efb13944126bf617525e84c95212810c2045ad100854040bc1ea17a310c55b", size = 8893877, upload-time = "2026-08-20T15:09:12.695Z" },
 ]
 
 [[package]]
@@ -2684,7 +2684,7 @@ name = "nvidia-cudnn-cu12"
 version = "9.10.2.21"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cublas-cu12" },
+    { name = "nvidia-cublas-cu12", marker = "sys_platform == 'linux'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ba/51/e123d997aa098c61d029f76663dedbfb9bc8dcf8c60cbd6adbe42f76d049/nvidia_cudnn_cu12-9.10.2.21-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:949452be657fa16687d0930933f032835951ef0892b37d2d53824d1a84dc97a8", size = 706758467, upload-time = "2025-06-06T21:54:08.597Z" },
@@ -2695,7 +2695,7 @@ name = "nvidia-cufft-cu12"
 version = "11.3.3.83"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-nvjitlink-cu12" },
+    { name = "nvidia-nvjitlink-cu12", marker = "sys_platform == 'linux'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/1f/13/ee4e00f30e676b66ae65b4f08cb5bcbb8392c03f54f2d5413ea99a5d1c80/nvidia_cufft_cu12-11.3.3.83-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:4d2dd21ec0b88cf61b62e6b43564355e5222e4a3fb394cac0db101f2dd0d4f74", size = 193118695, upload-time = "2025-03-07T01:45:27.821Z" },
@@ -2722,9 +2722,9 @@ name = "nvidia-cusolver-cu12"
 version = "11.7.3.90"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cublas-cu12" },
-    { name = "nvidia-cusparse-cu12" },
-    { name = "nvidia-nvjitlink-cu12" },
+    { name = "nvidia-cublas-cu12", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-cusparse-cu12", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-nvjitlink-cu12", marker = "sys_platform == 'linux'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/85/48/9a13d2975803e8cf2777d5ed57b87a0b6ca2cc795f9a4f59796a910bfb80/nvidia_cusolver_cu12-11.7.3.90-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:4376c11ad263152bd50ea295c05370360776f8c3427b30991df774f9fb26c450", size = 267506905, upload-time = "2025-03-07T01:47:16.273Z" },
@@ -2735,7 +2735,7 @@ name = "nvidia-cusparse-cu12"
 version = "12.5.8.93"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-nvjitlink-cu12" },
+    { name = "nvidia-nvjitlink-cu12", marker = "sys_platform == 'linux'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c2/f5/e1854cb2f2bcd4280c44736c93550cc300ff4b8c95ebe370d0aa7d2b473d/nvidia_cusparse_cu12-12.5.8.93-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:1ec05d76bbbd8b61b06a80e1eaf8cf4959c3d4ce8e711b65ebd0443bb0ebb13b", size = 288216466, upload-time = "2025-03-07T01:48:13.779Z" },


### PR DESCRIPTION
Two opt-in speed settings for training, both off by default, on top of the DDP work in #358.

## Why

Profiling the DDP scaling showed that the NPE network is not compute-bound but **launch-bound**: the spline flow issues tens of thousands of tiny CUDA kernels per step, and the CPU cannot dispatch them faster than the GPU finishes them. GPU utilization plateaus around 60% even at batch sizes that fill the memory. Separately, PyTorch runs float32 matmuls at full precision by default, so the tensor cores of A100-class GPUs sit idle.

## What is added

**`local.torch_compile: true`** wraps the network with `torch.compile`, which fuses the small kernels. It works in the single-GPU and the DDP path; under DDP each rank compiles into its own node-local cache (`local.torch_compile_cache_dir`, optional). The network is compiled once per run: the last partial batch of each epoch is dropped and the test epoch runs eagerly, since either would otherwise trigger a full recompilation. Checkpoints of compiled networks save with the usual keys and load anywhere.

**`local.float32_matmul_precision: high`** enables TensorFloat-32 matmuls (10-bit-mantissa inputs, fp32 accumulation, everything else stays fp32). `fused: true` under the optimizer settings selects the fused Adam kernel; that needed no code, only docs.

**glasflow dependency.** `torch.compile` only pays off if the rational-quadratic spline in `glasflow.nflows` is written with static shapes. The released version selects the spline tails with mask indexing, which breaks the compiled graph in every transform; with it, `torch_compile: true` still runs but is slower than eager. A numerically identical static-shape rewrite is in `nihargupte-ph/nflows@compile-friendly-rqs`, vendored by `nihargupte-ph/glasflow@compile-friendly-rqs`, and I will open PRs to `uofgravity` for both. Until that is released, use

```
pip install git+https://github.com/nihargupte-ph/glasflow@compile-friendly-rqs
```

`pyproject.toml` is unchanged apart from `torch>=2.6`. `uv.lock` is re-locked accordingly.

## Measurements

Production settings: the `npe_model` network (`hidden_dim` 1024, 30 flow steps), 10M SEOBNRv5PHM waveforms, per-GPU batch 4096, A100. "GPU step" is the single-GPU network time without dataloader; "realised" is a real `dingo_train` epoch. All rows are fp32 apart from the last, i.e. no AMP.

| configuration | GPU step | realised step, 1 GPU | realised step, 4 GPUs |
|---|---|---|---|
| fp32, no compile (today) | 0.85 s | 0.85 s | 0.88 s |
| compile only | 0.70 s | 0.70 s | 0.77 s |
| compile + TF32 + fused Adam | 0.28 s | 0.40 s | 0.62 s |
| compile + fp16 AMP + fused Adam | 0.21 s (bf16) | – | 0.63 s |

- Compile alone is 1.2x at this width (1.4x at `hidden_dim` 512, where the network is more launch-bound).
- All three together make the GPU step 3x faster (0.85 to 0.28 s). The realised gain is smaller, 2.1x on 1 GPU and 1.4x on 4 GPUs, because the CPU data pipeline then becomes the limit; that is a separate problem, not addressed here.
- **TF32 and AMP are alternatives, not a stack.** Under `automatic_mixed_precision: True` the matmuls already run in fp16, so `float32_matmul_precision` changes nothing; the 3x above is the no-AMP stack. TF32 alone gives the same 1.9x as AMP alone on this network (0.90 to 0.47 s per step), and is the option for trainings that stay in fp32. With AMP, the same stack (compile + AMP + fused Adam) is as fast or slightly faster.
- Accuracy: 3-epoch trainings with fp32, TF32 and fp16 AMP agree in train and test loss to within run-to-run noise (differences of 0.01 or less). TF32 stays opt-in; a longer comparison is advisable before making it a default.
- Compilation costs 5 to 12 minutes once per run and at every stage boundary that changes the trainable parameters, so `torch_compile` pays off for trainings of tens of epochs or more.

## Review pointers

- `dingo/core/nn/compile_utils.py` is the whole compile mechanism.
- `unwrap_network` / `get_ddp_module` in `torchutils.py` make checkpointing and `no_sync()` see through the compile wrapper.
- `tests/core/test_compile.py` exercises the compile path; the no-graph-break test only passes with the glasflow fork installed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0119JTh4nB6zdJNXE7tPBaLN



