### PR TITLE
Fix SVDBasis loading from file after the dtype_map change

### DIFF
--- a/dingo/gw/SVD.py
+++ b/dingo/gw/SVD.py
@@ -195,15 +195,17 @@ class SVDBasis(DingoDataset):
         """
         return data @ self.V
 
-    def from_file(self, filename):
+    def from_file(self, filename, dtype_map=None):
         """
         Load the SVD basis from a HDF5 file.
 
         Parameters
         ----------
         filename : str
+        dtype_map : dict, optional
+            Passed through to `DingoDataset.from_file`.
         """
-        super().from_file(filename)
+        super().from_file(filename, dtype_map=dtype_map)
         if self.V is None:
             raise KeyError("File does not contain SVD V matrix. No SVD basis to load.")
         self.Vh = self.V.T.conj()

--- a/tests/gw/test_svd_basis_io.py
+++ b/tests/gw/test_svd_basis_io.py
@@ -1,0 +1,19 @@
+"""SVDBasis file round trip: the constructor's file path passes through the
+DingoDataset loader, so the from_file override must accept its keywords."""
+
+import numpy as np
+
+from dingo.gw.SVD import SVDBasis
+
+
+def test_svd_basis_round_trips_through_file(tmp_path):
+    rng = np.random.default_rng(0)
+    data = rng.standard_normal((20, 8)) + 1j * rng.standard_normal((20, 8))
+    basis = SVDBasis()
+    basis.generate_basis(data, n=4)
+    basis.to_file(str(tmp_path / "svd.hdf5"))
+
+    loaded = SVDBasis(file_name=str(tmp_path / "svd.hdf5"))
+    np.testing.assert_allclose(loaded.V, basis.V)
+    np.testing.assert_allclose(loaded.s, basis.s)
+    assert loaded.n == basis.n


### PR DESCRIPTION
#### Summary

`SVDBasis(file_name=...)` raises `TypeError: SVDBasis.from_file() got an unexpected keyword argument 'dtype_map'` since #346, which made `DingoDataset.__init__` call `self.from_file(file_name, dtype_map=dtype_map)` while the `SVDBasis.from_file` override still took only a filename. This breaks `dingo_ls` on an SVD file and dataset generation from a precomputed basis (`generate_dataset.py`).

#### Fix

`SVDBasis.from_file` accepts `dtype_map=None` and forwards it to `DingoDataset.from_file`.

#### Verification

New `tests/gw/test_svd_basis_io.py` builds a basis, saves it, and reloads it through the constructor. It fails with the `TypeError` on `main` and passes with the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
