### PR TITLE
Fix density-recovery loader unpack and a missing pipe import

### DIFF
--- a/dingo/core/density/unconditional_density_estimation.py
+++ b/dingo/core/density/unconditional_density_estimation.py
@@ -88,7 +88,7 @@ def train_unconditional_density_estimator(
     model.event_metadata = result.event_metadata
 
     # set up dataloaders
-    train_loader, test_loader = build_train_and_test_loaders(
+    train_loader, test_loader, _ = build_train_and_test_loaders(
         SampleDataset(samples_torch),
         settings["training"]["train_fraction"],
         settings["training"]["batch_size"],

--- a/dingo/pipe/main.py
+++ b/dingo/pipe/main.py
@@ -10,6 +10,7 @@ import numpy as np
 import dingo.pipe.create_injections
 
 from bilby.core.prior import PriorDict
+from bilby.gw.detector import InterferometerList
 from bilby_pipe.input import Input
 from bilby_pipe.main import MainInput as BilbyMainInput
 from bilby_pipe.utils import (

--- a/tests/core/test_unconditional_density_estimation.py
+++ b/tests/core/test_unconditional_density_estimation.py
@@ -1,0 +1,113 @@
+import numpy as np
+import pandas as pd
+import pytest
+
+from dingo.core.density.unconditional_density_estimation import (
+    train_unconditional_density_estimator,
+)
+from dingo.core.posterior_models.normalizing_flow import NormalizingFlowPosteriorModel
+from dingo.core.result import Result
+
+
+PARAMETERS = ["x", "y"]
+
+
+def _nde_settings():
+    """Minimal but valid settings for a fast (1-epoch) unconditional flow.
+
+    Uses the ``model.posterior_kwargs`` shape that train_unconditional_density_estimator
+    reads (matching pipe DENSITY_RECOVERY_SETTINGS), not the flat nde_settings template.
+    """
+    return {
+        "data": {},
+        "model": {
+            "posterior_model_type": "normalizing_flow",
+            "posterior_kwargs": {
+                "num_flow_steps": 2,
+                "base_transform_kwargs": {
+                    "hidden_dim": 8,
+                    "num_transform_blocks": 1,
+                    "activation": "elu",
+                    "dropout_probability": 0.0,
+                    "batch_norm": False,
+                    "num_bins": 4,
+                    "base_transform_type": "rq-coupling",
+                },
+            },
+        },
+        "training": {
+            "device": "cpu",
+            "num_workers": 0,
+            "train_fraction": 0.9,
+            "batch_size": 64,
+            "epochs": 1,
+            "optimizer": {"type": "adam", "lr": 0.01},
+            "scheduler": {"type": "cosine", "T_max": 1},
+        },
+    }
+
+
+@pytest.fixture()
+def result():
+    """A Result holding Gaussian samples over three parameters."""
+    samples = pd.DataFrame(
+        {
+            "x": np.random.normal(1.0, 2.0, 256),
+            "y": np.random.normal(-3.0, 0.5, 256),
+            "z": np.random.normal(0.0, 1.0, 256),
+        }
+    )
+    return Result(
+        dictionary={"samples": samples, "settings": {"train_settings": {"data": {}}}}
+    )
+
+
+def test_train_unconditional_density_estimator_basic(result, tmp_path):
+    settings = _nde_settings()
+    settings["data"]["parameters"] = PARAMETERS
+    model = train_unconditional_density_estimator(result, settings, str(tmp_path))
+
+    assert isinstance(model, NormalizingFlowPosteriorModel)
+
+    # The network is configured as an unconditional flow over the chosen parameters.
+    assert settings["data"]["unconditional"] is True
+    assert settings["model"]["posterior_kwargs"]["input_dim"] == len(PARAMETERS)
+    assert settings["model"]["posterior_kwargs"]["context_dim"] is None
+
+    # Standardization is computed from the training samples.
+    expected_mean = result.samples[PARAMETERS].to_numpy().mean(axis=0)
+    expected_std = result.samples[PARAMETERS].to_numpy().std(axis=0)
+    stored = settings["data"]["standardization"]
+    for i, p in enumerate(PARAMETERS):
+        assert stored["mean"][p] == pytest.approx(expected_mean[i])
+        assert stored["std"][p] == pytest.approx(expected_std[i])
+
+    # The trained model can sample with the right shapes.
+    theta, log_prob = model.sample_and_log_prob(num_samples=5)
+    assert tuple(theta.shape) == (5, len(PARAMETERS))
+    assert tuple(log_prob.shape) == (5,)
+
+
+def test_train_unconditional_density_estimator_uses_all_parameters_by_default(
+    result, tmp_path
+):
+    # With no "parameters" entry, all sample columns are used.
+    settings = _nde_settings()
+    train_unconditional_density_estimator(result, settings, str(tmp_path))
+    assert settings["model"]["posterior_kwargs"]["input_dim"] == result.samples.shape[1]
+
+
+def test_train_unconditional_flow_end_to_end(result, tmp_path):
+    model = result.train_unconditional_flow(
+        PARAMETERS, _nde_settings(), train_dir=str(tmp_path), threshold_std=np.inf
+    )
+    assert isinstance(model, NormalizingFlowPosteriorModel)
+    # Trained over the requested subset only.
+    assert model.model_kwargs["posterior_kwargs"]["input_dim"] == len(PARAMETERS)
+
+
+def test_train_unconditional_flow_rejects_too_many_outliers(result):
+    # A tight threshold removes far more than 5% of Gaussian samples, so the outlier
+    # guard raises before any training happens (no train_dir needed).
+    with pytest.raises(ValueError, match="Too many proxy samples"):
+        result.train_unconditional_flow(PARAMETERS, _nde_settings(), threshold_std=1.0)


### PR DESCRIPTION
Two one-line runtime fixes on `main`, plus the test that catches the first.

**Density recovery is broken since #358.** `build_train_and_test_loaders` now returns the DDP sampler as a third value. `train_pipeline.py` was updated, but `train_unconditional_density_estimator` still unpacks two, so every GNPE importance-sampling run fails with `ValueError: too many values to unpack` at the density-recovery step. `main`'s CI did not catch it because nothing on `main` exercises that function; the tests that do live on `hackathon-1` (#387). This PR adds `tests/core/test_unconditional_density_estimation.py` from `hackathon-1` verbatim, so it merges cleanly later and `main` gets the coverage now.

**ET pipe runs raise NameError since #333.** The ET branch of `fill_in_arguments_from_model` in `dingo/pipe/main.py` calls `InterferometerList` without importing it. Only reached when an ASD dataset is given and a detector name is not among its keys, so H1/L1/V1 runs were unaffected and CI never executed the line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CJKZSPMcXF672PyaiZpDmw
