### PR TITLE
Fix MFD threshold search crash when band count changes

### DIFF
--- a/dingo/gw/dataset/generate_multibanded_domain.py
+++ b/dingo/gw/dataset/generate_multibanded_domain.py
@@ -595,6 +595,25 @@ def _output_settings_path(settings_file: str) -> str:
     return os.path.join(directory, out_name)
 
 
+def _same_nodes(nodes_a: np.ndarray, nodes_b: np.ndarray) -> bool:
+    """Return whether two MFD node arrays describe the same banding.
+
+    Node arrays of MFDs with a different number of bands have different lengths, which
+    ``np.allclose`` cannot broadcast; such MFDs are simply not the same.
+
+    Parameters
+    ----------
+    nodes_a, nodes_b : np.ndarray
+        MFD node arrays.
+
+    Returns
+    -------
+    bool
+        True if both arrays have the same shape and all nodes agree.
+    """
+    return np.shape(nodes_a) == np.shape(nodes_b) and np.allclose(nodes_a, nodes_b)
+
+
 def generate_multibanded_domain_settings(
     settings_file: str,
     num_samples: int,
@@ -822,7 +841,7 @@ def generate_multibanded_domain_settings(
             delta_f_max_time_shift,
             min_mfd_bins_per_band=min_mfd_bins_per_band,
         ).nodes
-        if np.allclose(lo_nodes, hi_nodes):
+        if _same_nodes(lo_nodes, hi_nodes):
             print("\n  Bracket maps to identical MFD nodes; no bisection needed.")
         else:
             print(f"\n  Refining bracket [{threshold_low:.3e}, {threshold_high:.3e}]:")
@@ -838,7 +857,7 @@ def generate_multibanded_domain_settings(
                 else:
                     threshold_high = threshold
 
-                if previous_nodes is not None and np.allclose(
+                if previous_nodes is not None and _same_nodes(
                     mfd.nodes, previous_nodes
                 ):
                     print("  Nodes unchanged; bisection converged.")

--- a/tests/gw/test_multibanded_domain_generation.py
+++ b/tests/gw/test_multibanded_domain_generation.py
@@ -20,7 +20,7 @@ from dingo.gw.dataset.evaluate_multibanded_domain import \
     _evaluate_multibanding_main
 from dingo.gw.dataset.generate_multibanded_domain import (
     _build_mfd_for_threshold, _compute_mismatches, _load_asd,
-    _output_settings_path, compute_max_decimation_factor,
+    _output_settings_path, _same_nodes, compute_max_decimation_factor,
     compute_waveform_difference_per_decimation_factor, floor_to_power_of_2,
     get_band_nodes_for_adaptive_decimation)
 from dingo.gw.domains import MultibandedFrequencyDomain, UniformFrequencyDomain
@@ -482,3 +482,88 @@ def test_load_asd_preserves_out_of_range_infs(asd_file_with_line, ufd_2x):
     # the ASD file's frequency range must remain infinite.
     assert np.all(np.isinf(asd_2x[f < 10.0]))
     assert np.all(np.isfinite(asd_2x[(f >= 10.0) & (f < 300.0)]))
+
+
+# ---------------------------------------------------------------------------
+# generate_multibanded_domain_settings: threshold search
+# ---------------------------------------------------------------------------
+
+
+class TestThresholdSearchBandCountChange:
+    """The bracket ends (and consecutive bisection steps) can map to MFDs with a
+    different number of bands. Comparing their nodes must not raise."""
+
+    @staticmethod
+    def _run(tmp_path, ufd):
+        import yaml
+
+        from dingo.gw.dataset import generate_multibanded_domain as gmd
+
+        settings = {
+            "domain": {
+                "type": "UniformFrequencyDomain",
+                "f_min": ufd.f_min,
+                "f_max": ufd.f_max,
+                "delta_f": ufd.delta_f,
+            },
+            "intrinsic_prior": INTRINSIC_PRIOR,
+        }
+        settings_file = str(tmp_path / "settings_ufd.yaml")
+        with open(settings_file, "w") as f:
+            yaml.dump(settings, f)
+
+        # Three bands below threshold 1 (meets target), two bands above (misses it).
+        # The bracketing walk from 5e-3 ends at [0.32, 5.12], straddling the change.
+        fine = MultibandedFrequencyDomain(
+            nodes=[20.0, 64.0, 128.0, 256.0], delta_f_initial=1.0, base_domain=ufd
+        )
+        coarse = MultibandedFrequencyDomain(
+            nodes=[20.0, 64.0, 256.0], delta_f_initial=1.0, base_domain=ufd
+        )
+
+        def mock_build(diffs, freqs, dec, ufd_, threshold, *args, **kwargs):
+            return fine if threshold < 1.0 else coarse
+
+        def mock_mismatches(polarizations, ufd_, mfd, asd):
+            return np.full(4, 1e-4 if mfd.num_bands == 3 else 1e-2)
+
+        with (
+            patch.object(
+                gmd,
+                "_generate_whitened_waveforms",
+                return_value=(
+                    ufd, None, None, {"h_cross": None}, {"h_cross": None}, None
+                ),
+            ),
+            patch.object(
+                gmd,
+                "compute_waveform_difference_per_decimation_factor",
+                return_value=([], []),
+            ),
+            patch.object(gmd, "_build_mfd_for_threshold", side_effect=mock_build),
+            patch.object(gmd, "_compute_mismatches", side_effect=mock_mismatches),
+        ):
+            output_path = gmd.generate_multibanded_domain_settings(
+                settings_file, num_samples=4, target_median_mismatch=1e-3
+            )
+        with open(output_path, "r") as f:
+            return yaml.safe_load(f)
+
+    def test_bracket_with_different_band_counts(self, tmp_path, ufd):
+        out = self._run(tmp_path, ufd)
+        assert out["domain"]["nodes"] == [20.0, 64.0, 128.0, 256.0]
+
+
+class TestSameNodes:
+    def test_identical_nodes(self):
+        assert _same_nodes(np.array([20.0, 64.0, 256.0]), np.array([20.0, 64.0, 256.0]))
+
+    def test_different_nodes_same_length(self):
+        assert not _same_nodes(
+            np.array([20.0, 64.0, 256.0]), np.array([20.0, 80.0, 256.0])
+        )
+
+    def test_different_number_of_bands(self):
+        assert not _same_nodes(
+            np.array([20.0, 64.0, 128.0, 256.0]), np.array([20.0, 64.0, 256.0])
+        )


### PR DESCRIPTION
## Problem

`dingo_generate_multibanded_domain` crashes during the threshold search with

```
File ".../generate_multibanded_domain.py", line 825, in generate_multibanded_domain_settings
    if np.allclose(lo_nodes, hi_nodes):
ValueError: operands could not be broadcast together with shapes (6,) (5,)
```

The search first brackets the target median mismatch between two thresholds, then bisects. Both the bracket check (`np.allclose(lo_nodes, hi_nodes)`) and the bisection convergence check (`np.allclose(mfd.nodes, previous_nodes)`) assume the compared MFDs have the same number of bands. A larger threshold can drop a band, so the node arrays differ in length and `np.allclose` raises instead of returning `False`.

This is easy to hit with token-aligned banding (`--token_size 16`), because bands snap to whole tokens. Reproduced on an 8 s SEOBNRv5PHM dataset (chirp mass 12–150, f_start 9 Hz, 20–2048 Hz, target median mismatch 1e-3). The bracket is [0.32, 5.12], giving 5 vs 4 bands. It crashes with both 1000 and 5000 waveforms.

## Fix

- Add `_same_nodes(nodes_a, nodes_b)`, which returns `False` when the shapes differ and otherwise uses `np.allclose`.
- Use it at both comparison sites.

MFDs with different band counts are by definition different bandings, so the search simply continues bisecting.

## Tests

- **Regression test:** mocks waveform generation so the bracketing walk ends at thresholds giving 3 vs 2 bands. It fails on `hackathon-1` with the broadcast error and passes with the fix.
- **Unit tests for `_same_nodes`:** identical nodes, same length but different nodes, and different band counts.
- `tests/gw/test_multibanded_domain_generation.py`: 41 passed.
- **End to end:** on the real case above with 5000 waveforms, the fixed code converges to nodes `[20, 40, 52, 68, 84, 2036]` (median mismatch 9.0e-4).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012UCuZKieZZ8h8XkutPLLfF
